### PR TITLE
Updated broken docker command

### DIFF
--- a/courses/machine_learning/deepdive/06_structured/7_pipelines.ipynb
+++ b/courses/machine_learning/deepdive/06_structured/7_pipelines.ipynb
@@ -111,7 +111,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!docker run -t gcr.io/ai-analytics-solutions/babyweight-pipeline-bqtocsv:latest --project $PROJECT  --bucket $BUCKET --local"
+    "#!docker run -t gcr.io/ai-analytics-solutions/babyweight-pipeline-bqtocsv:latest --project $PROJECT  --bucket $BUCKET --mode local"
    ]
   },
   {


### PR DESCRIPTION
In 7_pipelines.ipynb there is a command line cell that allows the user to check that the Docker image is working properly. However, what we see it that the line contains `--local` which says that `local` is a argument when in realist `--mode` is the argument and `local` is the argument's value