### PR TITLE
removed dictionary wrapping of tensor in input_fn

### DIFF
--- a/courses/machine_learning/deepdive/09_sequence/txtclsmodel/trainer/model.py
+++ b/courses/machine_learning/deepdive/09_sequence/txtclsmodel/trainer/model.py
@@ -103,7 +103,7 @@ def input_fn(texts, labels, tokenizer, batch_size, mode):
         shuffle = False
 
     return tf.estimator.inputs.numpy_input_fn(
-        x={'embedding_1_input': x},  # feature name must match internal keras input name
+        x,
         y=labels,
         batch_size=batch_size,
         num_epochs=num_epochs,
@@ -210,10 +210,8 @@ Defines the features to be passed to the model during inference
 """
 def serving_input_fn():
     feature_placeholder = tf.placeholder(tf.int16, [None, MAX_SEQUENCE_LENGTH])
-    features = {
-        'embedding_1_input': feature_placeholder
-    }
-    return tf.estimator.export.ServingInputReceiver(features, feature_placeholder)
+    features = feature_placeholder  # pass as-is
+    return tf.estimator.export.TensorServingInputReceiver(features, feature_placeholder)
 
 
 """

--- a/courses/machine_learning/deepdive/09_sequence/txtclsmodel/trainer/model_native.py
+++ b/courses/machine_learning/deepdive/09_sequence/txtclsmodel/trainer/model_native.py
@@ -253,10 +253,8 @@ Defines the features to be passed to the model during inference
 """
 def serving_input_fn():
     feature_placeholder = tf.placeholder(tf.string, [None])
-    features = {
-        'embedding_1_input': vectorize_sentences(feature_placeholder)
-    }
-    return tf.estimator.export.ServingInputReceiver(features, feature_placeholder)
+    features = vectorize_sentences(feature_placeholder)
+    return tf.estimator.export.TensorServingInputReceiver(features, feature_placeholder)
 
 
 """


### PR DESCRIPTION
simplifies Keras -> Estimator integration. 

Passing tensor directly works instead of having to sync dictionary key with keras input layer name. 