### PR TITLE
Minor fixes to the keras-babyweight notebook

### DIFF
--- a/blogs/babyweight_keras/babyweight.ipynb
+++ b/blogs/babyweight_keras/babyweight.ipynb
@@ -715,7 +715,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating a TensorFlow model using the Estimator API\n",
+    "## Creating a TensorFlow model using the Keras API\n",
     "\n",
     "First, write an read_dataset to create a generator object that reads the data."
    ]
@@ -1352,7 +1352,7 @@
     "#gcloud ml-engine models delete ${MODEL_NAME}\n",
     "gcloud ai-platform models create ${MODEL_NAME} --regions $REGION\n",
     "gcloud ai-platform versions create ${MODEL_VERSION} --model ${MODEL_NAME} \\\n",
-    "  --origin ${MODEL_LOCATION} --runtime-version 2.2"
+    "  --region=global --origin ${MODEL_LOCATION} --runtime-version 2.2"
    ]
   },
   {


### PR DESCRIPTION
Hi, I applied minor fixes to the notebook.
- Replace "Estimator API" in the section title with "Keras API".
- Add "region=global" option to "gcloud ai-platform versions create" command that became mandatory with the latest version of gcloud.