### PR TITLE
Use fillna and mode instead of apply and value_counts

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
@@ -1012,7 +1012,7 @@
     "\n",
     "While all the methods to handle missing values is beyond the scope of this lab, there are a few methods you should consider.  For numeric columns, use the \"mean\" values to fill in the missing numeric values.  For categorical columns, use the \"mode\" (or most frequent values) to fill in missing categorical values. \n",
     "\n",
-    "In this lab, we use the .apply and Lambda functions to fill every column with its own most frequent value.  You'll learn more about Lambda functions later in the lab."
+    "In this lab, we use the .fillna and .mode functions to fill every column with its own most frequent value."
    ]
   },
   {
@@ -1061,7 +1061,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lab Task #1b:** Apply the lambda function."
+    "**Lab Task #1b:** Apply the fillna function."
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/launching_into_ml/solutions/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/solutions/improve_data_quality.ipynb
@@ -1412,7 +1412,7 @@
     "\n",
     "While all the methods to handle missing values is beyond the scope of this lab, there are a few methods you should consider.  For numeric columns, use the \"mean\" values to fill in the missing numeric values.  For categorical columns, use the \"mode\" (or most frequent values) to fill in missing categorical values. \n",
     "\n",
-    "In this lab, we use the .apply and Lambda functions to fill every column with its own most frequent value.  You'll learn more about Lambda functions later in the lab."
+    "In this lab, we use the .fillna and .mode functions to fill every column with its own most frequent value."
    ]
   },
   {
@@ -1455,7 +1455,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Run the cell to apply the lambda function."
+    "Run the cell to apply the fillna function."
    ]
   },
   {
@@ -1464,10 +1464,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Here we are using the apply function with lambda.\n",
-    "# We can use the apply() function to apply the lambda function to both rows and columns of a dataframe.\n",
+    "# Here we are using the fillna function with the mode function.\n",
     "# TODO 1b\n",
-    "df_transport = df_transport.apply(lambda x:x.fillna(x.value_counts().index[0]))"
+    "df_transport = df_transport.fillna(df_transport.mode().loc[0])"
    ]
   },
   {


### PR DESCRIPTION
Due to performance, the `apply` function should only be used if there is no other more performant alternative. 

In this case, the `apply` function can be substituted by `fillna` and `mode`. 

For large DataFrames, this change could imply a performance gain of around 40%:
```ipython
In [10]: %timeit df.apply(lambda x: x.fillna(x.value_counts().index[0]))
2.77 s ± 53.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [11]: %timeit df.fillna(df.mode().loc[0])
1.7 s ± 29.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```