### PR TITLE
Change TF Version for AI Platform job

### DIFF
--- a/courses/machine_learning/deepdive/05_artandscience/b_hyperparam.ipynb
+++ b/courses/machine_learning/deepdive/05_artandscience/b_hyperparam.ipynb
@@ -56,7 +56,7 @@
     "os.environ['PROJECT'] = PROJECT\n",
     "os.environ['BUCKET'] = BUCKET\n",
     "os.environ['REGION'] = REGION\n",
-    "os.environ['TFVERSION'] = '1.8'  # Tensorflow version"
+    "os.environ['TFVERSION'] = '1.15'  # Tensorflow version matched with supported AI Platform containerized image"
    ]
   },
   {


### PR DESCRIPTION
Configure TFVERSION into appropriate runtime version for running AI Platform hyperparameter tuning job. Previous version (1.8) is not supported by containerized image in AI Platform