### PR TITLE
Update keras training notebook

### DIFF
--- a/courses/machine_learning/deepdive/06_structured/5_train_keras.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/5_train_keras.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,18 +36,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Updated property [core/project].\n",
-      "Updated property [compute/region].\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "gcloud config set project $PROJECT\n",
@@ -70,20 +61,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gs://cloud-training-demos-ml/babyweight/preproc/eval.csv-00000-of-00012\n",
-      "gs://cloud-training-demos-ml/babyweight/preproc/eval_2000.csv-00000-of-00030\n",
-      "gs://cloud-training-demos-ml/babyweight/preproc/train.csv-00000-of-00043\n",
-      "gs://cloud-training-demos-ml/babyweight/preproc/train_2000.csv-00000-of-00255\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "gsutil ls gs://${BUCKET}/babyweight/preproc/*-00000*"
@@ -364,8 +344,8 @@
     "\n",
     "    train_file_path = 'gs://{}/babyweight/preproc/{}*{}*'.format(BUCKET, 'train', PATTERN)\n",
     "    eval_file_path = 'gs://{}/babyweight/preproc/{}*{}*'.format(BUCKET, 'eval', PATTERN)\n",
-    "    trainds = load_dataset('train*', BATCH_SIZE, tf.estimator.ModeKeys.TRAIN)\n",
-    "    evalds = load_dataset('eval*', 1000, tf.estimator.ModeKeys.EVAL)\n",
+    "    trainds = load_dataset(train_file_path, BATCH_SIZE, tf.estimator.ModeKeys.TRAIN)\n",
+    "    evalds = load_dataset(eval_file_path, 1000, tf.estimator.ModeKeys.EVAL)\n",
     "    if EVAL_STEPS:\n",
     "        evalds = evalds.take(EVAL_STEPS)\n",
     "    steps_per_epoch = TRAIN_EXAMPLES // (BATCH_SIZE * NUM_EVALS)\n",
@@ -375,6 +355,7 @@
     "    \n",
     "    history = model.fit(trainds, \n",
     "                        validation_data=evalds,\n",
+    "                        validation_steps=steps_per_epoch,\n",
     "                        epochs=NUM_EVALS, \n",
     "                        steps_per_epoch=steps_per_epoch,\n",
     "                        verbose=2, # 0=silent, 1=progress bar, 2=one line per epoch\n",
@@ -447,10 +428,10 @@
     "COPY trainer /babyweight_tf2/trainer\n",
     "RUN apt update && \\\n",
     "    apt install --yes python3-pip && \\\n",
-    "    pip3 install --upgrade --quiet tf-nightly-2.0-preview\n",
+    "    pip3 install --upgrade --quiet tensorflow>=2.0.0\n",
     "\n",
     "ENV PYTHONPATH ${PYTHONPATH}:/babyweight_tf2\n",
-    "CMD [\"python3\", \"-m\", \"trainer.task\"]"
+    "ENTRYPOINT [\"python3\", \"-m\", \"trainer.task\"]"
    ]
   },
   {
@@ -519,16 +500,16 @@
     "gsutil -m rm -rf $OUTDIR\n",
     "\n",
     "#IMAGE=gcr.io/deeplearning-platform-release/tf2-cpu\n",
-    "IMAGE=gcr.io/$PROJECT/serverlessml_training_container\n",
+    "IMAGE=gcr.io/$PROJECT/babyweight_training_container\n",
     "\n",
     "gcloud beta ai-platform jobs submit training $JOBID \\\n",
-    "   --staging-bucket=gs://$BUCKET  --region=$REGION \\\n",
-    "   --master-image-uri=$IMAGE \\\n",
-    "   --master-machine-type=n1-standard-4 --scale-tier=CUSTOM \\\n",
-    "   -- \\\n",
-    "   --bucket=${BUCKET} \\\n",
-    "   --output_dir=${OUTDIR} \\\n",
-    "   --train_examples=200000   "
+    "    --staging-bucket=gs://$BUCKET --region=$REGION \\\n",
+    "    --master-image-uri=$IMAGE \\\n",
+    "    --master-machine-type=n1-standard-4 --scale-tier=CUSTOM \\\n",
+    "    -- \\\n",
+    "    --bucket=${BUCKET} \\\n",
+    "    --output_dir=${OUTDIR} \\\n",
+    "    --train_examples=200000"
    ]
   },
   {


### PR DESCRIPTION
* Fix incorrect dataset path
* Update tensorflow dependency since tf-nightly-2.0-preview no longer
  exists in pypi
* Dockerfile should use ENTRYPOINT instead of CMD to pass user args
* Fix incorrect repo name when submitting training
  serverlessml_training_container -> babyweight_training_container
* Add validation_steps in fit since this is now required

Tested on AI Platform Notebooks image tf2-2-1-cu101-notebooks-20200130