### PR TITLE
Fixed bucket name command typos

### DIFF
--- a/blogs/babyweight/train_deploy.ipynb
+++ b/blogs/babyweight/train_deploy.ipynb
@@ -64,7 +64,7 @@
     "if ! gsutil ls | grep -q gs://${BUCKET}/; then\n",
     "  gsutil mb -l ${REGION} gs://${BUCKET}\n",
     "fi\n",
-    "gsutil -m cp -R gs://cloud-training-demos/babyweight gs://{BUCKET}"
+    "gsutil -m cp -R gs://cloud-training-demos/babyweight gs://${BUCKET}"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "<p>\n",
     "Note that I have set in_test_mode=True in the following code -- this will run the code locally on a small subset of the data -- the full results were copied into your bucket using the following code:\n",
     "<pre>\n",
-    "gsutil -m cp -R gs://cloud-training-demos/babyweight gs://{BUCKET}\n",
+    "gsutil -m cp -R gs://cloud-training-demos/babyweight gs://${BUCKET}\n",
     "</pre>\n",
     "If you are running in your own project, change in_test_mode=False; after you launch this, the notebook will appear to be hung. Go to the GCP webconsole to the Dataflow section and monitor the running job. It took about <b>30 minutes</b> for me with autoscaling to 15 workers -- Qwiklabs accounts won't be able scale to that level, and so doing it on Qwiklabs would have taken 3-4 hours. Hence, the short-cut."
    ]


### PR DESCRIPTION
Received an invalid bucket name error in Datalab. Added $ to copy command so it would reference the environment variable set in previous cell. 