### PR TITLE
Change apiVersion

### DIFF
--- a/courses/ak8s/v1.1/Monitoring/hello-v2.yaml
+++ b/courses/ak8s/v1.1/Monitoring/hello-v2.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v2


### PR DESCRIPTION
extensions/v1beta1 is not available in recent versions of k8s (1.16). apps/v1 has been available since v1.9