### PR TITLE
Updated google-api-services from v1-rev58-1.22.0 to v1-rev64-1.23.0

### DIFF
--- a/courses/streaming/process/sandiego/pom.xml
+++ b/courses/streaming/process/sandiego/pom.xml
@@ -61,7 +61,7 @@
 	<dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-discovery</artifactId>
-      <version>v1-rev58-1.22.0</version>
+      <version>v1-rev64-1.23.0</version>
     </dependency>
 
     <!-- slf4j API frontend binding with JUL backend -->


### PR DESCRIPTION
This was the issue Jasen Baker found in the DE class.

Lab 2 and lab 3 which are streaming sensor data to pubsub are broken.
Running ./run_oncloud.sh $DEVSHELL_PROJECT_ID $BUCKET AverageSpeeds 

This was his recommended fix.