### PR TITLE
Update the start_datalab.sh to add ability to set the notebook directory

### DIFF
--- a/datalab/start_datalab.sh
+++ b/datalab/start_datalab.sh
@@ -1,26 +1,39 @@
 #!/bin/bash
 
+# If the PROJECT_ID environment variable is not set, Datalab will ask you
+# to set a project id when you try to use GCP resources such as BigQuery.
+# PROJECT_ID='your-project-id'
 IMAGE=gcr.io/cloud-datalab/datalab:local   # release
 
-# On linux, docker runs directly on host machine. It's important to bind
-# to 127.0.0.1 only to prevent Datalab from accessible on the local network.
-# On other platforms, bind to all ip addresses so VirtualBox can
-# access it. Users need to make sure that their VirtualBox port forwarding
-# setting only binds to 127.0.0.1.
+# By default, the home directory is used to store Cloud Datalab notebooks and
+# configurations. If you want to change this directory, simply update the
+# CONTENT variable below to the desired directory.
+CONTENT=${HOME}
+
+if [ ! -d $CONTENT ]; then
+    echo "CONTENT directory does not exist. Please check start_datalab.sh"
+    exit 1
+fi
+
+cd $CONTENT
+if [ ! -d "training-data-analyst" ]; then
+   git clone http://github.com/GoogleCloudPlatform/training-data-analyst/
+fi
+
+# On linux, docker runs directly on the host machine. It's important to bind to
+# 127.0.0.1 only to ensure that Datalab is not accessible on your local network.
+# On other platforms, bind to all ip addresses so VirtualBox can access it.
+# Users need to make sure that their VirtualBox port forwarding setting only
+# binds to 127.0.0.1.
 if [ "$OSTYPE" == "linux"* ]; then
   PORTMAP="127.0.0.1:8081:8080"
 else
   PORTMAP="8081:8080"
 fi
 
-# optionally, add a line like this to the docker run command:
-# (change your project-id to match)
-# if you don't do this, datalab will ask you to sign in and
-# set a project-id
-#   -e "PROJECT_ID=cloud-training-demos" \
-
 docker pull $IMAGE
-docker run -t \
+docker run -it \
    -p $PORTMAP \
-   -v "${HOME}:/content" \
-   $IMAGE &
+   -v "$CONTENT:/content" \
+   -e "PROJECT_ID=$PROJECT_ID" \
+   $IMAGE


### PR DESCRIPTION
This PR includes the following changes to the `start_datalab.sh` script used to run Cloud Datalab locally:

-  Allow users to easily set the Datalab notebook/config by setting `CONTENT`
- `PROJECT_ID` has moved to the top of the file to make it easier to set the project id
- `docker run -t` has changed to `docker run -it` to match the [Datalab Quickstart document](https://cloud.google.com/datalab/docs/quickstarts/quickstart-local)
- The `&` in the docker run command has been removed to make it easier for users to stop the running Datalab Docker container (and for consistency with the quick start doc)

