### PR TITLE
Update tftransform.ipynb normalize euclidean

### DIFF
--- a/courses/machine_learning/feateng/tftransform.ipynb
+++ b/courses/machine_learning/feateng/tftransform.ipynb
@@ -244,7 +244,7 @@
     "      result['latdiff'] = tft.scale_to_0_1(latdiff)\n",
     "      result['londiff'] = tft.scale_to_0_1(londiff)\n",
     "      dist = tf.sqrt(latdiff * latdiff + londiff * londiff)\n",
-    "      result['euclidean'] = dist\n",
+    "      result['euclidean'] = tft.scale_to_0_1(dist)\n",
     "      return result\n",
     "\n",
     "def preprocess(in_test_mode):\n",


### PR DESCRIPTION
It seems strange that the Euclidean distance was left in its raw form. It probably ought to be normalized just like the examples of latdiff and londiff.

This pull request scales it between 0 and 1 based on the training data. 

