### PR TITLE
Remove the linear regression line on the plot

### DIFF
--- a/courses/machine_learning/datasets/create_datasets.ipynb
+++ b/courses/machine_learning/datasets/create_datasets.ipynb
@@ -557,7 +557,7 @@
     }
    ],
    "source": [
-    "ax = sns.regplot(x=\"trip_distance\", y=\"fare_amount\", ci=None, truncate=True, data=trips)"
+    "ax = sns.regplot(x=\"trip_distance\", y=\"fare_amount\", fit_reg=False, ci=None, truncate=True, data=trips)"
    ]
   },
   {
@@ -616,7 +616,7 @@
    ],
    "source": [
     "trips = bq.Query(afewrecords3, EVERY_N=100000).to_dataframe()\n",
-    "ax = sns.regplot(x=\"trip_distance\", y=\"fare_amount\", ci=None, truncate=True, data=trips)"
+    "ax = sns.regplot(x=\"trip_distance\", y=\"fare_amount\", fit_reg=False, ci=None, truncate=True, data=trips)"
    ]
   },
   {


### PR DESCRIPTION
Students are unfamiliar with the concept of linear regression at the time when they are working with this notebook. This part of the plot causes confusion (e.g. is the line part of the data points? what does the line mean?) and side discussions from students who already know about linear regression (e.g. what's the error with the linear regression in Seaborn?). This part of the plot should be also be removed because it is not pertinent to the content of the notebook.