### PR TITLE
Fixes babyweight_keras notebook and associated app for latest versions of AppEngine and AI Platform

### DIFF
--- a/blogs/babyweight/application/app.yaml
+++ b/blogs/babyweight/application/app.yaml
@@ -1,12 +1,10 @@
-runtime: python27
-api_version: 1
-threadsafe: true
+runtime: python39
 
 handlers:
 - url: /
-  script: main.app
+  script: auto
 - url: /.*
-  script: main.app
+  script: auto
   login: required
 
 env_variables:

--- a/blogs/babyweight/application/main.py
+++ b/blogs/babyweight/application/main.py
@@ -26,12 +26,11 @@ from flask import url_for
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
 
-from google.appengine.api import app_identity
-
 
 credentials = GoogleCredentials.get_application_default()
-api = discovery.build('ml', 'v1', credentials=credentials)
-project = app_identity.get_application_id()
+api = discovery.build('ml', 'v1',
+        credentials=credentials, cache_discovery=False)
+project = os.environ['GOOGLE_CLOUD_PROJECT']
 model_name = os.getenv('MODEL_NAME', 'babyweight')
 
 
@@ -42,7 +41,7 @@ def get_prediction(features):
   input_data = {'instances': [features]}
   parent = 'projects/%s/models/%s' % (project, model_name)
   prediction = api.projects().predict(body=input_data, name=parent).execute()
-  return prediction['predictions'][0]['predictions'][0]
+  return prediction['predictions'][0]['weight'][0]
 
 
 @app.route('/')

--- a/blogs/babyweight/application/requirements.txt
+++ b/blogs/babyweight/application/requirements.txt
@@ -1,2 +1,3 @@
-Flask==0.12.1
-google-api-python-client==1.6.2
+Flask==1.1.2
+google-api-python-client==1.12.8
+oauth2client==4.1.3

--- a/blogs/babyweight_keras/babyweight.ipynb
+++ b/blogs/babyweight_keras/babyweight.ipynb
@@ -715,7 +715,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating a TensorFlow model using the Estimator API\n",
+    "## Creating a TensorFlow model using the Keras API\n",
     "\n",
     "First, write an read_dataset to create a generator object that reads the data."
    ]
@@ -1352,7 +1352,7 @@
     "#gcloud ml-engine models delete ${MODEL_NAME}\n",
     "gcloud ai-platform models create ${MODEL_NAME} --regions $REGION\n",
     "gcloud ai-platform versions create ${MODEL_VERSION} --model ${MODEL_NAME} \\\n",
-    "  --origin ${MODEL_LOCATION} --runtime-version 2.2"
+    "  --region=global --origin ${MODEL_LOCATION} --runtime-version 2.2"
    ]
   },
   {


### PR DESCRIPTION
Hi, I applied a few fixes to the babyweight_keras notebook and the associated app.

babyweight_keras notebook
- Add  `--region=global` option to `gcloud ai-platform versions create` command.
- Replace Estimator in the section title with Keras.

associated app
- Update config and codes for AppEngine 2nd generation (Python3)