### PR TITLE
replaced URL with value provided as parameter

### DIFF
--- a/courses/bdml_fundamentals/demos/earthquakevm/transform.py
+++ b/courses/bdml_fundamentals/demos/earthquakevm/transform.py
@@ -53,7 +53,7 @@ def get_marker(magnitude):
 
 
 def create_png(url, outfile): 
-  quakes = get_earthquake_data('http://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_week.csv')
+  quakes = get_earthquake_data(url)
   print(quakes[0].__dict__)
 
   # Set up Basemap


### PR DESCRIPTION
Fix for duplicate URL provided on script, due to function not using the value passed as parameters (#484)