### PR TITLE
Notebook_update: 3_keras_sequential_api.ipynb

### DIFF
--- a/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
+++ b/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
@@ -756,8 +756,7 @@
    ],
    "source": [
     "%%bash\n",
-    "gcloud config set compute/region us-east1\n",
-    "gcloud config set ai_platform/region global\n"
+    "gcloud config set compute/region us-east1\n"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
+++ b/courses/machine_learning/deepdive2/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
@@ -742,8 +742,7 @@
    ],
    "source": [
     "%%bash\n",
-    "gcloud config set compute/region us-east1\n",
-    "gcloud config set ai_platform/region global\n"
+    "gcloud config set compute/region us-east1\n"
    ]
   },
   {


### PR DESCRIPTION
- Removed the command to set ai platform/region to 'global' as it is a deprecated endpoint.
- Reference buganizer: http://b/192671052