### PR TITLE
Use previously set env vars for Serverless Data Analysis with Dataflow 

### DIFF
--- a/courses/data_analysis/lab2/python/grepc.py
+++ b/courses/data_analysis/lab2/python/grepc.py
@@ -26,7 +26,7 @@ BUCKET=os.environ.get('BUCKET')
 def run():
    argv = [
       '--project={0}'.format(PROJECT),
-      '--job_name=examplejob3',
+      '--job_name=examplejob2',
       '--save_main_session',
       '--staging_location=gs://{0}/staging/'.format(BUCKET),
       '--temp_location=gs://{0}/staging/'.format(BUCKET),


### PR DESCRIPTION
Hi,
In this lab (Serverless Data Analysis with Dataflow (Python) v1.3) we are already setting the env vars (Project ID and Bucket) in the shell. Seems redundant to again add those hardcoded in the script. 