### PR TITLE
Replace general BigQuery with link to task-specific data set

### DIFF
--- a/courses/machine_learning/deepdive/10_recommend/content_based_preproc.ipynb
+++ b/courses/machine_learning/deepdive/10_recommend/content_based_preproc.ipynb
@@ -84,7 +84,7 @@
     "\n",
     "The cell below creates a local text file containing all the article ids (i.e. 'content ids') in the dataset. \n",
     "\n",
-    "Have a look at the original dataset in [BigQuery](https://bigquery.cloud.google.com/welcome/). Then read through the query below and make sure you understand what it is doing. "
+    "Have a look at the original dataset in [BigQuery](https://console.cloud.google.com/bigquery?p=cloud-training-demos&d=GA360_test&t=ga_sessions_sample). Then read through the query below and make sure you understand what it is doing. "
    ]
   },
   {

--- a/courses/machine_learning/deepdive/10_recommend/labs/content_based_preproc.ipynb
+++ b/courses/machine_learning/deepdive/10_recommend/labs/content_based_preproc.ipynb
@@ -80,7 +80,7 @@
     "\n",
     "The cell below creates a local text file containing all the article ids (i.e. 'content ids') in the dataset. \n",
     "\n",
-    "Have a look at the original dataset in [BigQuery](https://bigquery.cloud.google.com/welcome/). Then read through the query below and make sure you understand what it is doing. "
+    "Have a look at the original dataset in [BigQuery](https://console.cloud.google.com/bigquery?p=cloud-training-demos&d=GA360_test&t=ga_sessions_sample). Then read through the query below and make sure you understand what it is doing. "
    ]
   },
   {


### PR DESCRIPTION
The BigQuery link in the notebook points to the welcome page of the (legacy) BigQuery Web UI. As the project always is a fresh, new (Qwiklabs) project, the project & data list is empty.

Finding the data set is a chore and you really need to scan it to solve the TODO (get custom dimension index). This link directly opens the data set.