### PR TITLE
Typo in the instructions

### DIFF
--- a/courses/machine_learning/deepdive/04_features/a_features.ipynb
+++ b/courses/machine_learning/deepdive/04_features/a_features.ipynb
@@ -484,7 +484,7 @@
     "\n",
     "We'll modify the feature_cols and input function to represent the features you want to use.\n",
     "\n",
-    "We divide **total_rooms** by **households** to get **avg_rooms_per_house** which we excect to positively correlate with **median_house_value**. \n",
+    "We divide **total_rooms** by **households** to get **avg_rooms_per_house** which we expect to positively correlate with **median_house_value**. \n",
     "\n",
     "We also divide **population** by **total_rooms** to get **avg_persons_per_room** which we expect to negatively correlate with **median_house_value**."
    ]


### PR DESCRIPTION
There's a typo in the text that describes the actions performed in the Training and Evaluation section