### PR TITLE
Escape $ sign in IPython notebook

### DIFF
--- a/courses/machine_learning/datasets/create_datasets.ipynb
+++ b/courses/machine_learning/datasets/create_datasets.ipynb
@@ -623,7 +623,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What's up with the streaks at $45 and $50?  Those are fixed-amount rides from JFK and La Guardia airports into anywhere in Manhattan, i.e. to be expected. Let's list the data to make sure the values look reasonable.\n",
+    "What's up with the streaks at \$45 and \$50?  Those are fixed-amount rides from JFK and La Guardia airports into anywhere in Manhattan, i.e. to be expected. Let's list the data to make sure the values look reasonable.\n",
     "\n",
     "Let's examine whether the toll amount is captured in the total amount."
    ]


### PR DESCRIPTION
IPython notebook interprets code within $ .. $ as [MathJax expressions](http://jupyter-notebook.readthedocs.io/en/latest/examples/Notebook/Typesetting%20Equations.html#Inline-Typesetting-(Mixing-Markdown-and-TeX)). Escape with \$ to display the dollar sign properly.

Before: 
![image](https://cloud.githubusercontent.com/assets/679475/24078084/061c5b2c-0c20-11e7-83a8-7f300ef61e3a.png)

After:
![image](https://cloud.githubusercontent.com/assets/679475/24078089/18ea3634-0c20-11e7-8c43-ba88b432ecbf.png)

