### PR TITLE
Clean python code for lab4a

### DIFF
--- a/CPB100/lab4a/demandforecast.ipynb
+++ b/CPB100/lab4a/demandforecast.ipynb
@@ -280,7 +280,7 @@
    "source": [
     "avg = np.mean(trips['numtrips'])\n",
     "std = np.std(trips['numtrips'])\n",
-    "print 'Just using average={0} has RMSE of {1}'.format(avg, std)"
+    "print('Just using average={0} has RMSE of {1}'.format(avg, std))"
    ]
   },
   {
@@ -1219,7 +1219,7 @@
     "trainsize = int(len(shuffled['numtrips']) * 0.8)\n",
     "avg = np.mean(shuffled['numtrips'][:trainsize])\n",
     "rmse = np.sqrt(np.mean((targets[trainsize:] - avg)**2))\n",
-    "print 'Just using average={0} has RMSE of {1}'.format(avg, rmse)"
+    "print('Just using average={0} has RMSE of {1}'.format(avg, rmse))"
    ]
   },
   {
@@ -1272,14 +1272,14 @@
     "                                             enable_centered_bias=False,\n",
     "                                             feature_columns=tf.contrib.learn.infer_real_valued_columns_from_input(predictors.values))\n",
     "\n",
-    "print \"starting to train ... this will take a while ... use verbosity=INFO to get more verbose output\"\n",
+    "print(\"starting to train ... this will take a while ... use verbosity=INFO to get more verbose output\")\n",
     "def input_fn(features, targets):\n",
     "  return tf.constant(features.values), tf.constant(targets.values.reshape(len(targets), noutputs)/SCALE_NUM_TRIPS)\n",
     "estimator.fit(input_fn=lambda: input_fn(predictors[:trainsize], targets[:trainsize]), steps=10000)\n",
     "\n",
     "pred = np.multiply(list(estimator.predict(predictors[trainsize:].values)), SCALE_NUM_TRIPS )\n",
     "rmse = np.sqrt(np.mean(np.power((targets[trainsize:].values - pred), 2)))\n",
-    "print 'LinearRegression has RMSE of {0}'.format(rmse)\n"
+    "print('LinearRegression has RMSE of {0}'.format(rmse))\n"
    ]
   },
   {
@@ -1340,14 +1340,14 @@
     "                                          enable_centered_bias=False,\n",
     "                                          feature_columns=tf.contrib.learn.infer_real_valued_columns_from_input(predictors.values))\n",
     "\n",
-    "print \"starting to train ... this will take a while ... use verbosity=INFO to get more verbose output\"\n",
+    "print(\"starting to train ... this will take a while ... use verbosity=INFO to get more verbose output\")\n",
     "def input_fn(features, targets):\n",
     "  return tf.constant(features.values), tf.constant(targets.values.reshape(len(targets), noutputs)/SCALE_NUM_TRIPS)\n",
     "estimator.fit(input_fn=lambda: input_fn(predictors[:trainsize], targets[:trainsize]), steps=10000)\n",
     "\n",
     "pred = np.multiply(list(estimator.predict(predictors[trainsize:].values)), SCALE_NUM_TRIPS )\n",
     "rmse = np.sqrt(np.mean((targets[trainsize:].values - pred)**2))\n",
-    "print 'Neural Network Regression has RMSE of {0}'.format(rmse)"
+    "print('Neural Network Regression has RMSE of {0}'.format(rmse))"
    ]
   },
   {
@@ -1404,7 +1404,7 @@
     "                                          feature_columns=tf.contrib.learn.infer_real_valued_columns_from_input(input.values))\n",
     "\n",
     "pred = np.multiply(list(estimator.predict(input.values)), SCALE_NUM_TRIPS )\n",
-    "print pred"
+    "print(pred)"
    ]
   },
   {

--- a/CPB100/lab4a/demandforecast.ipynb
+++ b/CPB100/lab4a/demandforecast.ipynb
@@ -279,7 +279,8 @@
    ],
    "source": [
     "avg = np.mean(trips['numtrips'])\n",
-    "print 'Just using average={0} has RMSE of {1}'.format(avg, np.sqrt(np.mean((trips['numtrips'] - avg)**2)))"
+    "std = np.std(trips['numtrips'])\n",
+    "print 'Just using average={0} has RMSE of {1}'.format(avg, std)"
    ]
   },
   {


### PR DESCRIPTION
Cosmetic changes to:

- Use `numpy.std()` instead of manually calculating RMSE
- Enclose message string in between brackets for `print` commands in order to be compatible with [Python 3](https://docs.python.org/3/library/functions.html#print).