### PR TITLE
Removing extraneous aggregation operation

### DIFF
--- a/CPB100/lab4a/demandforecast.ipynb
+++ b/CPB100/lab4a/demandforecast.ipynb
@@ -397,11 +397,11 @@
    "source": [
     "%bq query -n wxquery\n",
     "SELECT EXTRACT (DAYOFYEAR FROM CAST(CONCAT(@YEAR,'-',mo,'-',da) AS TIMESTAMP)) AS daynumber,\n",
-    "       MIN(EXTRACT (DAYOFWEEK FROM CAST(CONCAT(@YEAR,'-',mo,'-',da) AS TIMESTAMP))) dayofweek,\n",
+    "       EXTRACT (DAYOFWEEK FROM CAST(CONCAT(@YEAR,'-',mo,'-',da) AS TIMESTAMP)) AS dayofweek,\n",
     "       MIN(min) mintemp, MAX(max) maxtemp, MAX(IF(prcp=99.99,0,prcp)) rain\n",
     "FROM `fh-bigquery.weather_gsod.gsod*`\n",
     "WHERE stn='725030' AND _TABLE_SUFFIX = @YEAR\n",
-    "GROUP BY 1 ORDER BY daynumber DESC"
+    "GROUP BY 1, 2 ORDER BY daynumber DESC"
    ]
   },
   {


### PR DESCRIPTION
The MIN() function is extraneous here, as each day of year should only ever fall on the same day of week (and if it doesn't, that suggests a problem in our data).