### PR TITLE
bug fix: modify to remove underscore from instance name

### DIFF
--- a/datalab/create_vm.sh
+++ b/datalab/create_vm.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 #gsutil cp gs://cloud-datalab/datalab-server-no-websockets.yaml  datalab.yaml
-gcloud compute instances create datalabvm-${USER} \
+
+# Remove "_" from USER because "_" can not be used for instance name
+INSTANCE_NAME=${USER//_/}
+
+gcloud compute instances create datalabvm-${INSTANCE_NAME} \
    --image-family=container-vm --image-project=google-containers \
    --zone us-central1-a --machine-type n1-standard-1 \
    --metadata "google-container-manifest=$(cat datalab.yaml)" \

--- a/datalab/start_tunnel.sh
+++ b/datalab/start_tunnel.sh
@@ -2,7 +2,10 @@
 
 echo "This command won't exit. click on the *Web Preview* (up-arrow button at top-left), select *port 8081*, and start using Datalab."
 
+# Remove "_" from USER because "_" can not be used for instance name
+INSTANCE_NAME=${USER//_/}
+
 # if you change the zone from us-central1-a in ./create_vm.sh, change it here too
 gcloud compute ssh --zone us-central1-a \
    --ssh-flag="-N" --ssh-flag="-L" --ssh-flag="localhost:8081:localhost:8080" \
-   ${USER}@datalabvm-${USER}
+   ${USER}@datalabvm-${INSTANCE_NAME}


### PR DESCRIPTION
`datalabvm-${USER}` is invalid instance name if `_` is included in `${USER}`.