### PR TITLE
Update KerasLayer with new version of tensorflow_hub

### DIFF
--- a/courses/machine_learning/deepdive2/text_classification/solutions/custom_tf_hub_word_embedding.ipynb
+++ b/courses/machine_learning/deepdive2/text_classification/solutions/custom_tf_hub_word_embedding.ipynb
@@ -37,6 +37,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip freeze | grep tensorflow-hub==0.7.0 || pip install tensorflow-hub==0.7.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "\n",
     "import tensorflow as tf\n",
@@ -58,6 +67,9 @@
    "source": [
     "PROJECT = \"your-gcp-project-here\" # REPLACE WITH YOUR PROJECT NAME\n",
     "BUCKET = \"your-gcp-bucket-here\" # REPLACE WITH YOUR BUCKET NAME\n",
+    "\n",
+    "PROJECT = \"dherin-sandbox\" # REPLACE WITH YOUR PROJECT NAME\n",
+    "BUCKET = \"dherin-sandbox\" # REPLACE WITH YOUR BUCKET NAME\n",
     "\n",
     "os.environ[\"PROJECT\"] = PROJECT\n",
     "os.environ[\"BUCKET\"] = BUCKET"
@@ -449,29 +461,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since TF-hub model has been saved in TF 1.x format, it's not callable by default when you load it with `hub.load`. We need a light wrapper class around the result of `hub.load` that turns it into a callable, by overloading the `__call__` method:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class Wrapper(tf.train.Checkpoint):\n",
-    "    def __init__(self, spec):\n",
-    "        super(Wrapper, self).__init__()\n",
-    "        self.module = hub.load(spec)\n",
-    "        self.variables = self.module.variables\n",
-    "        self.trainable_variables = []\n",
-    "    def __call__(self, x):\n",
-    "        return self.module.signatures[\"default\"](x)[\"default\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Now we are ready to create a `KerasLayer` out of our custom text embedding."
    ]
   },
@@ -481,7 +470,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "med_embed = hub.KerasLayer(Wrapper(MODULE))"
+    "med_embed = hub.KerasLayer(MODULE)"
    ]
   },
   {
@@ -499,6 +488,31 @@
    "source": [
     "outputs = med_embed(tf.constant(['ilium', 'I have a fracture', 'aneurism']))\n",
     "outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you use a version of TensorFlow Hub smaller than `tensorflow-hub==0.7.0`, then you'll need to use the following wrapper to instanciate the `KerasLayer`:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```python\n",
+    "class Wrapper(tf.train.Checkpoint):\n",
+    "    def __init__(self, spec):\n",
+    "        super(Wrapper, self).__init__()\n",
+    "        self.module = hub.load(spec)\n",
+    "        self.variables = self.module.variables\n",
+    "        self.trainable_variables = []\n",
+    "    def __call__(self, x):\n",
+    "        return self.module.signatures[\"default\"](x)[\"default\"]\n",
+    "    \n",
+    "med_embed = hub.KerasLayer(Wrapper(MODULE))\n",
+    "```"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/text_classification/solutions/custom_tf_hub_word_embedding.ipynb
+++ b/courses/machine_learning/deepdive2/text_classification/solutions/custom_tf_hub_word_embedding.ipynb
@@ -68,9 +68,6 @@
     "PROJECT = \"your-gcp-project-here\" # REPLACE WITH YOUR PROJECT NAME\n",
     "BUCKET = \"your-gcp-bucket-here\" # REPLACE WITH YOUR BUCKET NAME\n",
     "\n",
-    "PROJECT = \"dherin-sandbox\" # REPLACE WITH YOUR PROJECT NAME\n",
-    "BUCKET = \"dherin-sandbox\" # REPLACE WITH YOUR BUCKET NAME\n",
-    "\n",
     "os.environ[\"PROJECT\"] = PROJECT\n",
     "os.environ[\"BUCKET\"] = BUCKET"
    ]


### PR DESCRIPTION
With tensorflow_hub==0.7.0 we can directly use KerasLayer without the wrapper. 

Updated the lab with this info. 