### PR TITLE
Fix minor typo in `ai_platform_qwik_start.ipynb` notebook

### DIFF
--- a/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
+++ b/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
@@ -419,7 +419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The last file, called task.py, trains on data loaded and preprocessed in util.py. Using the tf.distribute.MirroredStrategy() sope, it is possible to train on a distributed fashion. The trained model is then saved in a TensorFlow SavedModel format."
+    "The last file, called task.py, trains on data loaded and preprocessed in util.py. Using the tf.distribute.MirroredStrategy() scope, it is possible to train on a distributed fashion. The trained model is then saved in a TensorFlow SavedModel format."
    ]
   },
   {


### PR DESCRIPTION
The aim of this PR is to fix a minor typo in the [ ai_platform_qwik_start.ipynb](https://github.com/GoogleCloudPlatform/training-data-analyst/blob/master/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb) notebook.