### PR TITLE
Update kubectl wait option

### DIFF
--- a/courses/machine_learning/deepdive/06_structured/pipelines/2_deploy_kubeflow_pipelines.sh
+++ b/courses/machine_learning/deepdive/06_structured/pipelines/2_deploy_kubeflow_pipelines.sh
@@ -16,4 +16,4 @@ kubectl get job
 
 # This is an alternate method
 # jobname=$(kubectl get job | tail -1 | awk '{print $1}')
-# kubectl wait --for=condition=complete --timeout=5m $jobname
+# kubectl wait --for=condition=complete --timeout=5m job/$jobname


### PR DESCRIPTION
Below command failed with "error: resource(s) were provided, but no name, label selector, or --all flag specified" error so updating the job option:

(before) # kubectl wait --for=condition=complete --timeout=5m $jobname
(after) # kubectl wait --for=condition=complete --timeout=5m job/$jobname