### PR TITLE
Adding helpful comment

### DIFF
--- a/courses/machine_learning/tensorflow/a_tfstart.ipynb
+++ b/courses/machine_learning/tensorflow/a_tfstart.ipynb
@@ -202,7 +202,7 @@
     "  \n",
     "  # Heron's formula\n",
     "  s = (a + b + c) * 0.5   # (a + b) is a short-cut to tf.add(a, b)\n",
-    "  areasq = s * (s - a) * (s - b) * (s - c)\n",
+    "  areasq = s * (s - a) * (s - b) * (s - c) # (a * b) is a short-cut to tf.multiply(a, b), not tf.matmul(a, b)\n",
     "  return tf.sqrt(areasq)\n",
     "\n",
     "with tf.Session() as sess:\n",


### PR DESCRIPTION
Just as the overloaded "+" operator is explained, "*" should be too, particularly in light of the fact that it's not a matrix multiplication operation.