### PR TITLE
Replaced broken link with official Tensorflow documentation

### DIFF
--- a/courses/machine_learning/feateng/feateng.ipynb
+++ b/courses/machine_learning/feateng/feateng.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "This code reads from BigQuery and saves the data as-is on Google Cloud Storage.  We can do additional preprocessing and cleanup inside Dataflow, but then we'll have to remember to repeat that prepreprocessing during inference. It is better to use tf.transform which will do this book-keeping for you, or to do preprocessing within your TensorFlow model. We will look at this in future notebooks. For now, we are simply moving data from BigQuery to CSV using Dataflow.\n",
     "\n",
-    "While we could read from BQ directly from TensorFlow (See: https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/ops/cloud/bigquery_reader_ops.py), it is quite convenient to export to CSV and do the training off CSV.  Let's use Dataflow to do this at scale.\n",
+    "While we could read from BQ directly from TensorFlow (See: https://www.tensorflow.org/api_docs/python/tf/contrib/cloud/BigQueryReader), it is quite convenient to export to CSV and do the training off CSV.  Let's use Dataflow to do this at scale.\n",
     "\n",
     "Because we are running this on the Cloud, you should go to the GCP Console (https://console.cloud.google.com/dataflow) to look at the status of the job. It will take several minutes for the preprocessing job to launch."
    ]


### PR DESCRIPTION
The code for the old 'BigQuery to Tensorflow' python file has moved to https://github.com/tensorflow/tensorflow/blob/master/tensorflow/contrib/cloud/python/ops/bigquery_reader_ops.py (the old link was broken), but now an official documentation page for this package exists: https://www.tensorflow.org/api_docs/python/tf/contrib/cloud/BigQueryReader

The official documentation is probably a better starting point for a beginner than the module code.