### PR TITLE
Create a new model for prediction service by default.

### DIFF
--- a/blogs/babyweight/babyweight.ipynb
+++ b/blogs/babyweight/babyweight.ipynb
@@ -937,7 +937,7 @@
     "echo \"Deleting and deploying $MODEL_NAME $MODEL_VERSION from $MODEL_LOCATION ... this will take a few minutes\"\n",
     "#gcloud ml-engine versions delete ${MODEL_VERSION} --model ${MODEL_NAME}\n",
     "#gcloud ml-engine models delete ${MODEL_NAME}\n",
-    "#gcloud ml-engine models create ${MODEL_NAME} --regions $REGION\n",
+    "gcloud ml-engine models create ${MODEL_NAME} --regions $REGION\n",
     "gcloud ml-engine versions create ${MODEL_VERSION} --model ${MODEL_NAME} --origin ${MODEL_LOCATION} --runtime-version 1.4"
    ]
   },


### PR DESCRIPTION
Hi, "gcloud ml-engine models create" need to be uncommented by default for the initial execution (as supposed by the solution document.)