### PR TITLE
Moving the %%bigquery magic to the first line of code blocks.

### DIFF
--- a/courses/machine_learning/deepdive2/time_series_prediction/solutions/3_modeling_bqml.ipynb
+++ b/courses/machine_learning/deepdive2/time_series_prediction/solutions/3_modeling_bqml.ipynb
@@ -510,8 +510,8 @@
     }
    ],
    "source": [
-    "# TODO 1a\n",
     "%%bigquery --project $PROJECT\n",
+    "# TODO 1a\n",
     "#standardSQL\n",
     "CREATE OR REPLACE MODEL\n",
     "  stock_market.direction_model OPTIONS(model_type = \"logistic_reg\",\n",
@@ -611,8 +611,8 @@
     }
    ],
    "source": [
-    "# TODO 1b\n",
     "%%bigquery --project $PROJECT\n",
+    "# TODO 1b\n",
     "#standardSQL\n",
     "SELECT\n",
     "  *\n",
@@ -732,8 +732,8 @@
     }
    ],
    "source": [
-    "#TODO 1c\n",
     "%%bigquery --project $PROJECT\n",
+    "#TODO 1c\n",
     "#standardSQL\n",
     "SELECT\n",
     "  *\n",
@@ -917,8 +917,8 @@
     }
    ],
    "source": [
-    "#TODO 2a\n",
     "%%bigquery --project $PROJECT\n",
+    "#TODO 2a\n",
     "#standardSQL\n",
     "CREATE OR REPLACE MODEL\n",
     "  stock_market.price_model OPTIONS(model_type = \"linear_reg\",\n",


### PR DESCRIPTION
When using magics like '%%biquery', this has to be on the first line, else it fails with "syntax error at create or update model". So moving the comment lines that were above it, to under it.