### PR TITLE
Possible typos in hello-green deployment

### DIFF
--- a/courses/ak8s/kubernetes/deployments/hello-green.yaml
+++ b/courses/ak8s/kubernetes/deployments/hello-green.yaml
@@ -1,4 +1,4 @@
-apiVersion: app/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-green
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       labels:
-        app: hello
+        app: hello-green
         track: stable
         version: 2.0.0
     spec:


### PR DESCRIPTION
I just was doing the course, and the top line I think is definitely a typo (it should be apps/v1) but then I got an error about the metadata name not matching the label name, I'm providing a suggested fix.