### PR TITLE
Correct comment to state a triangle rather than two

### DIFF
--- a/courses/machine_learning/tensorflow/a_tfstart.ipynb
+++ b/courses/machine_learning/tensorflow/a_tfstart.ipynb
@@ -202,7 +202,7 @@
     "  return tf.sqrt(areasq)\n",
     "\n",
     "with tf.Session() as sess:\n",
-    "  # pass in two triangles\n",
+    "  # pass in a triangle\n",
     "  area = compute_area(tf.constant([\n",
     "      [5.0, 3.0, 7.1],\n",
     "      [2.3, 4.1, 4.8]\n",


### PR DESCRIPTION
A small detail but the benefit of a simple example like this is that it's easy to follow for people without a strong maths background. This error might trip those people up unnecessarily!