### PR TITLE
Update: Pub/Sub Java Client Library fix:

### DIFF
--- a/courses/developingapps/java/pubsub-languageapi-spanner/start/pom.xml
+++ b/courses/developingapps/java/pubsub-languageapi-spanner/start/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
  * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
         <google.datastore.version>1.6.0</google.datastore.version>
-        <google.pubsub.version>0.24.0-beta</google.pubsub.version>
+        <google.pubsub.version>0.26.0-beta</google.pubsub.version>
         <google.languageapi.version>0.24.0-beta</google.languageapi.version>
         <google.spanner.version>0.24.0-beta</google.spanner.version>
         <google.cloudstorage.version>1.6.0</google.cloudstorage.version>
@@ -117,7 +117,7 @@
     <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-pubsub</artifactId>
-        <version>0.24.0-beta</version>
+        <version>0.26.0-beta</version>
     </dependency>
     <dependency>
         <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
-Updated pom.xml for next available and compatible release for google-cloud-pubsub.
-Updated client library from 0.24.0-beta to 0.26.0-beta release.
-Verified that all internal dependencies compatible with the v0.26.0 release.
-The Pub/Sub connection issue with Pub/Sub client library for Java has been resolved with release 0.26.0-beta.