### PR TITLE
Fixed typo 'tf.where_loop' to 'tf.while_loop'

### DIFF
--- a/courses/machine_learning/deepdive/03_tensorflow/labs/a_tfstart.ipynb
+++ b/courses/machine_learning/deepdive/03_tensorflow/labs/a_tfstart.ipynb
@@ -360,7 +360,7 @@
     "will be fed into the program, as will the initial guess $x_0$. Your program will start from that initial guess and then iterate one step using the formula:\n",
     "<img src=\"https://wikimedia.org/api/rest_v1/media/math/render/svg/142614c0378a1d61cb623c1352bf85b6b7bc4397\" />\n",
     "<p>\n",
-    "If you got the above easily, try iterating indefinitely until the change between $x_n$ and $x_{n+1}$ is less than some specified tolerance. Hint: Use [tf.where_loop](https://www.tensorflow.org/api_docs/python/tf/while_loop)"
+    "If you got the above easily, try iterating indefinitely until the change between $x_n$ and $x_{n+1}$ is less than some specified tolerance. Hint: Use [tf.while_loop](https://www.tensorflow.org/api_docs/python/tf/while_loop)"
    ]
   },
   {


### PR DESCRIPTION
There is a hint to use tf.where_loop which should have been tf.while_loop.  The typo was corrected.