### PR TITLE
Fixed prev_line is not defined bug

### DIFF
--- a/courses/machine_learning/deepdive/09_sequence/poetry.ipynb
+++ b/courses/machine_learning/deepdive/09_sequence/poetry.ipynb
@@ -220,6 +220,7 @@
     "  open('data/poetry/test_input.txt', 'w') as test_infp,\\\n",
     "  open('data/poetry/test_output.txt', 'w') as test_outfp:\n",
     "    \n",
+    "    prev_line = ''\n",
     "    for curr_line in rawfp:\n",
     "        curr_line = curr_line.strip()\n",
     "        # poems break at empty lines, so this ensures we train only\n",


### PR DESCRIPTION
prev_line is referred to on line 228 (227 pre-edit) before being declared. Adding a simple declaration outside the for loop.