### PR TITLE
Fix link to RMSPropOptimizer in qwik_start

### DIFF
--- a/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
+++ b/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
@@ -406,7 +406,7 @@
     "        ])\n",
     "\n",
     "    # Custom Optimizer:\n",
-    "    # https://www.tensorflow.org/api_docs/python/tf/train/RMSPropOptimizer\n",
+    "    # https://www.tensorflow.org/api_docs/python/tf/compat/v1/train/RMSPropOptimizer\n",
     "    optimizer = tf.keras.optimizers.RMSprop(lr=learning_rate)\n",
     "\n",
     "    # Compile Keras model\n",


### PR DESCRIPTION
Previous link leads to 404: https://www.tensorflow.org/api_docs/python/tf/train/RMSPropOptimizer
Fixed link: https://www.tensorflow.org/api_docs/python/tf/compat/v1/train/RMSPropOptimizer