### PR TITLE
add global region to ai-platform commands in whatif notebooks

### DIFF
--- a/quests/dei/census/income_xgboost.ipynb
+++ b/quests/dei/census/income_xgboost.ipynb
@@ -404,7 +404,8 @@
     "  --python-version 3.7 \\\n",
     "  --origin $MODEL_DIR \\\n",
     "  --package-uris $CUSTOM_CODE_PATH \\\n",
-    "  --prediction-class predictor.MyPredictor"
+    "  --prediction-class predictor.MyPredictor \\\n",
+    "  --region=global"
    ]
   },
   {
@@ -446,7 +447,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud ai-platform predict --model=census_income_classifier --json-instances=predictions.json --version=original"
+    "!gcloud ai-platform predict --model=census_income_classifier --json-instances=predictions.json --version=original --region=global"
    ]
   },
   {
@@ -677,7 +678,8 @@
     "  --python-version 3.7 \\\n",
     "  --origin $MODEL_DIR \\\n",
     "  --package-uris $CUSTOM_CODE_PATH \\\n",
-    "  --prediction-class predictor.MyPredictor"
+    "  --prediction-class predictor.MyPredictor \\\n",
+    "  --region=global"
    ]
   },
   {

--- a/quests/dei/xgboost_caip_e2e.ipynb
+++ b/quests/dei/xgboost_caip_e2e.ipynb
@@ -376,7 +376,8 @@
     "--origin=$MODEL_BUCKET \\\n",
     "--staging-bucket=$MODEL_BUCKET \\\n",
     "--python-version=3.7 \\\n",
-    "--project=$GCP_PROJECT"
+    "--project=$GCP_PROJECT \\\n",
+    "--region=global"
    ]
   },
   {


### PR DESCRIPTION
Receiving errors or calls for user input without due to recent updates. Also adds more clarity to command as there's been confusion regarding endpoints used in commands.