### PR TITLE
specify pub/sub version to avoid backwards-compatibility issues

### DIFF
--- a/courses/streaming/publish/README.txt
+++ b/courses/streaming/publish/README.txt
@@ -9,15 +9,17 @@
     Then, try again
 
 (3) If you get a failure that the module pubsub has no attribute called Client
-    then you are running into path problems because an older version of pub/sub
-    is installed on your machine.  The solution is to use virtualenv:
+    then you are either:
+    - running into path problems because an older version of pub/sub is installed on your machine
+    - trying to use a newer version of pub/sub
+
+    The solution is to use virtualenv:
 
     (a) virtualenv cpb104
     (b) source cpb104/bin/activate
-    (c) pip install google-cloud-pubsub
+    (c) pip install google-cloud-pubsub==0.27.0
     (d) gcloud auth application-default login
-    
+
     Then, try the send_sensor_data.py again
 
     To exit the virtualenv environment, type 'deactivate'
-


### PR DESCRIPTION
Pub/Sub python client 0.29.0 introduces breaking changes for streaming code. Specifying an older version provides a workaround until scripts can be appropriately rewritten. 