### PR TITLE
adds region to pipeline options

### DIFF
--- a/courses/machine_learning/deepdive/06_structured/4_preproc.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/4_preproc.ipynb
@@ -215,6 +215,7 @@
     "      'temp_location': os.path.join(OUTPUT_DIR, 'tmp'),\n",
     "      'job_name': job_name,\n",
     "      'project': PROJECT,\n",
+    "      'region': REGION,\n",
     "      'teardown_policy': 'TEARDOWN_ALWAYS',\n",
     "      'no_save_main_session': True\n",
     "  }\n",

--- a/courses/machine_learning/deepdive/06_structured/4_preproc_tft.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/4_preproc_tft.ipynb
@@ -288,6 +288,7 @@
     "    'temp_location': os.path.join(OUTPUT_DIR, 'tmp'),\n",
     "    'job_name': job_name,\n",
     "    'project': PROJECT,\n",
+    "    'region': REGION,\n",
     "    'max_num_workers': 24,\n",
     "    'teardown_policy': 'TEARDOWN_ALWAYS',\n",
     "    'no_save_main_session': True,\n",

--- a/courses/machine_learning/deepdive/06_structured/labs/4_preproc.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/labs/4_preproc.ipynb
@@ -166,6 +166,7 @@
     "      'temp_location': os.path.join(OUTPUT_DIR, 'tmp'),\n",
     "      'job_name': job_name,\n",
     "      'project': PROJECT,\n",
+    "      'region': REGION,\n",
     "      'teardown_policy': 'TEARDOWN_ALWAYS',\n",
     "      'no_save_main_session': True\n",
     "  }\n",

--- a/courses/machine_learning/deepdive/08_image/flowers_fromscratch.ipynb
+++ b/courses/machine_learning/deepdive/08_image/flowers_fromscratch.ipynb
@@ -276,7 +276,7 @@
     "gsutil cp $IMAGE_URL flower.jpg\n",
     "\n",
     "# Base64 encode and create request message in json format.\n",
-    "python -c 'import base64, sys, json; img = base64.b64encode(open(\"flower.jpg\", \"rb\").read()); print json.dumps({\"image_bytes\":{\"b64\": img}})' &> request.json"
+    "python -c 'import base64, sys, json; img = base64.b64encode(open(\"flower.jpg\", \"rb\").read()).decode(); print(json.dumps({\"image_bytes\":{\"b64\": img}}))' &> request.json"
    ]
   },
   {

--- a/courses/machine_learning/deepdive/08_image/flowers_fromscratch_tpu.ipynb
+++ b/courses/machine_learning/deepdive/08_image/flowers_fromscratch_tpu.ipynb
@@ -594,7 +594,7 @@
     "gsutil cp $IMAGE_URL flower.jpg\n",
     "\n",
     "# Base64 encode and create request message in json format.\n",
-    "python -c 'import base64, sys, json; img = base64.b64encode(open(\"flower.jpg\", \"rb\").read()); print json.dumps({\"image_bytes\":{\"b64\": img}})' &> request.json"
+    "python -c 'import base64, sys, json; img = base64.b64encode(open(\"flower.jpg\", \"rb\").read()).decode(); print(json.dumps({\"image_bytes\":{\"b64\": img}}))' &> request.json"
    ]
   },
   {


### PR DESCRIPTION
region _'If not set, defaults to us-central1'_  https://cloud.google.com/dataflow/docs/guides/specifying-exec-params  which might differ from the region of the output bucket specified in the notebook before if it was changed from default 'us-central1' and data locality _'minimize network latency and network transport costs'_ https://cloud.google.com/dataflow/docs/concepts/regional-endpoints#why_specify_a_regional_endpoint