### PR TITLE
Removing reference to estimator

### DIFF
--- a/courses/machine_learning/images/mnist_linear.ipynb
+++ b/courses/machine_learning/images/mnist_linear.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# MNIST Image Classification with TensorFlow\n",
     "\n",
-    "This notebook demonstrates how to implement a simple linear image model on [MNIST](http://yann.lecun.com/exdb/mnist/) using the [Estimator API](https://www.tensorflow.org/guide/estimators). It builds the foundation for this <a href=\"mnist_models.ipynb\">companion notebook</a>, which explores tackling the same problem with other types of models such as DNN and CNN."
+    "This notebook demonstrates how to implement a simple linear image model on [MNIST](http://yann.lecun.com/exdb/mnist/) using the [tf.keras API](https://www.tensorflow.org/versions/r2.0/api_docs/python/tf/keras). It builds the foundation for this <a href=\"mnist_models.ipynb\">companion notebook</a>, which explores tackling the same problem with other types of models such as DNN and CNN."
    ]
   },
   {


### PR DESCRIPTION
Removing a reference in the instructions to estimator as we no longer teach the estimator api.

Thanks for the review, team!