### PR TITLE
pip install using the Python that is running the notebook

### DIFF
--- a/courses/machine_learning/deepdive/10_recommend/endtoend/endtoend.ipynb
+++ b/courses/machine_learning/deepdive/10_recommend/endtoend/endtoend.ipynb
@@ -47,8 +47,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "pip install sh --upgrade pip # needed to execute shell scripts later"
+    "import sys\n",
+    "!{sys.executable} -m pip install sh --upgrade pip # needed to execute shell scripts later"
    ]
   },
   {


### PR DESCRIPTION
Otherwise, local training does not work; now the default pip is not pointing at Python2 on the GCloud Notebook platform

![image](https://user-images.githubusercontent.com/37696/75120826-85cce880-565c-11ea-9c1e-e14c7e60c9cd.png)
