### PR TITLE
fix magic function usage

### DIFF
--- a/courses/machine_learning/deepdive/05_artandscience/d_customestimator.ipynb
+++ b/courses/machine_learning/deepdive/05_artandscience/d_customestimator.ipynb
@@ -600,7 +600,7 @@
     }
    ],
    "source": [
-    "%writefile test.json\n",
+    "%%writefile test.json\n",
     "{\"rawdata_input\": [0,0.214,0.406,0.558,0.655,0.687,0.65,0.549,0.393]}"
    ]
   },


### PR DESCRIPTION
Original syntax will cause following error:
```
UsageError: Line magic function `%writefile` not found (But cell magic `%%writefile` exists, did you mean that instead?).
```