### PR TITLE
modify not to type project id and bucket name

### DIFF
--- a/CPB102/lab3a/cloudml.ipynb
+++ b/CPB102/lab3a/cloudml.ipynb
@@ -87,8 +87,10 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "PROJECT = 'cloud-training-demos'    # CHANGE THIS\n",
-    "BUCKET = 'cloud-training-demos-ml'  # CHANGE THIS\n",
+    "import subprocess\n",
+    "\n",
+    "PROJECT = subprocess.check_output('gcloud config list project --format \"value(core.project)\"', shell=True).rstrip()\n",
+    "BUCKET = PROJECT + '-ml'\n",
     "\n",
     "os.environ['PROJECT'] = PROJECT # for bash\n",
     "os.environ['BUCKET'] = BUCKET # for bash"


### PR DESCRIPTION
I think it is better because the user does not need to type their project id.