### PR TITLE
Update wals notebook

### DIFF
--- a/courses/machine_learning/deepdive/10_recommend/wals.ipynb
+++ b/courses/machine_learning/deepdive/10_recommend/wals.ipynb
@@ -143,6 +143,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[['session_duration']].plot(kind='hist', logy=True, bins=100, figsize=[8,5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -151,9 +160,10 @@
    "outputs": [],
    "source": [
     "# the rating is the session_duration scaled to be in the range 0-1.  This will help with training.\n",
-    "df['rating'] = 0.3 * (1 + (df['session_duration'] - stats.loc['50%', 'session_duration'])/stats.loc['50%', 'session_duration'])\n",
+    "median = stats.loc['50%', 'session_duration']\n",
+    "df['rating'] = 0.3 * df['session_duration'] / median\n",
     "df.loc[df['rating'] > 1, 'rating'] = 1\n",
-    "df.describe()"
+    "df[['rating']].plot(kind='hist', logy=True, bins=100, figsize=[8,5])"
    ]
   },
   {
@@ -415,31 +425,6 @@
    },
    "outputs": [],
    "source": [
-    "grouped_by_users = mapped_df.groupby('userId')\n",
-    "N = 0\n",
-    "with tf.python_io.TFRecordWriter('data/items_for_user_subset') as ofp:\n",
-    "  for user, grouped in grouped_by_users:\n",
-    "    example = tf.train.Example(features=tf.train.Features(feature={\n",
-    "          'key': tf.train.Feature(int64_list=tf.train.Int64List(value=[user])),\n",
-    "          'indices': tf.train.Feature(int64_list=tf.train.Int64List(value=grouped['itemId'].values)),\n",
-    "          'values': tf.train.Feature(float_list=tf.train.FloatList(value=grouped['rating'].values))\n",
-    "        }))\n",
-    "    ofp.write(example.SerializeToString())    \n",
-    "    N = N + 1\n",
-    "    if N > 20:\n",
-    "      break"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
     "!ls -lrt data"
    ]
   },
@@ -497,6 +482,8 @@
     "    parsed_features = tf.parse_single_example(protos, features)\n",
     "    values = tf.sparse_merge(parsed_features['indices'], parsed_features['values'], vocab_size=vocab_size)\n",
     "    # Save key to remap after batching\n",
+    "    # This is a temporary workaround to assign correct row numbers in each batch.\n",
+    "    # You can ignore details of this part and remap_keys().\n",
     "    key = parsed_features['key']\n",
     "    decoded_sparse_tensor = tf.SparseTensor(indices=tf.concat([values.indices, [key]], axis = 0), values = tf.concat([values.values, [0.0]], axis = 0), dense_shape = values.dense_shape)\n",
     "    return decoded_sparse_tensor\n",
@@ -584,18 +571,7 @@
     "    }\n",
     "    return features, None\n",
     "  \n",
-    "  # just for developing line by line. You don't need this in production\n",
-    "  def _input_fn_subset():\n",
-    "    features = {\n",
-    "      WALSMatrixFactorization.INPUT_ROWS: parse_tfrecords('items_for_user_subset', args['nitems']),\n",
-    "      WALSMatrixFactorization.PROJECT_ROW: tf.constant(True)\n",
-    "    }\n",
-    "    return features, None\n",
-    "  \n",
-    "  def input_cols():\n",
-    "    return parse_tfrecords('users_for_item', args['nusers'])\n",
-    "  \n",
-    "  return _input_fn#_subset"
+    "  return _input_fn"
    ]
   },
   {
@@ -621,8 +597,9 @@
     "def try_out():\n",
     "  with tf.Session() as sess:\n",
     "    fn = read_dataset(tf.estimator.ModeKeys.EVAL, \n",
-    "                    {'input_path': 'data', 'batch_size': 8, 'nitems': 5668, 'nusers': 82802})\n",
+    "                    {'input_path': 'data', 'batch_size': 4, 'nitems': 5668, 'nusers': 82802})\n",
     "    feats, _ = fn()\n",
+    "    print feats['input_rows'].eval()\n",
     "    print feats['input_rows'].eval()\n",
     "\n",
     "try_out()"
@@ -665,45 +642,6 @@
     "      for best_items_for_user in topk.eval():\n",
     "        f.write(','.join(str(x) for x in best_items_for_user) + '\\n')\n",
     "\n",
-    "# online prediction returns row and column factors as needed\n",
-    "def create_serving_input_fn(args):\n",
-    "  def for_user_embeddings(userId):\n",
-    "      # all items for this user (for user_embeddings)\n",
-    "      items = tf.range(args['nitems'], dtype=tf.int64)\n",
-    "      users = userId * tf.ones([args['nitems']], dtype=tf.int64)\n",
-    "      ratings = 0.1 * tf.ones_like(users, dtype=tf.float32)\n",
-    "      return items, users, ratings, tf.constant(True)\n",
-    "    \n",
-    "  def for_item_embeddings(itemId):\n",
-    "      # all users for this item (for item_embeddings)\n",
-    "      users = tf.range(args['nusers'], dtype=tf.int64)\n",
-    "      items = itemId * tf.ones([args['nusers']], dtype=tf.int64)\n",
-    "      ratings = 0.1 * tf.ones_like(users, dtype=tf.float32)\n",
-    "      return items, users, ratings, tf.constant(False)\n",
-    "    \n",
-    "  def serving_input_fn():\n",
-    "    feature_ph = {\n",
-    "        'userId': tf.placeholder(tf.int64, 1),\n",
-    "        'itemId': tf.placeholder(tf.int64, 1)\n",
-    "    }\n",
-    "\n",
-    "    (items, users, ratings, project_row) = \\\n",
-    "                  tf.cond(feature_ph['userId'][0] < tf.constant(0, dtype=tf.int64),\n",
-    "                          lambda: for_item_embeddings(feature_ph['itemId']),\n",
-    "                          lambda: for_user_embeddings(feature_ph['userId']))\n",
-    "    rows = tf.stack( [users, items], axis=1 )\n",
-    "    cols = tf.stack( [items, users], axis=1 )\n",
-    "    input_rows = tf.SparseTensor(rows, ratings, (args['nusers'], args['nitems']))\n",
-    "    input_cols = tf.SparseTensor(cols, ratings, (args['nusers'], args['nitems']))\n",
-    "    \n",
-    "    features = {\n",
-    "      WALSMatrixFactorization.INPUT_ROWS: input_rows,\n",
-    "      WALSMatrixFactorization.INPUT_COLS: input_cols,\n",
-    "      WALSMatrixFactorization.PROJECT_ROW: project_row\n",
-    "    }\n",
-    "    return tf.contrib.learn.InputFnOps(features, None, feature_ph)\n",
-    "  return serving_input_fn\n",
-    "        \n",
     "def train_and_evaluate(args):\n",
     "    train_steps = int(0.5 + (1.0 * args['num_epochs'] * args['nusers']) / args['batch_size'])\n",
     "    steps_in_epoch = int(0.5 + args['nusers'] / args['batch_size'])\n",
@@ -718,8 +656,7 @@
     "            eval_input_fn=read_dataset(tf.estimator.ModeKeys.EVAL, args),\n",
     "            train_steps=train_steps,\n",
     "            eval_steps=1,\n",
-    "            min_eval_frequency=steps_in_epoch,\n",
-    "            export_strategies=tf.contrib.learn.utils.saved_model_export_utils.make_export_strategy(serving_input_fn=create_serving_input_fn(args))\n",
+    "            min_eval_frequency=steps_in_epoch\n",
     "        )\n",
     "\n",
     "    from tensorflow.contrib.learn.python.learn import learn_runner\n",
@@ -820,76 +757,6 @@
     "editable": true
    },
    "source": [
-    "## Get row and column factors\n",
-    "\n",
-    "Once you have a trained WALS model, you can get row and column factors (user and item embeddings) using the serving input function that we exported.  We'll look at how to use these in the section on building a recommendation system using deep neural networks."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "%writefile data/input.json\n",
-    "{\"userId\": 4, \"itemId\": -1}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "%bash\n",
-    "MODEL_DIR=$(ls wals_trained/export/Servo | tail -1)\n",
-    "gcloud ml-engine local predict --model-dir=wals_trained/export/Servo/$MODEL_DIR --json-instances=data/input.json"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "%writefile data/input.json\n",
-    "{\"userId\": -1, \"itemId\": 4}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "%bash\n",
-    "MODEL_DIR=$(ls wals_trained/export/Servo | tail -1)\n",
-    "gcloud ml-engine local predict --model-dir=wals_trained/export/Servo/$MODEL_DIR --json-instances=data/input.json"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
     "## Run on Cloud"
    ]
   },
@@ -944,6 +811,77 @@
    },
    "source": [
     "This took <b>10 minutes</b> for me."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get row and column factors\n",
+    "\n",
+    "Once you have a trained WALS model, you can get row and column factors (user and item embeddings) from the checkpoint file. We'll look at how to use these in the section on building a recommendation system using deep neural networks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_factors(args):\n",
+    "  with tf.Session() as sess:\n",
+    "    estimator = tf.contrib.factorization.WALSMatrixFactorization(\n",
+    "                         num_rows=args['nusers'], num_cols=args['nitems'],\n",
+    "                         embedding_dimension=args['n_embeds'],\n",
+    "                         model_dir=args['output_dir'])\n",
+    "    row_factors = estimator.get_row_factors()[0]\n",
+    "    col_factors = estimator.get_col_factors()[0]\n",
+    "    return row_factors, col_factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args = {\n",
+    "    'output_dir': 'gs://{}/wals/model_trained'.format(BUCKET),\n",
+    "    'nitems': 5668,\n",
+    "    'nusers': 82802,\n",
+    "    'n_embeds': 10\n",
+    "  }\n",
+    "\n",
+    "user_embeddings, item_embeddings = get_factors(args)\n",
+    "print user_embeddings[:3]\n",
+    "print item_embeddings[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can visualize the embedding vectors using dimensional reduction techniques such as PCA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from mpl_toolkits.mplot3d import Axes3D\n",
+    "from sklearn.decomposition import PCA\n",
+    "\n",
+    "pca = PCA(n_components=3)\n",
+    "pca.fit(user_embeddings)\n",
+    "user_embeddings_pca = pca.transform(user_embeddings)\n",
+    "\n",
+    "fig = plt.figure(figsize=(8,8))\n",
+    "ax = fig.add_subplot(111, projection='3d')\n",
+    "xs, ys, zs = user_embeddings_pca[::150].T\n",
+    "ax.scatter(xs, ys, zs)"
    ]
   },
   {

--- a/courses/machine_learning/deepdive/10_recommend/wals_tft.ipynb
+++ b/courses/machine_learning/deepdive/10_recommend/wals_tft.ipynb
@@ -189,7 +189,7 @@
     "    result = {\n",
     "      'userId' : tft.string_to_int(rowdict['visitorId'], vocab_filename='vocab_users'),\n",
     "      'itemId' : tft.string_to_int(rowdict['contentId'], vocab_filename='vocab_items'),\n",
-    "      'rating' : 0.3 * (1 + (rowdict['session_duration'] - median)/median)\n",
+    "      'rating' : 0.3 * rowdict['session_duration'] / median\n",
     "    }\n",
     "    # cap the rating at 1.0\n",
     "    result['rating'] = tf.where(tf.less(result['rating'], tf.ones(tf.shape(result['rating']))),\n",
@@ -459,49 +459,13 @@
     "  \n",
     "  def _input_fn():\n",
     "    features = {\n",
-    "      WALSMatrixFactorization.INPUT_ROWS: parse_tfrecords('items_for_user', args['nitems']),\n",
-    "      WALSMatrixFactorization.INPUT_COLS: parse_tfrecords('users_for_item', args['nusers']),\n",
+    "      WALSMatrixFactorization.INPUT_ROWS: parse_tfrecords('items_for_user-*-of-*', args['nitems']),\n",
+    "      WALSMatrixFactorization.INPUT_COLS: parse_tfrecords('users_for_item-*-of-*', args['nusers']),\n",
     "      WALSMatrixFactorization.PROJECT_ROW: tf.constant(True)\n",
     "    }\n",
     "    return features, None\n",
     "  \n",
-    "  # just for developing line by line. You don't need this in production\n",
-    "  def _input_fn_subset():\n",
-    "    features = {\n",
-    "      WALSMatrixFactorization.INPUT_ROWS: parse_tfrecords('items_for_user_subset', args['nitems']),\n",
-    "      WALSMatrixFactorization.PROJECT_ROW: tf.constant(True)\n",
-    "    }\n",
-    "    return features, None\n",
-    "  \n",
-    "  def input_cols():\n",
-    "    return parse_tfrecords('users_for_item', args['nusers'])\n",
-    "  \n",
-    "  return _input_fn#_subset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This code is helpful in developing the input function. You don't need it in production."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# make sure to change _input_fn above to _input_fn_subset\n",
-    "def try_out():\n",
-    "  with tf.Session() as sess:\n",
-    "    fn = read_dataset(tf.estimator.ModeKeys.EVAL, \n",
-    "                    {'input_path': 'gs://{}/wals/preproc_tft/'.format(BUCKET), \n",
-    "                     'batch_size': 8, 'nitems': 5668, 'nusers': 82802})\n",
-    "    feats, _ = fn()\n",
-    "    print feats['input_rows'].eval()\n",
-    "\n",
-    "#try_out()"
+    "  return _input_fn"
    ]
   },
   {
@@ -546,56 +510,6 @@
     "        f.write(originalUserIds[userId] + '\\t') # write userId \\t item1,item2,item3...\n",
     "        f.write(','.join(originalItemIds[itemId] for itemId in best_items_for_user) + '\\n')\n",
     "\n",
-    "# online prediction returns row and column factors as needed\n",
-    "def create_serving_input_fn(args):\n",
-    "  def for_user_embeddings(originalUserId):\n",
-    "      # convert the userId that the end-user provided to integer\n",
-    "      originalUserIds = tf.contrib.lookup.index_table_from_file(\n",
-    "          os.path.join(args['input_path'], 'transform_fn/transform_fn/assets/vocab_users'))\n",
-    "      userId = originalUserIds.lookup(originalUserId)\n",
-    "      \n",
-    "      # all items for this user (for user_embeddings)\n",
-    "      items = tf.range(args['nitems'], dtype=tf.int64)\n",
-    "      users = userId * tf.ones([args['nitems']], dtype=tf.int64)\n",
-    "      ratings = 0.1 * tf.ones_like(users, dtype=tf.float32)\n",
-    "      return items, users, ratings, tf.constant(True)\n",
-    "    \n",
-    "  def for_item_embeddings(originalItemId):\n",
-    "      # convert the userId that the end-user provided to integer\n",
-    "      originalItemIds = tf.contrib.lookup.index_table_from_file(\n",
-    "          os.path.join(args['input_path'], 'transform_fn/transform_fn/assets/vocab_items'))\n",
-    "      itemId = originalItemIds.lookup(originalItemId)\n",
-    "    \n",
-    "      # all users for this item (for item_embeddings)\n",
-    "      users = tf.range(args['nusers'], dtype=tf.int64)\n",
-    "      items = itemId * tf.ones([args['nusers']], dtype=tf.int64)\n",
-    "      ratings = 0.1 * tf.ones_like(users, dtype=tf.float32)\n",
-    "      return items, users, ratings, tf.constant(False)\n",
-    "  \n",
-    "  def serving_input_fn():\n",
-    "    feature_ph = {\n",
-    "        'visitorId': tf.placeholder(tf.string, 1, name='visitorId'),\n",
-    "        'contentId': tf.placeholder(tf.string, 1, name='contentId')\n",
-    "    }\n",
-    "\n",
-    "    (items, users, ratings, project_row) = \\\n",
-    "                  tf.cond(tf.equal(feature_ph['visitorId'][0], tf.constant(\"\", dtype=tf.string)),\n",
-    "                          lambda: for_item_embeddings(feature_ph['visitorId']),\n",
-    "                          lambda: for_user_embeddings(feature_ph['contentId']))\n",
-    "    rows = tf.stack( [users, items], axis=1 )\n",
-    "    cols = tf.stack( [items, users], axis=1 )\n",
-    "    input_rows = tf.SparseTensor(rows, ratings, (args['nusers'], args['nitems']))\n",
-    "    input_cols = tf.SparseTensor(cols, ratings, (args['nusers'], args['nitems']))\n",
-    "    \n",
-    "    features = {\n",
-    "      WALSMatrixFactorization.INPUT_ROWS: input_rows,\n",
-    "      WALSMatrixFactorization.INPUT_COLS: input_cols,\n",
-    "      WALSMatrixFactorization.PROJECT_ROW: project_row\n",
-    "    }\n",
-    "    return tf.contrib.learn.InputFnOps(features, None, feature_ph)\n",
-    "\n",
-    "  return serving_input_fn\n",
-    "        \n",
     "def train_and_evaluate(args):\n",
     "    train_steps = int(0.5 + (1.0 * args['num_epochs'] * args['nusers']) / args['batch_size'])\n",
     "    steps_in_epoch = int(0.5 + args['nusers'] / args['batch_size'])\n",
@@ -610,8 +524,7 @@
     "            eval_input_fn=read_dataset(tf.estimator.ModeKeys.EVAL, args),\n",
     "            train_steps=train_steps,\n",
     "            eval_steps=1,\n",
-    "            min_eval_frequency=steps_in_epoch,\n",
-    "            export_strategies=tf.contrib.learn.utils.saved_model_export_utils.make_export_strategy(serving_input_fn=create_serving_input_fn(args))\n",
+    "            min_eval_frequency=steps_in_epoch\n",
     "        )\n",
     "\n",
     "    from tensorflow.contrib.learn.python.learn import learn_runner\n",
@@ -692,26 +605,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Get row and column factors\n",
-    "\n",
-    "Once you have a trained WALS model, you can get row and column factors (user and item embeddings) using the serving input function that we exported.  We'll look at how to use these in the section on building a recommendation system using deep neural networks."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%bash\n",
-    "MODEL_DIR=$(ls wals_trained/export/Servo | tail -1)\n",
-    "saved_model_cli show --dir wals_trained/export/Servo/$MODEL_DIR --tag_set serve --signature_def serving_default"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Run on Cloud"
    ]
   },
@@ -748,7 +641,78 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This took <b>8 minutes</b> for me."
+    "This took <b>10 minutes</b> for me."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get row and column factors\n",
+    "\n",
+    "Once you have a trained WALS model, you can get row and column factors (user and item embeddings) from the checkpoint file. We'll look at how to use these in the section on building a recommendation system using deep neural networks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_factors(args):\n",
+    "  with tf.Session() as sess:\n",
+    "    estimator = tf.contrib.factorization.WALSMatrixFactorization(\n",
+    "                         num_rows=args['nusers'], num_cols=args['nitems'],\n",
+    "                         embedding_dimension=args['n_embeds'],\n",
+    "                         model_dir=args['output_dir'])\n",
+    "    row_factors = estimator.get_row_factors()[0]\n",
+    "    col_factors = estimator.get_col_factors()[0]\n",
+    "    return row_factors, col_factors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "args = {\n",
+    "    'output_dir': 'gs://{}/wals_tft/model_trained'.format(BUCKET),\n",
+    "    'nitems': 5668,\n",
+    "    'nusers': 82802,\n",
+    "    'n_embeds': 10\n",
+    "  }\n",
+    "\n",
+    "user_embeddings, item_embeddings = get_factors(args)\n",
+    "print user_embeddings[:3]\n",
+    "print item_embeddings[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can visualize the embedding vectors using dimensional reduction techniques such as PCA."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "from mpl_toolkits.mplot3d import Axes3D\n",
+    "from sklearn.decomposition import PCA\n",
+    "\n",
+    "pca = PCA(n_components=3)\n",
+    "pca.fit(user_embeddings)\n",
+    "user_embeddings_pca = pca.transform(user_embeddings)\n",
+    "\n",
+    "fig = plt.figure(figsize=(8,8))\n",
+    "ax = fig.add_subplot(111, projection='3d')\n",
+    "xs, ys, zs = user_embeddings_pca[::150].T\n",
+    "ax.scatter(xs, ys, zs)"
    ]
   },
   {

--- a/courses/machine_learning/deepdive/10_recommend/walsmodel/model.py
+++ b/courses/machine_learning/deepdive/10_recommend/walsmodel/model.py
@@ -169,45 +169,6 @@ def batch_predict(args):
       for best_items_for_user in topk.eval():
         f.write(','.join(str(x) for x in best_items_for_user) + '\n')
 
-# online prediction returns row and column factors as needed
-def create_serving_input_fn(args):
-  def for_user_embeddings(userId):
-      # all items for this user (for user_embeddings)
-      items = tf.range(args['nitems'], dtype=tf.int64)
-      users = userId * tf.ones([args['nitems']], dtype=tf.int64)
-      ratings = 0.1 * tf.ones_like(users, dtype=tf.float32)
-      return items, users, ratings, tf.constant(True)
-    
-  def for_item_embeddings(itemId):
-      # all users for this item (for item_embeddings)
-      users = tf.range(args['nusers'], dtype=tf.int64)
-      items = itemId * tf.ones([args['nusers']], dtype=tf.int64)
-      ratings = 0.1 * tf.ones_like(users, dtype=tf.float32)
-      return items, users, ratings, tf.constant(False)
-    
-  def serving_input_fn():
-    feature_ph = {
-        'userId': tf.placeholder(tf.int64, 1),
-        'itemId': tf.placeholder(tf.int64, 1)
-    }
-
-    (items, users, ratings, project_row) = \
-                  tf.cond(feature_ph['userId'][0] < tf.constant(0, dtype=tf.int64),
-                          lambda: for_item_embeddings(feature_ph['itemId']),
-                          lambda: for_user_embeddings(feature_ph['userId']))
-    rows = tf.stack( [users, items], axis=1 )
-    cols = tf.stack( [items, users], axis=1 )
-    input_rows = tf.SparseTensor(rows, ratings, (args['nusers'], args['nitems']))
-    input_cols = tf.SparseTensor(cols, ratings, (args['nusers'], args['nitems']))
-    
-    features = {
-      WALSMatrixFactorization.INPUT_ROWS: input_rows,
-      WALSMatrixFactorization.INPUT_COLS: input_cols,
-      WALSMatrixFactorization.PROJECT_ROW: project_row
-    }
-    return tf.contrib.learn.InputFnOps(features, None, feature_ph)
-  return serving_input_fn
-        
 def train_and_evaluate(args):
     train_steps = int(0.5 + (1.0 * args['num_epochs'] * args['nusers']) / args['batch_size'])
     steps_in_epoch = int(0.5 + args['nusers'] / args['batch_size'])
@@ -222,8 +183,7 @@ def train_and_evaluate(args):
             eval_input_fn=read_dataset(tf.estimator.ModeKeys.EVAL, args),
             train_steps=train_steps,
             eval_steps=1,
-            min_eval_frequency=steps_in_epoch,
-            export_strategies=tf.contrib.learn.utils.saved_model_export_utils.make_export_strategy(serving_input_fn=create_serving_input_fn(args))
+            min_eval_frequency=steps_in_epoch
         )
 
     from tensorflow.contrib.learn.python.learn import learn_runner

--- a/courses/machine_learning/deepdive/10_recommend/walsmodel/model.py
+++ b/courses/machine_learning/deepdive/10_recommend/walsmodel/model.py
@@ -42,18 +42,6 @@ def read_dataset(mode, args):
     key = parsed_features['key']
     decoded_sparse_tensor = tf.SparseTensor(indices=tf.concat([values.indices, [key]], axis = 0), values = tf.concat([values.values, [0.0]], axis = 0), dense_shape = values.dense_shape)
     return decoded_sparse_tensor
-
-def read_dataset(mode, args):
-  def decode_example(protos, vocab_size):
-    features = {'key': tf.FixedLenFeature([1], tf.int64),
-                'indices': tf.VarLenFeature(dtype=tf.int64),
-                'values': tf.VarLenFeature(dtype=tf.float32)}
-    parsed_features = tf.parse_single_example(protos, features)
-    values = tf.sparse_merge(parsed_features['indices'], parsed_features['values'], vocab_size=vocab_size)
-    # Save key to remap after batching
-    key = parsed_features['key']
-    decoded_sparse_tensor = tf.SparseTensor(indices=tf.concat([values.indices, [key]], axis = 0), values = tf.concat([values.values, [0.0]], axis = 0), dense_shape = values.dense_shape)
-    return decoded_sparse_tensor
     
   def remap_keys(sparse_tensor):
     # Current indices of our SparseTensor that we need to fix


### PR DESCRIPTION
Hi, this is a couple of updates for WALS and WALS_tft notebooks.

WALS notebook
- Simplify the scaling function and add histograms for ratings (before / after rescaling).
- Remove serving_input_fn() (both from notebook and code) and rewrite "Get row and column factors" to use checkpoints and show PCA visualization.
- Some minor cleanups
 -- Remove functions for user_subset dataset that were (probably) used during code development.
 -- Add a comment for remap_keys(), saying that users can ignore details.
 -- Modify try_out() to show two consecutive batches (so that users can understand that row numbers are not reset in each batch.)

WLAS_tft notebook
- Simplify the scaling function.
- Remove serving_input_fn() (both from notebook and code) and rewrite "Get row and column factors" to use checkpoints and show PCA visualization.
- Fix the filename glob (`items_for_user` => `items_for_user-*-of-*`, `users_for_item` => `users_for_item-*-of-*`)
- Some minor cleanups
 -- Remove unused parts in notebook and code.

You can see the new notebooks with actual outputs here:
- [wals notebook with output](https://gist.github.com/enakai00/b048a429291bdbe7f5774e62eaba7531)
- [wals_tft notebook with output](https://gist.github.com/enakai00/003dd38cd863f501b223b3799e9b0ceb)
