### PR TITLE
Typo "use add" => "add"

### DIFF
--- a/courses/machine_learning/deepdive/06_structured/labs/5_train.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/labs/5_train.ipynb
@@ -92,7 +92,7 @@
    "source": [
     "## Lab Task 1\n",
     "\n",
-    "The following code edits babyweight/trainer/task.py. You should use add hyperparameters needed by your model through the command-line using the `parser` module. Look at how `batch_size` is passed to the model in the code below. Do this for the following hyperparameters (defaults in parentheses): `train_examples` (5000), `eval_steps` (None), `pattern` (of)."
+    "The following code edits babyweight/trainer/task.py. You should add hyperparameters needed by your model through the command-line using the `parser` module. Look at how `batch_size` is passed to the model in the code below. Do this for the following hyperparameters (defaults in parentheses): `train_examples` (5000), `eval_steps` (None), `pattern` (of)."
    ]
   },
   {


### PR DESCRIPTION
You should *use add* hyperparameters needed by your model through the command-line using the `parser` module.
                    ^^^^

use add => add