### PR TITLE
Modified requirements.txt to fix broken python lab

### DIFF
--- a/courses/developingapps/v1.2/python/kubernetesengine/bonus/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/bonus/requirements.txt
@@ -6,7 +6,7 @@ google-cloud-pubsub>=0.28.3
 google-cloud-datastore>=1.3.0
 google-cloud-spanner>=0.28.0
 google-cloud-storage>=1.4.0
-google-cloud-language>=0.31.0
+google-cloud-language==1.3.0
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/end/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/end/requirements.txt
@@ -6,7 +6,7 @@ google-cloud-pubsub>=0.28.3
 google-cloud-datastore>=1.3.0
 google-cloud-spanner>=0.28.0
 google-cloud-storage>=1.4.0
-google-cloud-language>=0.31.0
+google-cloud-language==1.3.0
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/start/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/start/requirements.txt
@@ -6,7 +6,7 @@ google-cloud-pubsub>=0.28.3
 google-cloud-datastore>=1.3.0
 google-cloud-spanner>=0.28.0
 google-cloud-storage>=1.4.0
-google-cloud-language>=0.31.0
+google-cloud-language==1.3.0
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0


### PR DESCRIPTION
It seems there has been a recent change to the Google Cloud Natural Language API client library that has broken the "Deploying the Application into Kubernetes Engine: Python" lab in the Developing Applications w/GCP course. The solution is to specify the previous version of the library in the requirements.txt file. I have made the changes in the start, end and bonus folders for that lab.