### PR TITLE
fix typo

### DIFF
--- a/courses/machine_learning/cloudmle/taxifare/trainer/task.py
+++ b/courses/machine_learning/cloudmle/taxifare/trainer/task.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
         output_dir,
         json.loads(
             os.environ.get('TF_CONFIG', '{}')
-        ).get('task', {}).get('trail', '')
+        ).get('task', {}).get('trial', '')
     )
 
     # Run the training job


### PR DESCRIPTION
in the GCP specialization is shown the typo in the line 101 'trail' should be 'trial' as noted in the description