### PR TITLE
added ORDER BY RAND() to add complete shuffling when creating dataset with BQ

### DIFF
--- a/courses/machine_learning/deepdive2/building_production_ml_systems/labs/0_export_data_from_bq_to_gcs.ipynb
+++ b/courses/machine_learning/deepdive2/building_production_ml_systems/labs/0_export_data_from_bq_to_gcs.ipynb
@@ -131,7 +131,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {
@@ -173,7 +174,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/building_production_ml_systems/labs/1_training_at_scale.ipynb
+++ b/courses/machine_learning/deepdive2/building_production_ml_systems/labs/1_training_at_scale.ipynb
@@ -155,7 +155,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {
@@ -197,7 +198,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/building_production_ml_systems/solutions/0_export_data_from_bq_to_gcs.ipynb
+++ b/courses/machine_learning/deepdive2/building_production_ml_systems/solutions/0_export_data_from_bq_to_gcs.ipynb
@@ -140,7 +140,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {
@@ -182,7 +183,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/building_production_ml_systems/solutions/1_training_at_scale.ipynb
+++ b/courses/machine_learning/deepdive2/building_production_ml_systems/solutions/1_training_at_scale.ipynb
@@ -155,7 +155,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {
@@ -197,7 +198,8 @@
     "    AND pickup_latitude < 45\n",
     "    AND dropoff_latitude > 37\n",
     "    AND dropoff_latitude < 45\n",
-    "    AND passenger_count > 0"
+    "    AND passenger_count > 0\n",
+    "ORDER BY RAND()"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/structured/labs/1b_prepare_data_babyweight.ipynb
+++ b/courses/machine_learning/deepdive2/structured/labs/1b_prepare_data_babyweight.ipynb
@@ -371,7 +371,9 @@
     "FROM\n",
     "    babyweight.babyweight_augmented_data\n",
     "WHERE\n",
-    "    # TODO: Modulo hashmonth to be approximately 75% of the data"
+    "    # TODO: Modulo hashmonth to be approximately 75% of the data\n",
+    "ORDER\n",
+    "    BY RAND()"
    ]
   },
   {
@@ -406,7 +408,9 @@
     "FROM\n",
     "    babyweight.babyweight_augmented_data\n",
     "WHERE\n",
-    "    # TODO: Modulo hashmonth to be approximately 25% of the data"
+    "    # TODO: Modulo hashmonth to be approximately 25% of the data\n",
+    "ORDER\n",
+    "    BY RAND()"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/structured/solutions/1b_prepare_data_babyweight.ipynb
+++ b/courses/machine_learning/deepdive2/structured/solutions/1b_prepare_data_babyweight.ipynb
@@ -507,7 +507,9 @@
     "FROM\n",
     "    babyweight.babyweight_augmented_data\n",
     "WHERE\n",
-    "    ABS(MOD(hashmonth, 4)) < 3"
+    "    ABS(MOD(hashmonth, 4)) < 3\n",
+    "ORDER\n",
+    "    BY RAND()"
    ]
   },
   {
@@ -574,7 +576,9 @@
     "FROM\n",
     "    babyweight.babyweight_augmented_data\n",
     "WHERE\n",
-    "    ABS(MOD(hashmonth, 4)) = 3"
+    "    ABS(MOD(hashmonth, 4)) = 3\n",
+    "ORDER\n",
+    "    BY RAND()"
    ]
   },
   {


### PR DESCRIPTION
Fix related to issue #1376.

Not sure this solution is following best practices, but I think this is the easiest workaround.

I modified data creation part under `building_production_ml_systems` and `structured` directory, but please let me know I should fix other notebooks too.