### PR TITLE
MAINT: correctly spell specify

### DIFF
--- a/courses/machine_learning/feateng/feateng.ipynb
+++ b/courses/machine_learning/feateng/feateng.ipynb
@@ -445,7 +445,7 @@
     "# Arguments:\n",
     "#   -EVERY_N: Integer. Sample one out of every N rows from the full dataset.\n",
     "#     Larger values will yield smaller sample\n",
-    "#   -RUNNER: 'DirectRunner' or 'DataflowRunner'. Specfy to run the pipeline\n",
+    "#   -RUNNER: 'DirectRunner' or 'DataflowRunner'. Specify to run the pipeline\n",
     "#     locally or on Google Cloud respectively. \n",
     "# Side-effects:\n",
     "#   -Creates and executes dataflow pipeline. \n",


### PR DESCRIPTION
This is a super simple typo fix in a comment. Specify was written without an i initially.