### PR TITLE
Remove unused TensorFlow 2.1 installation

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
@@ -38,23 +38,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Ensure the right version of Tensorflow is installed.\n",
-    "!pip freeze | grep tensorflow==2.1 || pip install tensorflow==2.1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Please ignore any incompatibility warnings and errors and re-run the cell to view the installed tensorflow version.\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",


### PR DESCRIPTION
Remove installation of TensorFlow 2.1:
- Notebook instance comes with a newer version of TensorFlow.
- TensorFlow is not used in this notebook.
- The corresponding solutions notebook does not install TensorFlow 2.1