### PR TITLE
fix typo, rename wrong function

### DIFF
--- a/quests/dei/census/income_xgboost.ipynb
+++ b/quests/dei/census/income_xgboost.ipynb
@@ -97,7 +97,7 @@
     "    'education',\n",
     "    'education-num',\n",
     "    'marital-status',\n",
-    "    'occ|upation',\n",
+    "    'occupation',\n",
     "    'relationship',\n",
     "    'race',\n",
     "    'sex',\n",

--- a/quests/dei/what-if-tool-challenge.ipynb
+++ b/quests/dei/what-if-tool-challenge.ipynb
@@ -585,7 +585,7 @@
     "  return preds\n",
     "  \n",
     "# Return 'limited' model predictions.\n",
-    "def limited_custom_predict(examples_to_infer):\n",
+    "def bad_custom_predict(examples_to_infer):\n",
     "  # Delete columns not used by model\n",
     "  model_inputs = np.delete(\n",
     "      np.array(examples_to_infer), columns_not_for_model_input, axis=1).tolist()\n",


### PR DESCRIPTION
fix typo
rename func `limited_custom_predict` to `bad_custom_predict` match with WitConfigBuilder in https://www.qwiklabs.com/focuses/12011?parent=catalog