### PR TITLE
fixed importing path mismatch

### DIFF
--- a/courses/machine_learning/deepdive2/structured/labs/5a_train_keras_ai_platform_babyweight.ipynb
+++ b/courses/machine_learning/deepdive2/structured/labs/5a_train_keras_ai_platform_babyweight.ipynb
@@ -204,7 +204,7 @@
     "import json\n",
     "import os\n",
     "\n",
-    "from babyweight.trainer import model\n",
+    "from trainer import model\n",
     "\n",
     "import tensorflow as tf\n",
     "\n",


### PR DESCRIPTION
Different path from solution notebook and this cause error during trainng.

Solution:
https://github.com/GoogleCloudPlatform/training-data-analyst/blob/6f9f731d0b2202c06259c8eac389c7dd5c0d8930/courses/machine_learning/deepdive2/structured/solutions/5a_train_keras_ai_platform_babyweight.ipynb#L231