### PR TITLE
Fix: revert MLE training steps to 100000

### DIFF
--- a/blogs/babyweight/babyweight.ipynb
+++ b/blogs/babyweight/babyweight.ipynb
@@ -998,7 +998,7 @@
     "   -- \\\n",
     "   --bucket=${BUCKET} \\\n",
     "   --output_dir=${OUTDIR} \\\n",
-    "   --train_steps=20000"
+    "   --train_steps=100000"
    ]
   },
   {


### PR DESCRIPTION
I think the number of training steps for MLE job is mistakingly changed to 20000 in the past commit: fbac8bf0
This reverts it to the original value 100000.