### PR TITLE
Migrating from deprecated API version in the manifest

### DIFF
--- a/courses/ak8s/v1.1/GKE_Services/hello-v1.yaml
+++ b/courses/ak8s/v1.1/GKE_Services/hello-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v1

--- a/courses/ak8s/v1.1/GKE_Services/hello-v2.yaml
+++ b/courses/ak8s/v1.1/GKE_Services/hello-v2.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-v2


### PR DESCRIPTION
Upgraded API version to **apps/v1** as **extensions/v1beta1** is no longer served since v1.16 . 