### PR TITLE
Print RMSE for NN on the validation set

### DIFF
--- a/courses/machine_learning/tensorflow/b_tflearn.ipynb
+++ b/courses/machine_learning/tensorflow/b_tflearn.ipynb
@@ -176,7 +176,8 @@
     "shutil.rmtree('taxi_trained', ignore_errors=True) # start fresh each time\n",
     "model = tf.contrib.learn.DNNRegressor(hidden_units=[32, 8, 2],\n",
     "      feature_columns=make_feature_cols(), model_dir='taxi_trained')\n",
-    "model.fit(input_fn=make_input_fn(df_train), steps=100);"
+    "model.fit(input_fn=make_input_fn(df_train), steps=100);\n",
+    "print_rmse(model, 'validation', make_input_fn(df_valid))"
    ]
   },
   {


### PR DESCRIPTION
I'm adding print_rmse for the Deep NN regression on the validation set as this (I think!) needs to be done before claiming that "We are not beating our benchmark with either model" (as done in the subsequent text cell)

