### PR TITLE
Fix Tensorboard import error

### DIFF
--- a/courses/machine_learning/tensorflow/d_experiment.ipynb
+++ b/courses/machine_learning/tensorflow/d_experiment.ipynb
@@ -165,7 +165,7 @@
    },
    "outputs": [],
    "source": [
-    "from datalab.ml import TensorBoard\n",
+    "from google.datalab.ml import TensorBoard\n",
     "TensorBoard().start('./taxi_trained')\n",
     "TensorBoard().list()"
    ]


### PR DESCRIPTION
This patch fixes the following error resulting from the following code:
`from datalab.ml import TensorBoard`

Error message:
```
ImportErrorTraceback (most recent call last)
<ipython-input-8-c683d951966c> in <module>()
----> 1 from datalab.ml import TensorBoard
      2 TensorBoard().start('./taxi_trained')
      3 TensorBoard().list()

ImportError: No module named ml
```