### PR TITLE
added sample prediction instances to resolve bug with unreferenced variables

### DIFF
--- a/courses/machine_learning/deepdive/09_sequence/text_classification_native.ipynb
+++ b/courses/machine_learning/deepdive/09_sequence/text_classification_native.ipynb
@@ -168,6 +168,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Sample prediction instances\n",
+    "Here are some actual hacker news headlines gathered from July 2018. These titles were not part of the training or evaluation datasets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "techcrunch=[\n",
+    "  'Uber shuts down self-driving trucks unit',\n",
+    "  'Grover raises €37M Series A to offer latest tech products as a subscription',\n",
+    "  'Tech companies can now bid on the Pentagon’s $10B cloud contract'\n",
+    "]\n",
+    "nytimes=[\n",
+    "  '‘Lopping,’ ‘Tips’ and the ‘Z-List’: Bias Lawsuit Explores Harvard’s Admissions',\n",
+    "  'A $3B Plan to Turn Hoover Dam into a Giant Battery',\n",
+    "  'A MeToo Reckoning in China’s Workplace Amid Wave of Accusations'\n",
+    "]\n",
+    "github=[\n",
+    "  'Show HN: Moon – 3kb JavaScript UI compiler',\n",
+    "  'Show HN: Hello, a CLI tool for managing social media',\n",
+    "  'Firefox Nightly added support for time-travel debugging'\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Get Predictions\n",
     "Note how we can now feed the titles directly to the model! No need for the client to load a vocabulary tokenization mapping. The text tokenization is done for us inside of the Tensorflow model's serving_input_fn. "
    ]


### PR DESCRIPTION
This pull request fixes a bug in the notebook which references variables that haven't been set in the notebook (techcrunch+nytimes+github).