### PR TITLE
fix: add wget to install_missing.sh

### DIFF
--- a/courses/bdml_fundamentals/demos/earthquakevm/install_missing.sh
+++ b/courses/bdml_fundamentals/demos/earthquakevm/install_missing.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 sudo apt-get update
-sudo apt-get -y -qq --fix-missing install python3-mpltoolkits.basemap python3-numpy python3-matplotlib python3-requests
+sudo apt-get -y -qq --fix-missing install python3-mpltoolkits.basemap python3-numpy python3-matplotlib python3-requests wget
 
 # Copyright 2016 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at


### PR DESCRIPTION
I see that we are using wget in the ingest.sh script to download latest data from USGS into a csv file. But, wget is neither present in the install_missing.sh, nor is it already installed on the VM by default. So, I propose to edit the install_missing.sh file to include wget.