### PR TITLE
Update instructions

### DIFF
--- a/courses/machine_learning/cloudmle/cloudmle.ipynb
+++ b/courses/machine_learning/cloudmle/cloudmle.ipynb
@@ -279,7 +279,7 @@
     "\n",
     "First copy the training data to the cloud.  Then, launch a training job.\n",
     "\n",
-    "After you submit the job, go to the cloud console (http://console.cloud.google.com) and select <b>Machine Learning | Jobs</b> to monitor progress.  \n",
+    "After you submit the job, go to the cloud console (http://console.cloud.google.com) and select <b>AI Platform | Jobs</b> to monitor progress.  \n",
     "\n",
     "<b>Note:</b> Don't be concerned if the notebook stalls (with a blue progress bar) or returns with an error about being unable to refresh auth tokens. This is a long-lived Cloud job and work is going on in the cloud.  Use the Cloud Console link (above) to monitor the job."
    ]


### PR DESCRIPTION
On line 282 there was a reference to Machine Learning/jobs in GCP. I couldn't find such a reference, and I believe the correct one is AI Platform/jobs since this last one actually works.