### PR TITLE
Use map instead of apply

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
@@ -1642,7 +1642,7 @@
     "#### Data Quality Issue #4:  \n",
     "##### Handling Categorical Columns\n",
     "\n",
-    "The feature column \"lightduty\" is categorical and has a \"Yes/No\" choice.  We cannot feed values like this into a machine learning model.  We need to convert the binary answers from strings of yes/no to integers of 1/0.  There are various methods to achieve this.  We will use the \"apply\" method with a lambda expression.  Pandas. apply() takes a function and applies it to all values of a Pandas series.\n",
+    "The feature column \"lightduty\" is categorical and has a \"Yes/No\" choice.  We cannot feed values like this into a machine learning model.  We need to convert the binary answers from strings of yes/no to integers of 1/0.  There are various methods to achieve this.  We will use the \"map\" method with a lambda expression.  Pandas. map() takes a function and applies it to all values of a Pandas series.\n",
     "\n",
     "##### What is a Lambda Function?\n",
     "\n",
@@ -1685,7 +1685,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's convert the Yes to 1 and No to 0. Pandas. apply()  . apply takes a function and applies it to all values of a Pandas series (e.g. lightduty). "
+    "Let's convert the Yes to 1 and No to 0. Pandas. map()  . map takes a function and applies it to all values of a Pandas series (e.g. lightduty). "
    ]
   },
   {
@@ -1707,7 +1707,7 @@
     }
    ],
    "source": [
-    "df.loc[:,'lightduty'] = df['lightduty'].apply(lambda x: 0 if x=='No' else 1)\n",
+    "df.loc[:,'lightduty'] = df['lightduty'].map(lambda x: 0 if x=='No' else 1)\n",
     "df['lightduty'].value_counts(0)"
    ]
   },

--- a/courses/machine_learning/deepdive2/launching_into_ml/solutions/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/solutions/improve_data_quality.ipynb
@@ -2043,7 +2043,7 @@
     "#### Data Quality Issue #4:  \n",
     "##### Handling Categorical Columns\n",
     "\n",
-    "The feature column \"lightduty\" is categorical and has a \"Yes/No\" choice.  We cannot feed values like this into a machine learning model.  We need to convert the binary answers from strings of yes/no to integers of 1/0.  There are various methods to achieve this.  We will use the \"apply\" method with a lambda expression.  Pandas. apply() takes a function and applies it to all values of a Pandas series.\n",
+    "The feature column \"lightduty\" is categorical and has a \"Yes/No\" choice.  We cannot feed values like this into a machine learning model.  We need to convert the binary answers from strings of yes/no to integers of 1/0.  There are various methods to achieve this.  We will use the \"map\" method with a lambda expression.  Pandas. map() takes a function and applies it to all values of a Pandas series.\n",
     "\n",
     "##### What is a Lambda Function?\n",
     "\n",
@@ -2096,8 +2096,8 @@
    ],
    "source": [
     "# Let's convert the Yes to 1 and No to 0.\n",
-    "# The .apply takes a function and applies it to all values of a Pandas series (e.g. lightduty). \n",
-    "df.loc[:,'lightduty'] = df['lightduty'].apply(lambda x: 0 if x=='No' else 1)\n",
+    "# The .map takes a function and applies it to all values of a Pandas series (e.g. lightduty). \n",
+    "df.loc[:,'lightduty'] = df['lightduty'].map(lambda x: 0 if x=='No' else 1)\n",
     "df['lightduty'].value_counts(0)"
    ]
   },


### PR DESCRIPTION
Due to performance, the `apply` function should only be used if there is no other more performant alternative.

In this case, the `apply` function can be substituted by `map`.

For large DataFrames, this change could imply a performance gain of around 15%.
```ipython
In [10]: %timeit s.apply(lambda x: 0 if x=='small' else 1)
1.05 ms ± 135 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [11]: %timeit s.map(lambda x: 0 if x=='small' else 1)
895 µs ± 34.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

If instead of a lambda function, a dict is used, the performance gain might be of around  36%.
```ipython
In [12]: %timeit s.map({'small': 0, 'large': 1})
670 µs ± 8.12 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```
