### PR TITLE
fix syntax errors caused by TODO leftover

### DIFF
--- a/courses/machine_learning/deepdive2/end_to_end_ml/solutions/deploy_keras_ai_platform_babyweight.ipynb
+++ b/courses/machine_learning/deepdive2/end_to_end_ml/solutions/deploy_keras_ai_platform_babyweight.ipynb
@@ -336,7 +336,7 @@
    "source": [
     "%%writefile inputs.json\n",
     "{\"is_male\": \"True\", \"mother_age\": 26.0, \"plurality\": \"Single(1)\", \"gestation_weeks\": 39}\n",
-    "{\"is_male\": \"False\", \"mother_age\": 26.0, \"plurality\": \"Single(1)\", \"gestation_weeks\": 39} # TODO 3b"
+    "{\"is_male\": \"False\", \"mother_age\": 26.0, \"plurality\": \"Single(1)\", \"gestation_weeks\": 39}"
    ]
   },
   {
@@ -428,7 +428,7 @@
     "    --region ${REGION} \\\n",
     "    --input-paths=$INPUT \\\n",
     "    --output-path=$OUTPUT \\\n",
-    "    --model=babyweight # TODO 4\\\n",
+    "    --model=babyweight \\ # TODO 4\n",
     "    --version=ml_on_gcp # TODO 4"
    ]
   },


### PR DESCRIPTION
Stumbled upon this file while doing https://googlecoursera.qwiklabs.com/focuses/13173456

Changes: 
- changed inputs.json into valid JSON by removing  # TODO 3b from json body.
- fixed CLI version jobs submit prediction  by moving multiline command slash to be before relevant comment character.