### PR TITLE
Use str.startswith method instead of re.match

### DIFF
--- a/courses/data_analysis/lab2/python/grep.py
+++ b/courses/data_analysis/lab2/python/grep.py
@@ -14,11 +14,10 @@ limitations under the License.
 """
 
 import apache_beam as beam
-import re
 import sys
 
 def my_grep(line, term):
-   if re.match( r'^' + re.escape(term), line):
+   if line.startswith(term):
       yield line
 
 if __name__ == '__main__':
@@ -35,4 +34,3 @@ if __name__ == '__main__':
    )
 
    p.run().wait_until_finish()
-

--- a/courses/data_analysis/lab2/python/grepc.py
+++ b/courses/data_analysis/lab2/python/grepc.py
@@ -14,10 +14,9 @@ limitations under the License.
 """
 
 import apache_beam as beam
-import re
 
 def my_grep(line, term):
-   if re.match( r'^' + re.escape(term), line):
+   if line.startswith(term):
       yield line
 
 PROJECT='cloud-training-demos'


### PR DESCRIPTION
This pull request is to revise the codes as per discussed in #225. `grep.py` and `grepc.py` in _training-data-analyst/courses/data_analysis/lab2/python/_ have been modified accordingly.