### PR TITLE
Update b_hyperparam.ipynb

### DIFF
--- a/courses/machine_learning/deepdive/05_artandscience/b_hyperparam.ipynb
+++ b/courses/machine_learning/deepdive/05_artandscience/b_hyperparam.ipynb
@@ -320,10 +320,12 @@
     "export PYTHONPATH=${PYTHONPATH}:${PWD}/house_prediction_module\n",
     "gcloud ml-engine jobs submit training house_$(date -u +%y%m%d_%H%M%S) \\\n",
     "   --config=hyperparam.yaml \\\n",
-    "   --module-name=trainer.house \\\n",
+    "   --module-name=trainer.task \\\n",
     "   --package-path=$(pwd)/house_prediction_module/trainer \\\n",
     "   --job-dir=$OUTDIR \\\n",
-    "   --runtime-version=$TFVERSION \\"
+    "   --runtime-version=$TFVERSION \\\n",
+    "   --\\\n",
+    "   --output_dir=$OUTDIR \\"
    ]
   },
   {


### PR DESCRIPTION
module name typo and output_dir argument missing for task.py. fails to be executed on gcp without changes.