### PR TITLE
Update install_packages.sh

### DIFF
--- a/courses/data_analysis/lab2/python/install_packages.sh
+++ b/courses/data_analysis/lab2/python/install_packages.sh
@@ -2,5 +2,4 @@
 
 apt-get install python-pip
 pip install google-cloud-dataflow oauth2client==3.0.0 
-pip install --force six==1.10  # downgrade as 1.11 breaks apitools
 pip install -U pip


### PR DESCRIPTION
Downgrade of six module is no longer needed. 
closes #363

Please check #363 to confirm this is the correct lab that was broken.