### PR TITLE
Fix Typo (edtis -> edits) in Lab 5

### DIFF
--- a/courses/machine_learning/deepdive/06_structured/labs/5_train.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/labs/5_train.ipynb
@@ -119,7 +119,7 @@
    "source": [
     "## Lab Task 1\n",
     "\n",
-    "The following code edtis babyweight/trainer/task.py. You should use add hyperparameters needed by your model through the command-line using the `parser` module. Look at how `batch_size` is passed to the model in the code below. Do this for the following hyperparameters (defaults in parentheses): `train_examples` (5000), `eval_steps` (None), `pattern` (of)."
+    "The following code edits babyweight/trainer/task.py. You should use add hyperparameters needed by your model through the command-line using the `parser` module. Look at how `batch_size` is passed to the model in the code below. Do this for the following hyperparameters (defaults in parentheses): `train_examples` (5000), `eval_steps` (None), `pattern` (of)."
    ]
   },
   {


### PR DESCRIPTION
Noticed a tiny typo in the bootcamp today. Great set of materials! Thanks y'all!