### PR TITLE
"random" instead of "shuffle"

### DIFF
--- a/courses/machine_learning/deepdive/03_tensorflow/c_dataset.ipynb
+++ b/courses/machine_learning/deepdive/03_tensorflow/c_dataset.ipynb
@@ -69,7 +69,7 @@
     "    return features, label\n",
     "\n",
     "  # Create list of file names that match \"glob\" pattern (i.e. data_file_*.csv)\n",
-    "  filenames_dataset = tf.data.Dataset.list_files(filename, random=False)\n",
+    "  filenames_dataset = tf.data.Dataset.list_files(filename, shuffle=False)\n",
     "  # Read lines from text files\n",
     "  textlines_dataset = filenames_dataset.flat_map(tf.data.TextLineDataset)\n",
     "  # Parse text lines as comma-separated values (CSV)\n",


### PR DESCRIPTION
I thought it would be a change of API, to put "random" instead of "shuffle", but apparently "random" does not exist in past API versions.