### PR TITLE
AHYBRID045-BUG-FIX-RELEASE-CHANNEL

### DIFF
--- a/courses/ahybrid/v1.0/AHYBRID045/scripts/create_gke.sh
+++ b/courses/ahybrid/v1.0/AHYBRID045/scripts/create_gke.sh
@@ -23,7 +23,7 @@ gcloud beta container clusters create ${C1_NAME} \
     --workload-pool=${WORKLOAD_POOL} \
     --enable-stackdriver-kubernetes \
     --subnetwork=default \
-    --labels mesh_id=${MESH_ID}
+    --labels mesh_id=${MESH_ID} \
     --release-channel=regular
 
 # service account requires additional role bindings

--- a/courses/ahybrid/v1.0/AHYBRID045/scripts/install.sh
+++ b/courses/ahybrid/v1.0/AHYBRID045/scripts/install.sh
@@ -17,7 +17,6 @@
 source ./scripts/env.sh
 
 apt-get install kubectl
-sudo apt-get install google-cloud-sdk-kpt
 
 curl -sLO https://raw.githubusercontent.com/ahmetb/kubectx/v0.7.0/kubectx 
 chmod +x kubectx 


### PR DESCRIPTION
 - added continutation character to gcloud command
- removed kpt which isn't needed

This is for the 1.7.4/1.0.5 release, to be pushed today 10/9