### PR TITLE
Do not explicitly specify COS where not needed

### DIFF
--- a/courses/ahybrid/v1.0/common/scripts/create_gke.sh
+++ b/courses/ahybrid/v1.0/common/scripts/create_gke.sh
@@ -21,7 +21,6 @@ gcloud beta container clusters create ${C1_NAME} \
     --max-surge-upgrade 1 \
     --max-unavailable-upgrade 0 \
     --enable-autorepair \
-    --image-type "COS" \
     --release-channel "regular" \
     --machine-type=n1-standard-4 \
     --num-nodes=${C1_NODES} \


### PR DESCRIPTION
Starting with [GKE node version 1.19](https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#:~:text=starting%20with%20gke%20node%20version%201.19), COS image type is deprecated. I suggest to not explicitly specify any parameters where defaults would work.