### PR TITLE
Update Information_Schema demo for DE

### DIFF
--- a/quests/bq-optimize/demos/code/information_schema.sql
+++ b/quests/bq-optimize/demos/code/information_schema.sql
@@ -47,7 +47,7 @@ SELECT * FROM
 -- QUERY 3
 -- Are there any partitioned or clustered columns?
 -- For some datasets, this query will return no results. 
--- Running this query on the wikipedia datset will return results.
+-- Running this query on the wikipedia dataset will return results.
 
 SELECT * FROM 
   -- Replace baseball with a different dataset:

--- a/quests/bq-optimize/demos/code/information_schema.sql
+++ b/quests/bq-optimize/demos/code/information_schema.sql
@@ -106,7 +106,9 @@ SELECT
  TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), creation_time, DAY) AS days_live,
  option_value AS dataset_description
 FROM
+  -- Replace project-name with your project name
  `project-name.INFORMATION_SCHEMA.SCHEMATA` AS s
+   -- Replace project-name with your project name
  LEFT JOIN `project-name.INFORMATION_SCHEMA.SCHEMATA_OPTIONS` AS so
  USING (schema_name)
  

--- a/quests/bq-optimize/demos/code/information_schema.sql
+++ b/quests/bq-optimize/demos/code/information_schema.sql
@@ -3,9 +3,6 @@
 -- Querying dataset metadata
 -- https://cloud.google.com/bigquery/docs/dataset-metadata
 
--- Advanced example: Using Dataset and Table metadata to create SQL DDL for version control
--- https://cloud.google.com/bigquery/docs/information-schema-tables#advanced_example
-
 
 -- QUERY 1
 -- Query table metadata to get table size
@@ -116,3 +113,7 @@ FROM
 ORDER BY last_modified_time DESC
 
 LIMIT 15;
+
+
+-- For advanced examples, see: Using Dataset and Table metadata to create SQL DDL for version control
+-- https://cloud.google.com/bigquery/docs/information-schema-tables#advanced_example

--- a/quests/bq-optimize/demos/code/information_schema.sql
+++ b/quests/bq-optimize/demos/code/information_schema.sql
@@ -35,8 +35,7 @@ FROM
   `bigquery-public-data.baseball.__TABLES__`
 ORDER BY size_gb DESC;
 
--- Modify the query above to determine:
--- What is the largest table in terms of row count?
+-- Modify the query above to determine the largest table in terms of row count
 -- Is the same table as the largest in terms of GB?
 
 
@@ -50,7 +49,8 @@ SELECT * FROM
 
 -- QUERY 3
 -- Are there any partitioned or clustered columns?
--- For some datasets, this query will return no results. For dataset that will return results, use wikipedia.
+-- For some datasets, this query will return no results. 
+-- Running this query on the wikipedia datset will return results.
 
 SELECT * FROM 
   -- Replace baseball with a different dataset:
@@ -98,7 +98,8 @@ LIMIT 10;
 
 
 -- EXAMPLE QUERY FOR YOUR OWN PROJECT
--- Note that this query will not run on the BigQuery Public Dataset project but it will run in your own project
+-- Note that this query will not run on the BigQuery Public Data project.
+-- You can run this query in your own project (e.g. qwiklabs-gcp-XX-XXXXXXXXXX).
 -- Identify the most recently modified datasets in project and how long they have been around:
 
 SELECT

--- a/quests/bq-optimize/demos/code/information_schema.sql
+++ b/quests/bq-optimize/demos/code/information_schema.sql
@@ -59,7 +59,7 @@ WHERE
 -- QUERY 4
 -- Question: If you wanted to query across multiple datasets, how could you do it?
 -- https://stackoverflow.com/questions/43457651/bigquery-select-tables-from-all-tables-within-project
--- Answer: With a UNION (or a Python script) to iterate through each dataset in `bq ls`
+-- Answer: With a UNION or a Python script to iterate through each dataset in `bq ls`
 
 -- For example, which table has the most rows?
 

--- a/quests/bq-optimize/demos/code/information_schema.sql
+++ b/quests/bq-optimize/demos/code/information_schema.sql
@@ -3,34 +3,18 @@
 -- Querying dataset metadata
 -- https://cloud.google.com/bigquery/docs/dataset-metadata
 
--- QUERY 1
--- Most recently modified BigQuery Public Datasets and how long they have been around:
-SELECT
- s.*,
- TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), creation_time, DAY) AS days_live,
- option_value AS dataset_description
-FROM
- `bigquery-public-data.INFORMATION_SCHEMA.SCHEMATA` AS s
- LEFT JOIN `bigquery-public-data.INFORMATION_SCHEMA.SCHEMATA_OPTIONS` AS so
- USING (schema_name)
-
-WHERE so.option_name = 'description'
- 
-ORDER BY last_modified_time DESC
-
-LIMIT 15;
-
 -- Advanced example: Using Dataset and Table metadata to create SQL DDL for version control
 -- https://cloud.google.com/bigquery/docs/information-schema-tables#advanced_example
 
 
--- QUERY 2
--- Querying table metadata to get table size
--- Pick any dataset in the bigquery-public-dataset and tell me
+-- QUERY 1
+-- Query table metadata to get table size
+-- Pick any dataset in the bigquery-public-dataset and tell me:
 
 -- How many tables it contains?
--- What is the largest table in GB?
--- What is the largest table in row count?
+-- What is the largest table in terms of GB?
+
+-- Dataset options include: bitcoin_blockchain, github_repos, nasa_wildfire, wikipedia, and more
 
 SELECT 
   dataset_id,
@@ -51,8 +35,12 @@ FROM
   `bigquery-public-data.baseball.__TABLES__`
 ORDER BY size_gb DESC;
 
+-- Modify the query above to determine:
+-- What is the largest table in terms of row count?
+-- Is the same table as the largest in terms of GB?
 
--- QUERY 3
+
+-- QUERY 2
 -- For the dataset you chose, how many columns of data are present?
 
 SELECT * FROM 
@@ -60,8 +48,9 @@ SELECT * FROM
  `bigquery-public-data.baseball.INFORMATION_SCHEMA.COLUMNS`;
 
 
--- QUERY 4
+-- QUERY 3
 -- Are there any partitioned or clustered columns?
+-- For some datasets, this query will return no results. For dataset that will return results, use wikipedia.
 
 SELECT * FROM 
   -- Replace baseball with a different dataset:
@@ -70,10 +59,12 @@ WHERE
   is_partitioning_column = 'YES' OR clustering_ordinal_position IS NOT NULL;
 
 
--- QUERY 5
+-- QUERY 4
 -- Question: If you wanted to query across multiple datasets, how could you do it?
 -- https://stackoverflow.com/questions/43457651/bigquery-select-tables-from-all-tables-within-project
--- Answer: With a UNION or a python script to iterate through each dataset in `bq ls`
+-- Answer: With a UNION (or a Python script) to iterate through each dataset in `bq ls`
+
+-- For example, which table has the most rows?
 
 WITH ALL__TABLES__ AS (
   SELECT * FROM `bigquery-public-data.baseball.__TABLES__` UNION ALL
@@ -104,4 +95,21 @@ FROM ALL__TABLES__
 ORDER BY row_count DESC -- Top 10 tables with the most rows
 LIMIT 10;
 
--- Which table was it? 
+
+
+-- EXAMPLE QUERY FOR YOUR OWN PROJECT
+-- Note that this query will not run on the BigQuery Public Dataset project but it will run in your own project
+-- Identify the most recently modified datasets in project and how long they have been around:
+
+SELECT
+ s.*,
+ TIMESTAMP_DIFF(CURRENT_TIMESTAMP(), creation_time, DAY) AS days_live,
+ option_value AS dataset_description
+FROM
+ `project-name.INFORMATION_SCHEMA.SCHEMATA` AS s
+ LEFT JOIN `project-name.INFORMATION_SCHEMA.SCHEMATA_OPTIONS` AS so
+ USING (schema_name)
+ 
+ORDER BY last_modified_time DESC
+
+LIMIT 15;


### PR DESCRIPTION
This PR updates the information_schema.sql file that is used for demos in the DE course 1: Modernizing Data Lakes and Data Warehouses with GCP.  These update address the permission error from the last query (previously the first query) that runs on the BigQuery Public Data project.  The query and comments have been modified to indicate that the query should be run in learners' projects (e.g. qwiklabs-gcp-XX-XXXXXXXXXX), not on the BigQuery Public Data project.