### PR TITLE
Anthos April21 Post-publication fixes

### DIFF
--- a/courses/ahybrid/v1.0/common/scripts/acm.sh
+++ b/courses/ahybrid/v1.0/common/scripts/acm.sh
@@ -48,7 +48,9 @@ spec:
 EOF
 
 gcloud services enable anthosconfigmanagement.googleapis.com
+sleep 20
 gcloud alpha container hub config-management enable
+sleep 20
 gcloud alpha container hub config-management apply \
   --membership=${C1_NAME}-connect \
   --config=config-management.yaml \

--- a/courses/ahybrid/v1.0/common/scripts/c2.sh
+++ b/courses/ahybrid/v1.0/common/scripts/c2.sh
@@ -23,19 +23,7 @@ gcloud beta container clusters create ${C1_NAME} \
     --labels mesh_id=${MESH_ID} \
     --release-channel "regular"
 
-# service account requires additional role bindings
-kubectl create clusterrolebinding [BINDING_NAME] \
-    --clusterrole cluster-admin --user [USER]
-
-gcloud iam service-accounts create ${C1_NAME}-connect-sa
-
-gcloud projects add-iam-policy-binding ${PROJECT_ID} \
- --member="serviceAccount:${C1_NAME}-connect-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
- --role="roles/gkehub.connect"
-
-gcloud iam service-accounts keys create ${C1_NAME}-connect-sa-key.json \
-  --iam-account=${C1_NAME}-connect-sa@${PROJECT_ID}.iam.gserviceaccount.com
-
+echo "Registering the gke cluster..."
 gcloud container hub memberships register ${C1_NAME}-connect \
    --gke-cluster=${C1_ZONE}/${C1_NAME}  \
-   --service-account-key-file=./${C1_NAME}-connect-sa-key.json
+   --enable-workload-identity

--- a/courses/ahybrid/v1.0/common/scripts/create_gke.sh
+++ b/courses/ahybrid/v1.0/common/scripts/create_gke.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+echo "Creating the gke cluster..."
 gcloud beta container clusters create ${C1_NAME} \
     --zone ${C1_ZONE} \
     --no-enable-basic-auth \
@@ -35,20 +36,7 @@ gcloud beta container clusters create ${C1_NAME} \
     --subnetwork=default \
     --scopes ${C1_SCOPE}
 
-
-# service account requires additional role bindings
-kubectl create clusterrolebinding [BINDING_NAME] \
-    --clusterrole cluster-admin --user [USER]
-
-gcloud iam service-accounts create ${C1_NAME}-connect-sa
-
-gcloud projects add-iam-policy-binding ${PROJECT_ID} \
- --member="serviceAccount:${C1_NAME}-connect-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
- --role="roles/gkehub.connect"
-
-gcloud iam service-accounts keys create ${C1_NAME}-connect-sa-key.json \
-  --iam-account=${C1_NAME}-connect-sa@${PROJECT_ID}.iam.gserviceaccount.com
-
+echo "Registering the gke cluster..."
 gcloud container hub memberships register ${C1_NAME}-connect \
    --gke-cluster=${C1_ZONE}/${C1_NAME}  \
-   --service-account-key-file=./${C1_NAME}-connect-sa-key.json
+   --enable-workload-identity


### PR DESCRIPTION
We discovered a few problems with the anthos setup files only after pushing to production. This branch resolves those:

* Inserted sleep statements to resolve problem with activated service not being recognized as enabled
* Changed gke cluster reservation to use workload identity
* Changed remote cluster creation script to successfully copy/use the config file