### PR TITLE
Fix check for import lines to use a regex

### DIFF
--- a/courses/data_analysis/lab2/python/grep.py
+++ b/courses/data_analysis/lab2/python/grep.py
@@ -14,10 +14,11 @@ limitations under the License.
 """
 
 import apache_beam as beam
+import re
 import sys
 
 def my_grep(line, term):
-   if term in line:
+   if re.match( r'^' + re.escape(term), line):
       yield line
 
 if __name__ == '__main__':

--- a/courses/data_analysis/lab2/python/grepc.py
+++ b/courses/data_analysis/lab2/python/grepc.py
@@ -14,9 +14,10 @@ limitations under the License.
 """
 
 import apache_beam as beam
+import re
 
 def my_grep(line, term):
-   if term in line:
+   if re.match( r'^' + re.escape(term), line):
       yield line
 
 PROJECT='cloud-training-demos'


### PR DESCRIPTION
 Existing code checks for import in any text which returns false positives. This now checks for lines that start with import.