### PR TITLE
Fix: typo in the headline

### DIFF
--- a/blogs/babyweight/babyweight.ipynb
+++ b/blogs/babyweight/babyweight.ipynb
@@ -1187,7 +1187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h2> Useing the model to predict </h2>\n",
+    "<h2> Using the model to predict </h2>\n",
     "<p>\n",
     "Send a JSON request to the endpoint of the service to make it predict a baby's weight ... I am going to try out how well the model would have predicted the weights of our two kids and a couple of variations while we are at it ..."
    ]


### PR DESCRIPTION
Hi. This is just to fix a typo in the headline.