### PR TITLE
On linux bind to localhost only so docker does not expose the port

### DIFF
--- a/datalab/start_datalab.sh
+++ b/datalab/start_datalab.sh
@@ -2,6 +2,17 @@
 
 IMAGE=gcr.io/cloud-datalab/datalab:local   # release
 
+# On linux, docker runs directly on host machine. It's important to bind
+# to 127.0.0.1 only to prevent Datalab from accessible on the local network.
+# On other platforms, bind to all ip addresses so VirtualBox can
+# access it. Users need to make sure that their VirtualBox port forwarding
+# setting only binds to 127.0.0.1.
+if [ "$OSTYPE" == "linux"* ]; then
+  PORTMAP="127.0.0.1:8081:8080"
+else
+  PORTMAP="8081:8080"
+fi
+
 # optionally, add a line like this to the docker run command:
 # (change your project-id to match)
 # if you don't do this, datalab will ask you to sign in and
@@ -10,6 +21,6 @@ IMAGE=gcr.io/cloud-datalab/datalab:local   # release
 
 docker pull $IMAGE
 docker run -t \
-   -p "8081:8080" \
+   -p $PORTMAP \
    -v "${HOME}:/content" \
    $IMAGE &


### PR DESCRIPTION
I came across this repository during my training on [Course CPB100: Google Cloud Platform Big Data & Machine Learning Fundamentals](https://cloud.google.com/training/courses/cpb100). I noticed that a patch was missing in the `start_datalab.sh` script for linux users. This PR addresses the security concern described in googledatalab/datalab/issues/786 . The code was taken directly from the patch in googledatalab/datalab/issues/850 .