### PR TITLE
1.7.4/1.0.4 RELEASE - AHYBRID080 UPDATE TO ANTHOS SERVICE MESH

### DIFF
--- a/courses/ahybrid/v1.0/AHYBRID080/scripts/create_gke.sh
+++ b/courses/ahybrid/v1.0/AHYBRID080/scripts/create_gke.sh
@@ -24,7 +24,7 @@ gcloud beta container clusters create ${C1_NAME} \
     --workload-pool=${WORKLOAD_POOL} \
     --enable-stackdriver-kubernetes \
     --subnetwork=default \
-    --labels mesh_id=${MESH_ID}
+    --labels mesh_id=${MESH_ID} \
     --release-channel=regular
 
 # service account requires additional role bindings

--- a/courses/ahybrid/v1.0/AHYBRID080/scripts/install.sh
+++ b/courses/ahybrid/v1.0/AHYBRID080/scripts/install.sh
@@ -17,7 +17,6 @@
 source ./scripts/env.sh
 
 apt-get install kubectl
-apt-get install google-cloud-sdk-kpt
 
 curl -sLO https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/kubectx 
 chmod +x kubectx 

--- a/courses/ahybrid/v1.0/AHYBRID080/scripts/install.sh
+++ b/courses/ahybrid/v1.0/AHYBRID080/scripts/install.sh
@@ -17,6 +17,7 @@
 source ./scripts/env.sh
 
 apt-get install kubectl
+sudo apt-get install google-cloud-sdk-kpt
 
 curl -sLO https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/kubectx 
 chmod +x kubectx 

--- a/courses/ahybrid/v1.0/AHYBRID080/scripts/tracing.yaml
+++ b/courses/ahybrid/v1.0/AHYBRID080/scripts/tracing.yaml
@@ -1,0 +1,9 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    enableTracing: true
+  values:
+    global:
+       proxy:
+         tracer: stackdriver


### PR DESCRIPTION
- THIS IS A HOTFIX; LAB IS CURRENTLY BROKEN
Updated install of Anthos Service Mesh to 1.6.8
Fixed numbering in instructions
Added small section to show new GUI options
Updated cluster to regular channel
Simplified TMUX instructions
