### PR TITLE
fixed parameter name `problems` -> `problem`

### DIFF
--- a/courses/machine_learning/deepdive/09_sequence/poetry.ipynb
+++ b/courses/machine_learning/deepdive/09_sequence/poetry.ipynb
@@ -631,7 +631,7 @@
     "t2t-trainer \\\n",
     "  --data_dir=gs://${BUCKET}/poetry/subset \\\n",
     "  --t2t_usr_dir=./poetry/trainer \\\n",
-    "  --problems=$PROBLEM \\\n",
+    "  --problem=$PROBLEM \\\n",
     "  --model=transformer \\\n",
     "  --hparams_set=transformer_poetry \\\n",
     "  --output_dir=$OUTDIR --job-dir=$OUTDIR --train_steps=10"
@@ -666,7 +666,7 @@
     "echo \"Y\" | t2t-trainer \\\n",
     "  --data_dir=gs://${BUCKET}/poetry/subset \\\n",
     "  --t2t_usr_dir=./poetry/trainer \\\n",
-    "  --problems=$PROBLEM \\\n",
+    "  --problem=$PROBLEM \\\n",
     "  --model=transformer \\\n",
     "  --hparams_set=transformer_poetry \\\n",
     "  --output_dir=$OUTDIR \\\n",


### PR DESCRIPTION
using parameter `problem` instead of `problemes` fixes error:
p.s. see discussion https://gitter.im/tensor2tensor/Lobby?at=5b0273bdf04ce53632f379ce

```
 File "/root/.local/lib/python2.7/site-packages/tensor2tensor/utils/registry.py", line 251, in parse_problem_name
    if problem_name.endswith("_rev"):
AttributeError: 'NoneType' object has no attribute 'endswith'
```