### PR TITLE
Add additional guidance about enabling Google Cloud Machine Learning …

### DIFF
--- a/courses/machine_learning/cloudmle/cloudmle.ipynb
+++ b/courses/machine_learning/cloudmle/cloudmle.ipynb
@@ -103,7 +103,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Allow the Cloud ML Engine service account to read/write to the bucket containing training data."
+    "Allow the Cloud ML Engine service account to read/write to the bucket containing training data. Note that the cell below requires Google Cloud Machine Learning Engine to be enabled in the project of choice."
    ]
   },
   {


### PR DESCRIPTION
…Engine

The curl command used to generate SVC_ACCOUNT fails if Google Cloud Machine Learning Engine is not enabled in the project, and as the command is piped it can be hard to understand what is the problem in datalab if the cell fails to run.