### PR TITLE
change from custom container to pre-built for training

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise.ipynb
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ddfac32e",
+   "id": "5ccbe4b9",
    "metadata": {},
    "source": [
     "# Vertex AI: Qwik Start"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9c54da6a",
+   "id": "9eb6f5b8",
    "metadata": {},
    "source": [
     "## Learning objectives\n",
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9dfddcd3",
+   "id": "24cf53d2",
    "metadata": {},
    "source": [
     "## Introduction: customer lifetime value (CLV) prediction with BigQuery and TensorFlow on Vertex AI"
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e133ecb1",
+   "id": "cd8ee8f2",
    "metadata": {},
    "source": [
     "In this lab, you will use [BigQuery](https://cloud.google.com/bigquery) for data processing and exploratory data analysis and the [Vertex AI](https://cloud.google.com/vertex-ai) platform to train and deploy a custom TensorFlow Regressor model to predict customer lifetime value. The goal of the lab is to introduce to Vertex AI through a high value real world use case - predictive CLV. You will start with a local BigQuery and TensorFlow workflow you may already be familiar with and progress toward training and deploying your model in the cloud with Vertex AI as well as retrieving predictions and explanations from your model.\n",
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f704eadd",
+   "id": "808ff433",
    "metadata": {},
    "source": [
     "### Predictive CLV: how much monetary value existing customers will bring to the business in the future\n",
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19362152",
+   "id": "4f98f42f",
    "metadata": {},
    "source": [
     "## Setup"
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "003babee",
+   "id": "94da832a",
    "metadata": {},
    "source": [
     "### Define constants"
@@ -92,8 +92,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "20c33bea",
+   "execution_count": 1,
+   "id": "b7f97b63",
    "metadata": {},
    "outputs": [
     {
@@ -112,8 +112,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "7d650b10",
+   "execution_count": 2,
+   "id": "e5a6f656",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,27 +125,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1061,
-   "id": "e8d6aea1",
+   "execution_count": 50,
+   "id": "da2d1ab5",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "dougkelly-vertex-demos-bucket\n"
+      "dsparing-sandbox\n"
      ]
     }
    ],
    "source": [
     "# Create Google Cloud Storage bucket for artifact storage.\n",
-    "GCS_BUCKET = f\"{PROJECT_ID}-bucket\"\n",
+    "GCS_BUCKET = f\"{PROJECT_ID}\"\n",
     "print(GCS_BUCKET)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c2ce6a76",
+   "id": "0b5bbe85",
    "metadata": {},
    "source": [
     "### Import libraries"
@@ -153,8 +153,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1058,
-   "id": "71324644",
+   "execution_count": 4,
+   "id": "0425ec2f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +170,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c974744",
+   "id": "a99314be",
    "metadata": {},
    "source": [
     "### Initialize the Vertex Python SDK client"
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba644c65",
+   "id": "4359bfae",
    "metadata": {},
    "source": [
     "Import the Vertex SDK for Python into your Python environment and initialize it."
@@ -186,8 +186,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
-   "id": "88bf4da4",
+   "execution_count": 5,
+   "id": "6c1bacb9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "571b3b9f",
+   "id": "11605bc3",
    "metadata": {},
    "source": [
     "## Download and process the lab data into BigQuery"
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3766e60e",
+   "id": "6f94d988",
    "metadata": {},
    "source": [
     "### Dataset\n",
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1555cd46",
+   "id": "4a54fee5",
    "metadata": {},
    "source": [
     "### Data ingestion"
@@ -227,7 +227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "03853e0d",
+   "id": "1d4e24d5",
    "metadata": {},
    "source": [
     "Execute the command below to ingest the lab data from the UCI Machine Learning repository into `Cloud Storage` and then upload to `BigQuery` for data processing. The data ingestion and processing scripts are available under the `utils` folder in the lab directory."
@@ -235,8 +235,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
-   "id": "9fa80942",
+   "execution_count": 6,
+   "id": "835fe4ce",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,16 +244,46 @@
     "BQ_DATASET_NAME=\"online_retail\"\n",
     "BQ_RAW_TABLE_NAME=\"online_retail_raw\"\n",
     "BQ_CLEAN_TABLE_NAME=\"online_retail_clean\"\n",
-    "BQ_ML_TABLE_NAME=\"online_retail_ml\"\n",
-    "BQ_URI=f\"bq://{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}\""
+    "BQ_ML_TABLE_NAME=\"online_retail_ml\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "709f3dfd",
+   "execution_count": 7,
+   "id": "1d644ed5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " 2021-07-15 21:21:04,404 [WARNING] File already exists in GCS.\n",
+      "\n",
+      " 2021-07-15 21:21:04,410 [INFO] Initializing BigQuery dataset.\n",
+      "\n",
+      " 2021-07-15 21:21:04,586 [WARNING] Dataset online_retail already exists, not creating.\n",
+      "\n",
+      " 2021-07-15 21:21:05,004 [INFO] BQ raw dataset load job starting...\n",
+      "\n",
+      " 2021-07-15 21:21:14,299 [INFO] BQ raw dataset load job complete.\n",
+      "\n",
+      " 2021-07-15 21:21:14,460 [INFO] Loaded 541909 rows into dsparing-sandbox.online_retail.online_retail_raw.\n",
+      "\n",
+      " 2021-07-15 21:21:14,466 [INFO] BQ make clean dataset starting...\n",
+      "\n",
+      " 2021-07-15 21:21:18,131 [INFO] BQ make clean dataset complete\n",
+      "\n",
+      " 2021-07-15 21:21:18,280 [INFO] Loaded 16766 rows into dsparing-sandbox.online_retail.online_retail_clean.\n",
+      "\n",
+      " 2021-07-15 21:21:18,287 [INFO] BQ make ML dataset starting...\n",
+      "\n",
+      " 2021-07-15 21:21:21,098 [INFO] BQ make ML dataset complete\n",
+      "\n",
+      " 2021-07-15 21:21:21,244 [INFO] Loaded 3330 rows into dsparing-sandbox.online_retail.online_retail_ml.\n"
+     ]
+    }
+   ],
    "source": [
     "!python utils/data_download.py \\\n",
     "--PROJECT_ID={PROJECT_ID} \\\n",
@@ -266,7 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c84a3724",
+   "id": "2f747938",
    "metadata": {},
    "source": [
     "### Data processing"
@@ -274,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "610eab04",
+   "id": "5faac28a",
    "metadata": {},
    "source": [
     "As is the case with many real-world datasets, the lab dataset required some cleanup for you to utilize this historical customer transaction data for predictive CLV.\n",
@@ -302,7 +332,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7eb3604d",
+   "id": "99d1bb21",
    "metadata": {},
    "source": [
     "## Exploratory data analysis (EDA) in BigQuery"
@@ -310,7 +340,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e89213a",
+   "id": "178b09fe",
    "metadata": {},
    "source": [
     "Below you will use BigQuery from this notebook to do exploratory data analysis to get to know this dataset and identify opportunities for data cleanup and feature engineering."
@@ -318,7 +348,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e238673",
+   "id": "6bf11a6a",
    "metadata": {},
    "source": [
     "### Recency: how recently have customers purchased?"
@@ -326,16 +356,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
-   "id": "2e018983",
+   "execution_count": 8,
+   "id": "ee89329d",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 445.87query/s]                          \n",
-      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2649.80rows/s]\n"
+      "Query complete after 0.01s: 100%|██████████| 1/1 [00:00<00:00, 484.27query/s]                          \n",
+      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2451.03rows/s]\n"
      ]
     }
    ],
@@ -345,13 +375,13 @@
     "SELECT \n",
     "  days_since_last_purchase\n",
     "FROM \n",
-    "  `dougkelly-vertex-demos.online_retail.online_retail_clv_ml` #Please update this with your table name e.g. `{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}`."
+    "  `dsparing-sandbox.online_retail.online_retail_ml` #Please update this with your table name e.g. `{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
-   "id": "45bbbe4b",
+   "execution_count": 9,
+   "id": "d6657bcc",
    "metadata": {},
    "outputs": [
     {
@@ -427,7 +457,7 @@
        "max                  274.000000"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -438,8 +468,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 435,
-   "id": "1334bbb6",
+   "execution_count": 10,
+   "id": "c88af766",
    "metadata": {},
    "outputs": [
     {
@@ -461,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd79ce73",
+   "id": "6c221225",
    "metadata": {},
    "source": [
     "From the chart, there are clearly a few different customer groups here such as loyal customers that have made purchases in the last few days as well as inactive customers that have not purchased in 250+ days. Using CLV predictions and insights, you can strategize on marketing and promotional interventions to improve customer purchase recency and re-active dormant customers."
@@ -469,7 +499,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18b37750",
+   "id": "fd9a1f45",
    "metadata": {},
    "source": [
     "### Frequency: how often are customers purchasing?"
@@ -477,16 +507,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 889,
-   "id": "eddacb70",
+   "execution_count": 11,
+   "id": "0f836399",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 470.42query/s]                          \n",
-      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2330.19rows/s]\n"
+      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 532.14query/s]                          \n",
+      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2208.07rows/s]\n"
      ]
     }
    ],
@@ -496,13 +526,13 @@
     "SELECT\n",
     "  n_purchases\n",
     "FROM\n",
-    "  `dougkelly-vertex-demos.online_retail.online_retail_clv_ml` #Please update this with your table name e.g. `{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}`."
+    "  `dsparing-sandbox.online_retail.online_retail_ml` #Please update this with your table name e.g. `{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 430,
-   "id": "b87c036d",
+   "execution_count": 12,
+   "id": "39b80ce4",
    "metadata": {},
    "outputs": [
     {
@@ -578,7 +608,7 @@
        "max      81.000000"
       ]
      },
-     "execution_count": 430,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -589,8 +619,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 432,
-   "id": "790e7d24",
+   "execution_count": 13,
+   "id": "d4f4a656",
    "metadata": {},
    "outputs": [
     {
@@ -612,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "813e252b",
+   "id": "5dc9cf63",
    "metadata": {},
    "source": [
     "From the chart and quantiles, you can see that half of the customers have less than or equal to only 2 purchases. You can also tell from the average purchases > median purchases and max purchases of 81 that there are customers, likely wholesalers, who have made significantly more purchases. This should have you already thinking about feature engineering opportunities such as bucketizing purchases and removing or clipping outlier customers. You can also explore alternative modeling strategies for CLV on new customers who have only made 1 purchase as the approach demonstrated in this lab will perform better on customers with more relationship transactional history. "
@@ -620,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f88eaa5",
+   "id": "8172b067",
    "metadata": {},
    "source": [
     "### Monetary: how much are customers spending?"
@@ -628,16 +658,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 436,
-   "id": "89c5aaad",
+   "execution_count": 14,
+   "id": "d5fe0a7a",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 508.46query/s]                          \n",
-      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2447.51rows/s]\n"
+      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 514.32query/s]                          \n",
+      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2241.55rows/s]\n"
      ]
     }
    ],
@@ -647,13 +677,13 @@
     "SELECT\n",
     "  target_monetary_value_3M\n",
     "FROM\n",
-    "`dougkelly-vertex-demos.online_retail.online_retail_clv_ml` #Please update this with your table name e.g. `{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}`."
+    "`dsparing-sandbox.online_retail.online_retail_ml` #Please update this with your table name e.g. `{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_TABLE_NAME}`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 437,
-   "id": "8be06b07",
+   "execution_count": 15,
+   "id": "2b944c23",
    "metadata": {},
    "outputs": [
     {
@@ -729,7 +759,7 @@
        "max               268478.000000"
       ]
      },
-     "execution_count": 437,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -740,8 +770,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1268,
-   "id": "54bdf23e",
+   "execution_count": 16,
+   "id": "4f764c55",
    "metadata": {},
    "outputs": [
     {
@@ -763,7 +793,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62a53a37",
+   "id": "65168095",
    "metadata": {},
    "source": [
     "From the chart and summary statistics, you can see there is a wide range in customer monetary value ranging from 2.90 to 268,478 GBP. Looking at the quantiles, it is clear there are a few outlier customers whose monetary value is greater than 3 standard deviations from the mean. With this small dataset, it is recommended to remove, clip  You should also be revisiting your CLV business requirements to see if binning customer monetary value and reframing this as a ML classification problem would suit your needs."
@@ -771,7 +801,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0de2d9db",
+   "id": "2131ba79",
    "metadata": {},
    "source": [
     "### Establish a simple model performance baseline"
@@ -779,7 +809,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a533931",
+   "id": "dbb97a8d",
    "metadata": {},
    "source": [
     "In order to evaluate the performance of your custom TensorFlow DNN Regressor model you will build in the next steps, it is a ML best practice to establish a simple performance baseline. Below is a simple SQL baseline that multiplies a customer's average purchase spent compounded by their daily purchase rate and computes standard regression metrics."
@@ -787,16 +817,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "e72f2cb6",
+   "execution_count": 17,
+   "id": "edeb16d4",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 764.41query/s] \n",
-      "Downloading: 100%|██████████| 1/1 [00:01<00:00,  1.51s/rows]\n"
+      "Query complete after 0.00s: 100%|██████████| 6/6 [00:00<00:00, 1246.64query/s]                        \n",
+      "Downloading: 100%|██████████| 1/1 [00:01<00:00,  1.28s/rows]\n"
      ]
     },
     {
@@ -841,7 +871,7 @@
        "0  1762.06  81502420.93  9027.87"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -856,7 +886,7 @@
     "      DATE_DIFF(DATE('2011-12-01'), DATE('2011-09-01'), DAY) AS target_days,\n",
     "      DATE_DIFF(DATE('2011-09-01'), MIN(order_date), DAY) AS feature_days,\n",
     "  FROM\n",
-    "    `dougkelly-vertex-demos.online_retail.online_retail_clv_clean`\n",
+    "    `dsparing-sandbox.online_retail.online_retail_clean`\n",
     "  GROUP BY\n",
     "      customer_id\n",
     "  ),\n",
@@ -867,7 +897,7 @@
     "      AVG(avg_purchase_revenue) * (COUNT(n_purchases) * (1 + SAFE_DIVIDE(COUNT(target_days),COUNT(feature_days)))) AS predicted_monetary_value_3M,\n",
     "      SUM(target_monetary_value_3M) AS target_monetary_value_3M\n",
     "  FROM\n",
-    "    `dougkelly-vertex-demos.online_retail.online_retail_clv_ml`\n",
+    "    `dsparing-sandbox.online_retail.online_retail_ml`\n",
     "  LEFT JOIN day_intervals USING(customer_id)\n",
     "  GROUP BY\n",
     "      customer_id\n",
@@ -884,7 +914,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0367c26",
+   "id": "3c693e66",
    "metadata": {},
    "source": [
     "These baseline results provide further support for the strong impact of outliers. The extremely high MSE comes from the exponential penalty applied to missed predictions and the magnitude of error on a few predictions.\n",
@@ -894,16 +924,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 720,
-   "id": "d6e6cc0d",
+   "execution_count": 18,
+   "id": "63cdd94d",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 4/4 [00:00<00:00, 1855.89query/s]                        \n",
-      "Downloading: 100%|██████████| 3324/3324 [00:01<00:00, 2272.22rows/s]\n"
+      "Query complete after 0.00s: 100%|██████████| 5/5 [00:00<00:00, 2247.99query/s]                        \n",
+      "Downloading: 100%|██████████| 3324/3324 [00:01<00:00, 2364.55rows/s]\n"
      ]
     }
    ],
@@ -917,7 +947,7 @@
     "      DATE_DIFF(DATE('2011-12-01'), DATE('2011-09-01'), DAY) AS target_days,\n",
     "      DATE_DIFF(DATE('2011-09-01'), MIN(order_date), DAY) AS feature_days,\n",
     "  FROM\n",
-    "    `dougkelly-vertex-demos.online_retail.online_retail_clv_clean`\n",
+    "    `dsparing-sandbox.online_retail.online_retail_clean`\n",
     "  GROUP BY\n",
     "      customer_id\n",
     "  ),\n",
@@ -928,7 +958,7 @@
     "      AVG(avg_purchase_revenue) * (COUNT(n_purchases) * (1 + SAFE_DIVIDE(COUNT(target_days),COUNT(feature_days)))) AS predicted_monetary_value_3M,\n",
     "      SUM(target_monetary_value_3M) AS target_monetary_value_3M\n",
     "  FROM\n",
-    "    `dougkelly-vertex-demos.online_retail.online_retail_clv_ml`\n",
+    "    `dsparing-sandbox.online_retail.online_retail_ml`\n",
     "  INNER JOIN day_intervals USING(customer_id)\n",
     "  GROUP BY\n",
     "      customer_id\n",
@@ -942,8 +972,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 721,
-   "id": "56aac082",
+   "execution_count": 19,
+   "id": "20d2133c",
    "metadata": {},
    "outputs": [
     {
@@ -975,33 +1005,33 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>12733.0</td>\n",
-       "      <td>767.900000</td>\n",
-       "      <td>383.95</td>\n",
+       "      <td>13045.0</td>\n",
+       "      <td>610.56</td>\n",
+       "      <td>305.28</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>14911.0</td>\n",
-       "      <td>1933.768148</td>\n",
-       "      <td>136846.14</td>\n",
+       "      <td>12436.0</td>\n",
+       "      <td>1018.02</td>\n",
+       "      <td>509.01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>14016.0</td>\n",
-       "      <td>2170.605000</td>\n",
-       "      <td>4341.21</td>\n",
+       "      <td>13147.0</td>\n",
+       "      <td>237.60</td>\n",
+       "      <td>712.80</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>14156.0</td>\n",
-       "      <td>6296.437037</td>\n",
-       "      <td>117379.63</td>\n",
+       "      <td>13276.0</td>\n",
+       "      <td>274.76</td>\n",
+       "      <td>590.93</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>12594.0</td>\n",
-       "      <td>722.828571</td>\n",
-       "      <td>3338.22</td>\n",
+       "      <td>14420.0</td>\n",
+       "      <td>775.04</td>\n",
+       "      <td>387.52</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1009,14 +1039,14 @@
       ],
       "text/plain": [
        "  customer_id  predicted_monetary_value_3M  target_monetary_value_3M\n",
-       "0     12733.0                   767.900000                    383.95\n",
-       "1     14911.0                  1933.768148                 136846.14\n",
-       "2     14016.0                  2170.605000                   4341.21\n",
-       "3     14156.0                  6296.437037                 117379.63\n",
-       "4     12594.0                   722.828571                   3338.22"
+       "0     13045.0                       610.56                    305.28\n",
+       "1     12436.0                      1018.02                    509.01\n",
+       "2     13147.0                       237.60                    712.80\n",
+       "3     13276.0                       274.76                    590.93\n",
+       "4     14420.0                       775.04                    387.52"
       ]
      },
-     "execution_count": 721,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1027,13 +1057,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 853,
-   "id": "747ebbc3",
+   "execution_count": 20,
+   "id": "4b4d87fb",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAFOCAYAAABjfG0oAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA7G0lEQVR4nO3de3xcdZ3/8dc7vaShLdCLtNAWqhQECqVKF3CLbioKiCsgFxcWBVdWXERXV1YuosKKiMULu67rBQS5CJZC1VZ+InbBALKl3CyFcJFKC01birQpNLVJ0+Tz++P7HXqSziQnydzzeT4e88jM99w+c2bynjPfc+YcmRnOOeeqU02pC3DOOVc4HvLOOVfFPOSdc66Kecg751wV85B3zrkq5iHvnHNVzEO+F5Iul/SzUteRL5JWSXpfvP8lST8pwjLrJTUVejku/yRNlWSShpa6lmolqUHSPxdq/mUf8nEFNEuqTTn+xyX9odB1FUrin6ol3lZJurgQyzKzb5hZr28uSTdK+nohaiiEcv9glnS6pOclvS7pVUk3Sdq11HVB142ASlZp79lCKuuQlzQVeDdgwAmlrabodjezUcAZwFclHdd9BN+6Kn85XqOHgNlmthvwNmAo4IFURqrqf8vMyvYGfJXwD/Fd4K5uw6YAvwD+AmwAvg8cCLQCHUALsCmO2wD8c2LajwN/SDz+L2A18AbwOPDuxLDLgZ/lqO9Z4O8Tj4cCrwHvBEYAP4u1bQIeBSakeM5TCR9qQxNtjwL/DtQDTcBFwCvALYQP6ouBP8dlzQfGJqb9GPBSHHYpsAp4X7bnBhwF/F+sd3VcT+cC7cC2uE5/HcfdC1gQ1/9K4F8T86kDbgSagWeALwJNPTzn6cBiYCOwHvhSbL8R+HpivPrkfOJ6WANsBp4HjgaOi7W2x3qfTNS7KC5jBfDJbq/xHfH12gw8BewPXAK8GtfFMYnxdwOuB9bF5X8dGJJ4bz0EXBOX9fVczzuOPwq4GfhND+P0tb7enuv8uMzNQCMwKw67BegEtsZ1dyE73o9nAy8T3t+X9lDrjcAPgLvjPB4CJgL/Gd8PzwHvSIx/IOH/c1Os5YRu8/of4P/FWpcC+yaGH8CO983zwEdie673bOb/ZDPhffnhbpmQfN2uin8PSYyzR1w3b+n2nGtj/Qcn2t4Sx90DGAPcRfhfaY73JyfGbSDmEzv/T2bW/9De3ns5X5NCBXQ+bvEN+mngsPiiTYjtQ4An4wsykhCoRyVerD90m8+bKzHbOMBHgXGEkL6AEKAjsq30bvP9KnBr4vEHgefi/U8BvwZ2ifUeBuya4jm/+aICAmYDfyUEWD2wHZgb31h1wOeBh4HJse3HwM/jvA4ivMnfE4d9N06/U8gDexPe/GcAw+L6mJn4Z0uGbQ3hw/CrwHDC1uiLwLFx+DeBB4GxhA/jp8kR8sDo+Ia9IL6Oo4Ejciy3PjMf4O2EcNsrsd72zfWaAfcTwmcEMJPwD3d0YvxW4Ni43m8mfHBdGtfFJ4GViXn9Kq7nkYR/4keATyXeW9uBz8Z51eV43kcBr8fXeguJkM4ybl/rS/Ncjye8L68CHk5Mu4r4/uj2fryO8H47FGgDDsxR642ED4LD4vLvi7WeFZf3deD3cdxhhP/xLxHeR+8lvAffnpjXRuDw+LxvBebFYSPj6/9Pcdg743KnZ3vvxLbTCB+ANcA/xPW+Z67XLa7DuYnpP0f8wMjyvG8Arkw8Ph/4bbw/DjiFkAWjCR/Yv8qWT/Qe8r8ix3sv5/sn38Gcrxvhn6AdGB8fPwf8W7z/rvjGHZpluo/Tx5DPMo9m4NBcgZEYb1p8U+4SH98KfDXe/wRhq3hGH5935kXdFOt4lriVTAi5bcQPoNj2LPEfOD7eM663oYQQnpcYNjJOny3kLwF+2cM/bjJsjwBe7jbOJcBP4/0XgeMSw84ld8ifAfwx5XLr2RHy0whbse8DhnWbrvs/yhTCt7vRibargBsT4y9ODPsQ4cMxs3U+Or4muwMTCCFX1+05/D7x3no52/PJ8RwnxeXv38M4fakvzXP938Swg4CticeryB7yyS3PR4DTe3jNrks8/izwbOLxIez4hv1uwgZVTWL4z4HLE/P6SWLY8ezYiPoH4MFuy/4xcFm2906OWpcBJ+Z63Qjv89WZ+oDHiN8WsszrfcCLiccPAWflGHcm0Jx43ECKkO/tvZfrVs79TmcDvzOz1+Lj22LbNYQ38ktmtj0fC5J0AfDPhE95A3YFxvc2nZmtkPQs8CFJvybsN3hHHHxLrHOepN0JX7UvNbP2lGWNz/H8/mJmrYnH+wC/lNSZaOsgvCH2IrxJM/VukbQhx/KmEL7KprEPsJekTYm2IYStd7ovl9BdlEtflvumuO4/T/inmC7pHuALZrY2y+h7ARvNbHO3mmYlHq9P3N8KvGZmHYnHELpW9iJsga6TlBm/hq7PN3m/t+exRtJvgXnAOyWdSQgrCCH2gX7U19tzfSVx/6/ACElDe/l/6j7NqB7G7V5r98eZafcCVptZ8r37EuGDr7fl7gMc0e09OJTwf5eVpLOALxCCkziv5P95l9fNzJZK2gL8naR1hA2LRTlmfx9QJ+mIWPNM4JdxubsQcus4QtcNwGhJQxKvYRr70Pt7bydlGfKS6oCPAEMkZV7kWmB3SYcSntTeOd6YlmWWWwhflTImJpb1bkLf7tFAo5l1SmomdJWk8XPCp2kN8IyZrQCIYf4fwH/EHci/IfQbXp9yvrl0f36rgU+Y2UPdR4xvzAMTj3chfHXMZjXha3HaZa40s/1yjL+OEN6N8fHeOcbLzOuMHMNyvm4AZnYbcFs8MuXHhG6sj2Wpdy0wVtLoRPjtTejT7KvVhK2pXB/CZFl+b4YC+wKY2a2Eb4T9NdDn2tfaB2ItMEVSTSLo9wb+lGLa1cD9Zvb+HMO7PA9J+xC6nI4GlphZh6RldP0/z/bcbyJ0574C3NltA2vHhCE35hPey+sJ+xAz6/8CQvfiEWb2iqSZwB/JnjE9vefTvPd2Uq5H15xE2Bo9iPCJOJMQVg8S+vYeIQTJNyWNlDRC0uw47XpgsqThifktA06WtIukacA5iWGjCX1xfwGGSvoqYUs+rXnAMcB5hG8bAEiaI+kQSUMIO3Tb43PKtx8BV8Y3MZLeIunEOOxO4O8lHRXXx9fI/ZrfCrxP0kckDZU0Lr4ZIazTtyXGfQR4Q9JFkuokDZF0sKS/icPnA5dIGiNpMuErey53ARMlfV5SraTRcWsIwut2vKSxkiYS9j8Qn+fbJb03HlrbSthCzKzf9cBUSTUAZraa0HV2VXyvzCC8B/ocpma2Dvgd8B1Ju0qqkbSvpL9LOw9JZ0raW8E+wJXAvX2tJUd9A32u3V/rQlpKCLULJQ2TVE/oipqXYtq7gP0lfSxOO0zS30jKbNR0fx4jCSH+FwBJ/wQcnGI5twAfJgT9zb2MexuhG+lMEllAyJitwCZJY4HLepjHMuA98f2xG6EbFOj/e69cQ/5sQv/uy2b2SuZGOILmTMIn4IcIX59eJhxx8g9x2vsIW5CvSMp09VxD6IteT/hkTr7h7yEcCfAnwlfFVvr2dXsdsAT4W+D2xKCJhJB9g9Bvfj+hywZJP5L0o7TL6MV/Eb5C/k7SZsJO2CNibY2EHUC3ET4UmwnrKtvzeJnQ53kBYWfXMsJONgjfPg6StEnSr+JXzA8RPnxXEnZ4/YSw5x/CN5iX4rDf0cNX6Li18/44v1eAF4A5cfAthB3sq+J8kuu3lrCD97U43R6EHXgQdmwBbJD0RLx/BuFr+lrC1+jLzGxxrrp6cRZhR+EzhHV6J2FfSFoHEYI4c/TJ84Sdp/kykOd6FfDl+Fr/ex5r2omZbSN0cX6A8Dr+gNCP/VyKaTcTNq5OJzzPV9hxQALs/J59BvgO4X91PWHfwE7ffrMspwl4gvAB8WAv42Y+tPYiZErGfxJ25L5G+P/8bQ/zWEx4ny8nHNxwV7dR+vzeU+y8d845l4WkG4C1ZvblUtfSH2XZJ++cc+Ug7k87mR0HVFSccu2ucc65kpJ0BeE3Ht8ys5Wlrqe/vLvGOeeqmG/JO+dcFfOQd865KuY7XhPGjx9vU6dO7dM0W7ZsYeTIkYUpqIC87uLyuourmHVv3bqVTZs2sXbt2tfM7C1FWWgfeMgnTJ06lccee6xP0zQ0NFBfX1+YggrI6y4ur7u4ilV3Y2MjCxYsYPLkyZxzzjk9nb6jZLy7xjnn+iEZ8GeeeWapy8nJQ9455/qoe8DX1qa6cF1JeMg751wfVFLAg4e8c86lVmkBDx7yzjmXSiUGPHjIO+dcryo14MFD3jnnelTJAQ8e8kWzoaWNJ1dvYkNLW6lLcc6lVOkBD/5jqKJYuGwNFy1YzrCaGto7O7n6lBmcMHNS7xM650qmGgIefEu+4Da0tHHRguW0tneyuW07re2dXLhguW/RO1fGqiXgwUO+4JqatzKsputqHlZTQ1Pz1hJV5JzrSTUFPHjIF9zkMXW0d3Z2aWvv7GTymLoSVeScy6XaAh485Atu3Kharj5lBiOG1TC6digjhtVw9SkzGDeq8t88zlWTagx48B2vRXHCzEnMnjaepuatTB5T5wHvXJmp1oAHD/miGTeq1sPduTJUzQEP3l3jnBvEqj3gwUPeOTdIDYaABw9559wgNFgCHjzknXODzGAKePCQd84NIoMt4MFD3jk3SAzGgAcPeefcIDBYAx485J1zVW4wBzx4yDvnqthgD3gocMhLmiLp95KeldQo6XOx/XJJayQti7fjE9NcImmFpOclHZtoP0zSU3HY9yQpttdKuj22L5U0NTHN2ZJeiLezC/lcnXPlxQM+KPRpDbYDF5jZE5JGA49LWhyHXWNm306OLOkg4HRgOrAX8L+S9jezDuCHwLnAw8BvgOOAu4FzgGYzmybpdGAu8A+SxgKXAbMAi8teZGbNBX7OzrkSa21t9YCPCrolb2brzOyJeH8z8CzQ0yWRTgTmmVmbma0EVgCHS9oT2NXMlpiZATcDJyWmuSnevxM4Om7lHwssNrONMdgXEz4YyoZfEtC5/GtsbKS5udkDPiraCcpiN8o7gKXAbOAzks4CHiNs7TcTPgAeTkzWFNva4/3u7cS/qwHMbLuk14FxyfYs0yTrOpfwDYEJEybQ0NDQp+fV0tLS52kAXt/aTlPzVkT4mjF5TB271Q3r83z6q791l5rXXVyVVndrayvNzc3U1dUxceJElixZUuqSSq4oIS9pFLAA+LyZvSHph8AVhHy7AvgO8AlAWSa3Htrp5zQ7GsyuBa4FmDVrltXX1/f4XLpraGigr9NsaGlj9tz7aG0f8mbbiGHbeeii9xTtTJX9qbsceN3FVUl1J/vgJ06cyJw5c0pdUlko+NE1koYRAv5WM/sFgJmtN7MOM+sErgMOj6M3AVMSk08G1sb2yVnau0wjaSiwG7Cxh3mVnF8S0Ln86r6TNR6X4Sj80TUCrgeeNbPvJtr3TIz2YeDpeH8RcHo8YuatwH7AI2a2Dtgs6cg4z7OAhYlpMkfOnArcF/vt7wGOkTRG0hjgmNhWcn5JQOfyx4+i6Vmhu2tmAx8DnpK0LLZ9CThD0kxC98kq4FMAZtYoaT7wDOHInPPjkTUA5wE3AnWEo2ruju3XA7dIWkHYgj89zmujpCuAR+N4XzOzjQV5ln2UuSTghQuWM6ymhvbOTr8koHP94AHfu4KGvJn9gex947/pYZorgSuztD8GHJylvRU4Lce8bgBuSFtvMfklAZ0bGA/4dPzyfyXklwR0rn884NPz0xo45yqKB3zfeMg75yqGB3zfecg75yqCB3z/eMg758qeB3z/ecg758qaB/zAeMg758qWB/zAecg758qSB3x+eMg758qOB3z+eMg758qKB3x+ecg758qGB3z+ecg758qCB3xheMg750rOA75wPOSdcyXlAV9YHvLOuZLxgC88D3nnXEl4wBeHh7xzrug84IvHQ945V1Qe8MXlIe+cKxoP+OLzkHfOFYUHfGl4yDvnCs4DvnQ85J1zBeUBX1oe8s65gvGALz0PeedcQXjAlwcPeedc3nnAlw8PeedcXnnAlxcPeedc3njAlx8PeedcXnjAlycPeefcgHnAly8PeefcgHjAlzcPeedcv3nAlz8Peedcv3jAVwYPeedcn3nAVw4Peedcn3jAVxYPeedcah7wlcdD3jmXigd8ZRra00BJmwFLNsXHAszMdi1gbc65MuEBX7l625K/F3gG+DpwsJmNNrNdM397m7mkKZJ+L+lZSY2SPhfbx0paLOmF+HdMYppLJK2Q9LykYxPth0l6Kg77niTF9lpJt8f2pZKmJqY5Oy7jBUln92nNOOcAD/hK12PIm9lJwLHAX4DrJN0v6dOSxqac/3bgAjM7EDgSOF/SQcDFwL1mth/hg+RigDjsdGA6cBzwA0lD4rx+CJwL7Bdvx8X2c4BmM5sGXAPMjfMaC1wGHAEcDlyW/DBxzvWutbXVA77C9donb2avm9lPgQ8APwK+Bnw8zczNbJ2ZPRHvbwaeBSYBJwI3xdFuAk6K908E5plZm5mtBFYAh0vaE9jVzJaYmQE3d5smM687gaPjVv6xwGIz22hmzcBidnwwOOd60djYSHNzswd8heuxTx5A0t8CZwDvBv4AfNjMHuzrgmI3yjuApcAEM1sH4YNA0h5xtEnAw4nJmmJbe7zfvT0zzeo4r+2SXgfGJduzTJOs61zCNwQmTJhAQ0NDn55XS0tLn6cpB153cVVa3a2trTQ3N1NXV8fEiRNZsmRJqUvqk0pb34XU247XVcAmYB4hCLfH9ncCZLbSeyNpFLAA+LyZvRG707OOmqXNemjv7zQ7GsyuBa4FmDVrltXX1+eqLauGhgb6Ok058LqLq5LqTvbBT5w4kTlz5pS6pD6rpPVdaL1tya8iBOOxwDF0DU4D3tvbAiQNIwT8rWb2i9i8XtKecSt+T+DV2N4ETElMPhlYG9snZ2lPTtMkaSiwG7Axttd3m6aht3qdG8y672SttC14t7MeQ97M6gcy89g3fj3wrJl9NzFoEXA28M34d2Gi/TZJ3wX2IuxgfcTMOiRtlnQkobvnLOC/u81rCXAqcJ+ZmaR7gG8kdrYeA1wykOfjXDXzo2iqU5o++YkAZvaKpLcQ+uafM7NnUsx/NvAx4ClJy2LblwjhPl/SOcDLwGlxGY2S5hMO29wOnG9mHXG684AbgTrg7niD8CFyi6QVhC340+O8Nkq6Ang0jvc1M9uYoua829DSRlPzViaPqWPcKP/HceXHA7569dYn/ynC4Y2SNJdwVE0jcJWkq83s+p6mN7M/kL1vHODoHNNcCVyZpf0x4OAs7a3ED4ksw24AbuipxkJbuGwNFy1YzrCaGto7O7n6lBmcMHOn/b/OlYwHfHXrbUv+M4Rj1uuAl4BpcYt+DPB7wla0y2FDSxsXLVhOa3snrXQCcOGC5cyeNt636F1Z8ICvfr0dJ99uZn81sw3An83sFYB43PlOR6q4rpqatzKspusqHlZTQ1Pz1hJV5NwOHvCDQ28h3xmPjgH4YKZR0ogU0w56k8fU0d7Z2aWtvbOTyWPqSlSRc4EH/ODRW1CfTNxiN7Pkj5HGARcUqqhqMW5ULVefMoMRw2oYXTuUEcNquPqUGd5V40rKA35w6e0QypdztK8B1mQeS1piZu/Kc21V4YSZk5g9bbwfXePKggf84NPrIZQpjcjTfKrSuFG1Hu6u5DzgB6d89av7TljnypgH/ODlO0+dq3Ie8INbvkI+5xnHnHOl4wHvUoe8pH0kvS/er5M0OjH4Y3mvzDk3IB7wDlKGvKRPEi7I8ePYNBn4VWa4mT2d98qcc/3mAe8y0m7Jn0842dgbAGb2ArBHj1M450rCA94lpQ35NjPblnkQz9vuR9Q4V2Y84F13aUP+fklfAuokvR+4A/h14cpyzvWVB7zLJm3IXwz8BXgK+BTwG+DLhSrKOdc3HvAul1S/eDWzTuC6eHPOlREPeNeTVCEvaSXZL4L9trxX5JxLzQPe9SbtuWtmJe6PIFyJaWz+y3HOpeUB79JI1SdvZhsStzVm9p/AewtbmnMuFw94l1ba7pp3Jh7WELbsR+cY3TlXQB7wri/Sdtd8J3F/O7AK+Ejeq3HO9cgD3vVV2qNr5hS6EOdczzzgXX/0GPKSvtDTcDP7bn7Lcc5l4wHv+qu3LXnvd3euxDzg3UD0do3X/yhWIc65nXnAu4FKe3TNCOAcYDqJ67ma2ScKVJdzg54HvMuHtOeuuQWYCBwL3E84n/zmQhXl3GDnAe/yJW3ITzOzrwBbzOwm4IPAIYUry7nBywPe5VPakG+PfzdJOhjYDZhakIqcG8Q84F2+pf0x1LWSxgBfARYBo+J951yeeMC7Qkgb8j81sw5Cf7yfedK5PPOAd4WStrtmpaRrJR0tSQWtyLlBxgPeFVLakH878L+EC3qvkvR9SUcVriznBgcPeFdoaU81vNXM5pvZycBMYFdC141zrp884F0xpN2SR9LfSfoB8AThB1F+Fkrn+skD3hVLXy7/twyYD3zRzLYUsijnqpkHvCumtEfXHGpmb+QaKOkSM7sqTzU5V7U84F2xpe2Tzxnw0WnZGiXdIOlVSU8n2i6XtEbSsng7PjHsEkkrJD0v6dhE+2GSnorDvpc5wkdSraTbY/tSSVMT05wt6YV4OzvN83SukDzgXSmk7pPvRa7DKm8EjsvSfo2ZzYy33wBIOgg4nXAStOOAH0gaEsf/IXAusF+8ZeZ5DtBsZtOAa4C5cV5jgcuAI4DDgcvij7mcK4nW1lYPeFcS+Qp5y9po9gCwMeU8TgTmmVmbma0EVgCHS9oT2NXMlpiZATcDJyWmuSnevxPIHMd/LLDYzDaaWTOwmOwfNs4VXGNjI83NzR7wriTS9sn3pq8/kPqMpLOAx4ALYhBPAh5OjNMU29rj/e7txL+rAcxsu6TXgXHJ9izTdC1cOpfwLYEJEybQ0NDQpyfS0tLS52nKgdddHK2trTQ3N1NXV8fEiRNZsmRJqUvqk0pb3xmVWnchpD26ZqyZ9bRFfkcflvlD4ArC1v8VhIuEf4LsHxTWQzv9nKZro9m1wLUAs2bNsvr6+h5K31lDQwN9naYceN2Fl+yDnzhxInPmVN6lkitpfSdVat2FkLa7ZqmkOyQdn+20Bmb2jbQLNLP1ZtZhZp3AdYQ+cwhb21MSo04G1sb2yVnau0wjaSjh7Jgbe5iXc0XRfSernw3ElUrakN+fsLX7MWCFpG9I2r8/C4x97BkfBjJH3iwCTo9HzLyVsIP1ETNbB2yWdGT8gDkLWJiYJnPkzKnAfbHf/h7gGElj4g7XY2KbcwXnR9G4cpKquyYG52JgsaQ5wM+AT0t6ErjYzLJ2NEr6OVAPjJfURDjipV7STEL3ySrgU3EZjZLmA88A24Hz45kvAc4jHKlTB9wdbwDXA7dIWkHYgj89zmujpCuAR+N4X+ulu8m5vPCAd+UmbZ/8OOCjhC359cBnCVvRMwn98W/NNp2ZnZGl+fpcyzGzK4Ers7Q/Bhycpb2VHMfom9kNwA25luVcvnnAu3KU9uiaJYTrvJ5kZskjXR6T9KP8l+VcZfGAd+Wq15CPP0i6y8yuyDbczObmvSrnKogHvCtnve54jf3ihxahFucqjge8K3dpu2uWSVpE6H9/8wyUZvaLglTlXAXwgHeVIG3IjwU2AO9NtBkw6EO+o9N4cvUmJo+pY9wo/ycfLDzgXaVIewjlPxW6kEq0cNkaml7ZzI/uX0p7ZydXnzKDE2ZmPXuCqyIe8K6SpD2EcgThjI/TCVeFAsDMPlGgusrehpY2LlqwnPMPMDa3bQfgwgXLmT1tvG/RVzEPeFdp0v7i9RZgIuHsjvcTThOwuVBFVYKm5q0Mq+m6+obV1NDUvLVEFblC84B3lShtyE8zs68AW8zsJuCDwCGFK6v8TR5TR3tnZ5e29s5OJo+pK1FFrpA84F2lShvy7fHvJkkHE04ENrUgFVWIcaNqufqUGdRIjK4dyohhNVx9ygzvqqlCHvCukqU9uubaeKKvLxNOZzAK+ErBqqoQJ8ycxL0b/8TP3v0OP7qmSnnAu0qXNuTvjRf2eAB4G0A8U+SgN6RGHDpl91KX4QrAA95Vg7TdNQuytN2Zz0KcKyce8K5a9LglL+kAwmGTu0k6OTFoVxKHUjpXTTzgXTXprbvm7cDfA7sDH0q0bwY+WaCanCsZD3hXbXoMeTNbCCyU9K5cFwZx/bOhpY2m5q2+w7aMeMC7apR2x+sGSfcCE8zsYEkzgBPM7OsFrK1qLVy2hosWLGdYTY2fDqFMeMC7apV2x+t1wCXE4+XNbDnxUnuubzKnQ2ht72Rz23Za2zu5cMFyNrS0lbq0QcsD3lWztCG/i5k90q1te76LGQz8dAjlxQPeVbu0If+apH0JpxdG0qnAuoJVVcX8dAjlwwPeDQZpQ/584MfAAZLWAJ8HzitUUdUsczqEEcNq/HQIJeQB7waLtOeTfxF4n6SRQI2ZDeozUA7UCTMnMXvaeD+6pkQ84N1gkvZ88rXAKYSTkg2VBICZfa1glVWwNIdHjhtV6+FeAh7wbrBJewjlQuB14HHADwPpgR8eWb484N1glDbkJ5vZcQWtpAokD49sJexc9atFlQcPeDdYpd3x+n+SBvVFQtLwwyPLkwe8G8zSbskfBXxc0kpCd40AM7MZBausAvnhkeXHA94NdmlD/gMFraJKZA6PvLBbn7x31ZSGB7xz6Q+hfEnSocC7Y9ODZvZk4cqqXH54ZHnwgHcuSNUnL+lzwK3AHvH2M0mfLWRhlWzcqFoOnbK7B3yJeMA7t0Pa7ppzgCPMbAuApLnAEuC/C1WYc/3hAe9cV2mPrhHQkXjcEducKxse8M7tLO2W/E+BpZJ+GR+fBFxfkIqc6wcPeOeyS7vj9buSGgiHUgr4JzP7YyELcy4tD3jncku7JQ+wknAO+aGAJL3TzJ4oTFnOpeMB71zP0p6g7Arg48CfieeUj3/fW5iynOudB7xzvUu7Jf8RYF8z21bIYpxLywPeuXTSHl3zNLB7X2cu6QZJr0p6OtE2VtJiSS/Ev2MSwy6RtELS85KOTbQfJumpOOx7iuc6llQr6fbYvlTS1MQ0Z8dlvCDp7L7W7sqXB7xz6aUN+auAP0q6R9KizC3FdDcC3c9eeTFwr5ntB9wbHyPpIMLFwafHaX4gaUic5ofAucB+8ZaZ5zlAs5lNA64B5sZ5jQUuA44ADgcuS36YuMrV2trqAe9cH6TtrrmJEKBPAZ29jPsmM3sguXUdnQjUJ+bbAFwU2+eZWRuwUtIK4HBJq4BdzWwJgKSbCYdw3h2nuTzO607g+3Er/1hgsZltjNMsJnww/Dxt7a78NDY20tzc7AHvXB+kDfnXzOx7eVrmBDNbB2Bm6yTtEdsnAQ8nxmuKbe3xfvf2zDSr47y2S3odGJdszzKNq0CZLprp06dz8skne8A7l1LakH9c0lXAIhJXhsrzIZTZfkFrPbT3d5quC5XOJXQFMWHCBBoaGnotNKmlpaXP05SDSqq7tbWV5uZmpk+fzvDhw1myZEmpS+qzSlrfSV535Usb8u+If49MtPX3EMr1kvaMW/F7Aq/G9iZgSmK8ycDa2D45S3tymiZJQ4HdgI2xvb7bNA3ZijGza4FrAWbNmmX19fXZRsupoaGBvk5TDiql7uRO1pNPPpklS5ZURN3dVcr67s7rrnypdrya2ZwstzcDvo9HrywCMuOfTbh+bKb99HjEzFsJO1gfiV07myUdGfvbz+o2TWZepwL3mZkB9wDHSBoTd7geE9tcBfGjaJwbuL784rUnnyPsRO1C0s8JW9TjJTURjnj5JjBf0jnAy8BpAGbWKGk+8Azhl7Xnm1nmpGjnEY7UqSPscL07tl8P3BJ30m4kHJ2DmW2MP+B6NI73tcxOWFcZPOCdy498hXzWM1Ka2Rk5xj86x/hXAldmaX8MODhLeyvxQyLLsBuAG3Is35UxD3jn8iftcfK9ybpT07m+8oB3Lr/yFfJ+bnk3YB7wzuVf2sv/vbWXtofyVpEblDzgnSuMtFvyC7K03Zm5Y2afyU85bjDygHeucHrc8SrpAMK5ZHaTdHJi0K7AiEIW5gYHD3jnCqu3o2veDvw94QyUH0q0bwY+WaCa3CDhAe9c4fUY8ma2EFgo6V2ZE4Q5lw8e8M4VR9o++Q2S7s2cF17SDElfLmBdFWtDSxtPrt7Ehpa23kcepDzgnSuetCF/HXAJ4YyQmNly4q9L3Q4Ll61h9tz7+OhPljJ77n0sWram1CWVHQ9454orbcjvYmaPdGvbnu9iKtmK9Zv54p3LaW3vZHPbdlrbO7lwwXLfok/wgHeu+NKG/GuS9iX+slXSqcC6glVVYRYuW8Px33uQbdu7Xk9lWE0NTc1bS1RVefGAd6400p675nzC6XgPkLQGWAl8tGBVVZCOTuOiBcvZ1rHzmR3aOzuZPKauBFWVFw9450onVcib2YvA+ySNBGrMbHNhy6oc2zo6GVZTQ2u3qyIOH1rD1afMYNyowR1oHvDOlVaqkJf0hW6PAV4HHjezZfkvq3IMH1JDe2e3gB8ifvPZo5g2YXSJqioPHvDZbWhpo6l5K5PH1A36jQBXeGn75GcB/0K4TuokwuXy6oHrJF1YmNIqw5AacfUpMxgxrIbRtUMZMayGb592qAe8B3xWfgSWK7a0ffLjgHeaWQuApMsI5655D/A4cHVhyqsMJ8ycxOxp433rLPKAz25DSxsXLQhHYGW69y5csJzZ08YP+veMK5y0Ib83sC3xuB3Yx8y2SvJjBIFxo2r9HxUP+J40NW/daf9N5ggsf++4Qkkb8rcBD0vKXFv1Q8DP447YZwpSmas4HvA9mzymbqf9N34Eliu0Xvvk48WzbySckGwTYYfrv5jZ18xsi5mdWdAKXUXwgO/duFG1O+2/8SOwXKH1uiVvZibpV2Z2GKH/3bkuPODT8/03rtjSdtc8LOlvzOzRglbjKo4HfN/5/htXTGlDfg7wKUkvAVsI13Q1M5tRsMpc2fOAd678pQ35DxS0CldxPOCdqwxpT2vwEoCkPfDL/g16HvDOVY5Uv3iVdIKkFwgnJrsfWAXcXcC6XJnygHeusqQ9rcEVwJHAn8zsrcDRwEMFq8qVJQ945ypP2pBvN7MNQI2kGjP7PTCzcGW5cuMB71xlSrvjdZOkUcADwK2SXiVeCtAFyTMLAlV1HLQHvHOVK23IPwn8Ffg34ExgN2BUoYqqNAuXreGiBcsZVlPD1vbtSGLE0CG0d3Zy9SkzOGHmpFKX2G8e8M5VttTHyZtZJ9AJ3AQgaXnBqqogbds7+eIdT7KtwxInnjLaO8IlcCv5LIMe8M5Vvh5DXtJ5wKeBfbuF+mh8xysLl61h9astbOsYknOcSj3LoAe8c9Whty352wiHSl4FXJxo32xmGwtWVQXInBv8/AN2vrZrUiWeZdAD3rnq0WPIm9nrhLNOnlGccipHU/NWhoTLIHYhYOiQrn3ylbQV7wHvXHVJ2yfvunl6zets2daxU/suw4ewvbOTc9/zNv7xiL094J1zJZX2OHmXsKGljSv+X/ZrpWzZ1kHbduN/GlYUuaqB8YB3rjp5yPdD5jJuPRki0dS8tUgVDYwHvHPVy0O+HyaPqWNbR2eP42zZ1sHTa18vUkX95wHvXHUrWchLWiXpKUnLJD0W28ZKWizphfh3TGL8SyStkPS8pGMT7YfF+ayQ9L14uUIk1Uq6PbYvlTQ1X7WPG1XLZ+ZM63W8r/26kQf+9CobWsrzWuce8M5Vv1Jvyc8xs5lmNis+vhi418z2A+6Nj5F0EHA6MB04DviBpMzB6T8EzgX2i7fjYvs5QLOZTQOuAebms/B/PGJvaofufHRNUtt2419+9gSz597HomVr8rn4AWttbfWAd24QKHXId3ci8Re18e9JifZ5ZtZmZiuBFcDhkvYEdjWzJWZmwM3dpsnM607g6MxWfj6MG1XLt049lJpeZvnXbR20tndy4YLlZbNF39jYSHNzswe8c4NAKUPegN9JelzSubFtgpmtA4h/94jtk4DViWmbYtukeL97e5dpzGw74Xj/cfl8AifMnMQ+43ahdmjvqzHzy9dSy3TRDB8+3APeuUGglMfJzzaztfFqU4slPdfDuNk2l62H9p6m6Trj8AFzLsCECRNoaGjoseidZrhtK/96kNFpPf/ytUYdvPbCH2n4c96+TPRZa2srzc3NTJ8+neHDh7NkyZKS1dJfLS0tfX6NyoHXXVyVWnchlCzkzWxt/PuqpF8ChwPrJe1pZutiV8yrcfQmYEpi8snA2tg+OUt7cpomSUMJZ87c6VQMZnYtcC3ArFmzrL6+vk/Po6GhgSlT9uML85exPR5wM2yIOOPwKcx/rIlhNTVv/vL16BKejTK5k/Xkk09myZIl9PW5loOGhgavu4i87spXkpCXNBKoMbPN8f4xwNeARcDZwDfj34VxkkXAbZK+C+xF2MH6iJl1SNos6UhgKXAW8N+Jac4GlgCnAvfFfvu8O2HmJGZPG0/j2jcAY/peuzFuVC2fO3r/kp9XfkNLGw883sgjDb9lvyneB+/cYFOqLfkJwC/jftChwG1m9ltJjwLzJZ0DvAycBmBmjZLmA88A24HzzSxzToHzgBuBOsLJ1DLXnr0euEXSCsIW/OmFfELjRtXynv3fslNbKU9rsHDZGr54x5NYRzumGcw95BAPeOcGmZKEvJm9CByapX0D4fqx2aa5ErgyS/tjwMFZ2luJHxKlkLxSVCmCfkNL25vnuYehYHDpomeoP3BiRZ1Pxzk3MH6CsgJIXimqVFeHeuDxRqyjneRLXKnntnfO9V+5HSdf8TLnmW9t72Rz2/aSHCPf2Bj64E1dL2ZSinPbb2hp48nVm8rmNwLODTYe8gOwoaWNre0dXQIs28nLinmMfOYomv2mTGTuyYcwYlgNo2uHMmJYTdHPbb9w2Rpmz72Pj/5kaVn+6te5wcC7a/op0yXzrwe2829z73uzS2bymDraO7uevKxYW9DZzkVTf+DEkuwbSH6jyVz7tpKvd+tcpfIt+X5IBliHWZcumXGjarn6lBlF34LOdbKxcaNqOXTK7kUP1lJ/o3HOBb4l3w+ZAMtsocKO88ePG1X75nHzxdqCLsezSZbyG41zbgffku+HbAG2ZVsHS1/c8ObjYm1Bl2PAAyX7RuOc68q35Pth3KhavvLBg7j0V093af/G3c8xsnYoZx65T1HqKNeAzyj2Nxrn3M58S76fmpr/mrX9y796mhXrNxd8+eUe8Bml2ifgnAs85PthQ0sbP3nwxazDDPjAfz1Q0MMFKyXgnXOl5yHfD03NWxk+dEjO4e2dFOwHUB7wzrm+8JDvh8lj6ujo5YSWmaNt8skD3jnXVx7y/ZA8ciTXFQW3bOvg6bWv522ZHvDOuf7wkO+nE2ZO4qGL3steu42gJsfFnq6465m8dNl4wDvn+stDfgDm3v0sazZtpTNHz00+fuHpAe+cGwgP+X768f1/Zv7jPR9BM9BfeHrAO+cGykO+Hza0tPHt3z3f4zi1Qwf2C08PeOdcPvgvXvuhqXkrw4fU0N7RkXX4LsOG8KOPHbbT5QDT8oB3zuWLb8n3w+QxdWzP1REPbO80XvxLS79++eoB75zLJw/5fhg3qpbPzJmWc/i2jk4u//UzvO+aB/jqwqdSz9cD3jmXbx7y/fSPR+ydauXdvOTlVFv0HvDOuULwkB+Ann/zusOy1Zt6HO4B75wrFA/5fmpc+0bqkJ85Zffc8/GAd84VkId8P72xtT3VeGe9a2+mTRiddZgHvHOu0PwQyn6a98hLOYfVAF/90EEcNW28B7xzrqQ85PthQ0sbf/jzxpzDjz7gLXzo0L1y/hDKA945VyzeXdMPS/68ocfhv3/+L8yee1/WC4d4wDvnislDvh9ea2ntcfh2g9b2zi4XDtnQ0sYv73+Cn9250APeOVc03l3TD0dNewvwbK/jZc5C+YcVr/HFO57EOtoxzWDuIYd0CfgNLW1+sWvnXEF4yBfQto5ORg4fwhfveJJtHQYMBYNLFz1D/YETGTeqloXL1nDRguUMq6mhvbOTq0+ZwQkzJ5W6dOdclfDumn7o7cdNGQdOHMWS5c9hHV0Pt8xs4W9oaeOiBctpbe9kc9v2nbp4nHNuoHxLvh+GpvxoXNb0Bk82baKGrhf9zpxnvql5K8Nqamil881hmQ8A77ZxzuWDh3w/zH9sdepxjRokqB1SE05PHLtkMiHe3tnZZfyBXmjEOeeSPOT74bFVzX0af/iwIVx9yiFMGTuyy87VzAXBL+zWJ+9b8c65fPGQ74dtnb2Pk/TXbR1ccMeTfOvUQzm023lsTpg5idnTxvvRNc65gvAdr0XStt1y7lQdN6qWQ6fs7gHvnMs7D/kiyuxUdc65Yqn6kJd0nKTnJa2QdHEpa/Gdqs65YqvqkJc0BPgf4APAQcAZkg4qRS21Q+U7VZ1zRVftO14PB1aY2YsAkuYBJwLPFKuAGuDf3r8//3jE3h7wzrmiq/aQnwQkD2pvAo4o1sIP2GMkt577Lg9351zJyCztRewqj6TTgGPN7J/j448Bh5vZZxPjnAucCzBhwoTD5s2b1+t8n1rz+pv3J9TB+iz7UifsOoI9RpdvuLe0tDBq1KhSl9FnXndxed3pzZkz53Ezm1XUhaZQ7VvyTcCUxOPJwNrkCGZ2LXAtwKxZs6y+vr7HGTY2NvKD365nKyMBccEh2/nOU11X4+Nffl/Zb703NDTQ23MtR153cXndla+qd7wCjwL7SXqrpOHA6cCi/s4sc8GPL+6/BdBOw099x56s+uYHyz7gnXODR1VvyZvZdkmfAe4BhgA3mFljf+bV/YpOn6itZfY3FgPbmbTrcB760vvzWbpzzuVFVYc8gJn9BvjNQOaR65J9D33p/TQ0NPDZM+vzUKlzzuVftXfXDJhfk9U5V8k85HvgAe+cq3Qe8jl4wDvnqoGHfBYe8M65auEh340HvHOumnjIJ2zdutUD3jlXVTzkEzZt2uQB75yrKlV97pq+kvQX4KU+TjYeeK0A5RSa111cXndxlaLufczsLUVeZq885AdI0mPleFKi3njdxeV1F1el1l0I3l3jnHNVzEPeOeeqmIf8wF1b6gL6yesuLq+7uCq17rzzPnnnnKtiviXvnHNVzEO+nyQdJ+l5SSskXVzCOlZJekrSMkmPxbaxkhZLeiH+HZMY/5JY8/OSjk20Hxbns0LS9yQpttdKuj22L5U0tZ913iDpVUlPJ9qKUqeks+MyXpB0dh7qvlzSmrjOl0k6vpzqljRF0u8lPSupUdLnYntZr+8e6i7r9V32zMxvfbwRLkDyZ+BtwHDgSeCgEtWyChjfre1q4OJ4/2Jgbrx/UKy1FnhrfA5D4rBHgHcRLnl1N/CB2P5p4Efx/unA7f2s8z3AO4Gni1knMBZ4Mf4dE++PGWDdlwP/nmXcsqgb2BN4Z7w/GvhTrK2s13cPdZf1+i73m2/J98/hwAoze9HMtgHzgBNLXFPSicBN8f5NwEmJ9nlm1mZmK4EVwOGS9gR2NbMlFt7xN3ebJjOvO4GjM1tFfWFmDwAbS1DnscBiM9toZs3AYuC4AdadS1nUbWbrzOyJeH8z8CwwiTJf3z3UnUtZ1F3uPOT7ZxKwOvG4iZ7fjIVkwO8kPS7p3Ng2wczWQfjHAfaI7bnqnhTvd2/vMo2ZbQdeB8blqfZi1Fmo1+ozkpbH7pxMt0fZ1R27I94BLKWC1ne3uqFC1nc58pDvn2xbsqU6TGm2mb0T+ABwvqT39DBurrp7ej6leK75rLMQ9f8Q2BeYCawDvjOAGgpWt6RRwALg82b2Rk+j9qOGYtZdEeu7XHnI908TMCXxeDKwthSFmNna+PdV4JeErqT18Ssr8e+rcfRcdTfF+93bu0wjaSiwG+m7L3pTjDrz/lqZ2Xoz6zCzTuA6wjovq7olDSME5a1m9ovYXPbrO1vdlbC+y1qpdwpU4o1wAfQXCTt7Mjtep5egjpHA6MT9/yP0I36LrjvYro73p9N1R9WL7NhR9ShwJDt2VB0f28+n646q+QOodypdd2AWvE7CjrSVhJ1pY+L9sQOse8/E/X8j9AuXTd1xGTcD/9mtvazXdw91l/X6LvdbyQuo1BtwPGHv/5+BS0tUw9vim/xJoDFTB6GP8V7ghfh3bGKaS2PNzxOPOIjts4Cn47Dvs+OHciOAOwg7tR4B3tbPWn9O+KrdTthqOqdYdQKfiO0rgH/KQ923AE8By4FF3UKo5HUDRxG6GpYDy+Lt+HJf3z3UXdbru9xv/otX55yrYt4n75xzVcxD3jnnqpiHvHPOVTEPeeecq2Ie8s45V8U85J1zrop5yLu8kVQv6a54/wT1cApmSbtL+nQ/lnG5pH8fSJ35JOkkSQeVuo6kfK8jSfvEcyMti6cA/pfEsAZJLydPWifpV5Ja8rV8NzAe8q5Xkob0dRozW2Rm3+xhlN0Jp32tdCcRTnmbWvw5fSVZB/ytmc0EjgAulrRXYvgmYDaED2/CKYNdmfCQH+QkTZX0nKSb4ln+7pS0i8LFSL4q6Q/AaZKOkbRE0hOS7ognkcpcPOW5ON7Jifl+XNL34/0Jkn4p6cl4+1vgm8C+cevwW3G8L0p6NNbxH4l5XRovCvG/wNt7eT4Nkq6R9IDCxSf+RtIv4oUgvp4Y7wuSno63zyfWxbOSrotbrL+TVBeH7Svpt3GL9kFJB8TncQLwrfg89pX0yfgcnpS0QNIucfobJX1X0u/j+C9IekscVqNwEYvxWZ7PbvG1qImPd5G0WtKwXMvKsj5mxfvjJa2K94dI+lZifX8q1zo1s21m1hYf1rJzbswjnCIAwnvgF7jyUeqf3PqttDfCeVmMcDZLgBuAfydcjOTC2DYeeAAYGR9fBHyV8BPx1cB+hHOEzAfuiuN8HPh+vH874YyCEC64shs7nw/mGMLFl0UIkbsIF+w4jPCT9l2AXQk/Od/pAhKJ+TSw42IYnyOcZGpPQjg1EX7an5nnSGAU4ZQQ74g1bQdmxunnAx+N9+8F9ov3jwDui/dvBE5NLH9c4v7Xgc8mxruLHedWuSyxTo4BFvTwnBYCc+L9fwB+0suyLs+so7g+ZiVex1Xx/rnAl+P9WuAx4K091DCFcFqBvwLnd1vfR8RhQ4DfxfXYUur3tt/CrdK+NrrCWG1mD8X7PwP+Nd6/Pf49ktAl8VDseh0OLAEOAFaa2QsAkn5GCI/u3gucBWBmHcDrSlx6Ljom3v4YH48ifHiMBn5pZn+Ny1iU4vlkxnkKaLR4DnVJLxLC6qg4zy2x/RfAu+N0K81sWZz+cWBq/Nbyt8Adia7n2hzLPjh+Y9g9Pod7EsPuiM8fwofpQuA/CedM+WkPz+d2Qrj/nrDF/IMUy+rNMcAMSafGx7sR1vfKbCOb2eo4/l7AryTdaWbr4+AO4A+xxjozW6W+X1fGFYiHvIOdz5udebwl/hXhqjlnJEeSNDPLtP0l4Coz+3G3ZXy+H8vIdC10Ju5nHg8l+7nDu08LIbzqCN8sNlnok+7NjcBJZvakpI8D9YlhmfWJma2WtF7Sewlbwmf2MM9FwFWSxhK+hdyXYlkZ29nRvTIi0S7Cln9fPhgws7WSGgkfincmBs0jnOr68r7MzxWe98k7gL0lvSveP4OwVZb0MDBb0jR4s194f+A54K2S9k1Mm829wHlx2iGSdgU2E7bSM+4BPpHo658kaQ9CN9GHJdVJGg18aCBPNHoAOCk+j5HAh4EHc41s4cIVKyWdFmuTpEPj4O7PYzSwTuG86D0FN8BPCN+c5ie28LMtv4VwxsT/InSHZcZNs6xVhA8GgFMT7fcA58VpkbR/XBc7kTQ5sW9iDGEn6/PdRnsQuIpw1k5XRjzkHYRraZ4taTnhvNo/TA40s78Q+th/Hsd5GDjAzFoJ3TP/T2HH60s55v85YI6kpwhdINPNbAOh++dpSd8ys98BtwFL4nh3Es6V/wShu2IZ4WISOcM4rTjPGwnBuZTQx/3HHicKIXqOpMxpnU+M7fOAL0r6Y/yw+0qc52LCh2BPFhG6WXrqqsm4HfgoO7rQSLmsbxPC/P8IffIZPwGeAZ6Q9DTwY3J/sz8QWBqf+/3At83sqeQIFnzbzF5L8VxcEfmphgc5hWtp3mVmB5e6lsEmHvVyjZm9u9S1uOrlffLOlYDCD8XOo/cuHecGxLfkXUWS9D/EH+Ak/JeZpen6KEuSLgVO69Z8h5ldWaTlH0K4ClNSm5kdUYzlu8LwkHfOuSrmO16dc66Kecg751wV85B3zrkq5iHvnHNVzEPeOeeq2P8HqIqz5qsq34wAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXkAAAFOCAYAAABjfG0oAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAA7FUlEQVR4nO3de3xcdZ3/8dc7TUkDbaEXaaEtVCkIFEqVLugW3VYUEFdALruwKLiy4iL605WVi6iwImLxwq7regFhuQiWQtVWVsUuGG5bys1SCBeptNK0pUibYoNNmiaf3x/f79CTdGZyksw9n+fjMY/MfM/tM2cm7znzPWfOkZnhnHOuNtWVuwDnnHPF4yHvnHM1zEPeOedqmIe8c87VMA9555yrYR7yzjlXwzzk+yDpckk/LncdhSJptaT3xvtfkPSjEixzjqSWYi/HFZ6kqZJMUn25a6lVkpok/VOx5l/xIR9XQKukhpTjf1TSg8Wuq1gS/1Rt8bZa0sXFWJaZfc3M+nxzSbpR0leLUUMxVPoHs6TTJT0v6TVJr0i6SdLoctcFPTcCqlm1vWeLqaJDXtJU4F2AASeUt5qS28PMRgJnAF+WdFzvEXzrqvLleI0eAmab2e7AW4B6wAOpgtTU/5aZVewN+DLhH+LbwF29hk0Bfgr8CdgIfBc4CGgHuoA2YHMctwn4p8S0HwUeTDz+D2AN8GfgceBdiWGXAz/OUd+zwN8mHtcDrwJvB0YAP461bQYeBSakeM5TCR9q9Ym2R4F/BeYALcBFwMvALYQP6ouBP8RlLQDGJqb9CPDHOOxSYDXw3mzPDTgK+L9Y75q4ns4FOoFtcZ3+Io67N7Awrv9VwP9LzKcRuBFoBZ4BPg+05HnO04ElwCZgA/CF2H4j8NXEeHOS84nrYS2wBXgeOBo4LtbaGet9MlHv4riMlcDHe73Gd8TXawvwFHAAcAnwSlwXxyTG3x24Hlgfl/9VYFjivfUQcE1c1ldzPe84/kjgZuCXecbpb319PdcFcZlbgGZgVhx2C9ANbI3r7kJ2vB/PBl4ivL8vzVPrjcD3gF/FeTwETAT+Pb4fngPelhj/IML/5+ZYywm95vVfwP/EWpcB+yWGH8iO983zwN/F9lzv2cz/yRbC+/JDvTIh+bpdFf8emhhnz7hu3tTrOTfE+g9JtL0pjrsnMAa4i/C/0hrvT06M20TMJ3b+n8ys//q+3ns5X5NiBXQhbvEN+kng8PiiTYjtw4An4wuyGyFQj0q8WA/2ms8bKzHbOMCHgXGEkL6AEKAjsq30XvP9MnBr4vEHgOfi/U8AvwB2jfUeDoxO8ZzfeFEBAbOBvxACbA6wHZgX31iNwGeBh4HJse2HwE/ivA4mvMnfHYd9O06/U8gD+xDe/GcAw+P6mJn4Z0uGbR3hw/DLwC6ErdEXgWPj8K8DDwBjCR/GT5Mj5IFR8Q17QXwdRwFH5ljunMx8gLcSwm3vxHrbL9drBtxHCJ8RwEzCP9zRifHbgWPjer+Z8MF1aVwXHwdWJeb187iedyP8Ez8CfCLx3toOfDrOqzHH8z4KeC2+1q+TCOks4/a3vjTP9XjC+/Iq4OHEtKuJ749e78frCO+3w4AO4KActd5I+CA4PC7/3ljrWXF5XwV+G8cdTvgf/wLhffQewnvwrYl5bQKOiM/7VmB+HLZbfP3/MQ57e1zu9Gzvndh2GuEDsA74+7je98r1usV1OC8x/WeIHxhZnvcNwJWJx+cDv473xwGnELJgFOED++fZ8om+Q/7n5Hjv5Xz/FDqYC3Uj/BN0AuPj4+eAf4n33xnfuPVZpvso/Qz5LPNoBQ7LFRiJ8abFN+Wu8fGtwJfj/Y8Rtopn9PN5Z17UzbGOZ4lbyYSQ20b8AIptzxL/gePjveJ6qyeE8PzEsN3i9NlC/hLgZ3n+cZNheyTwUq9xLgH+O95/ETguMexccof8GcDvUi53DjtCfhphK/a9wPBe0/X+R5lC+HY3KtF2FXBjYvwliWEfJHw4ZrbOR8XXZA9gAiHkGns9h98m3lsvZXs+OZ7jpLj8A/KM05/60jzX/00MOxjYmni8muwhn9zyfAQ4Pc9rdl3i8aeBZxOPD2XHN+x3ETao6hLDfwJcnpjXjxLDjmfHRtTfAw/0WvYPgcuyvXdy1LocODHX60Z4n6/J1Ac8Rvy2kGVe7wVeTDx+CDgrx7gzgdbE4yZShHxf771ct0rudzob+I2ZvRof3xbbriG8kf9oZtsLsSBJFwD/RPiUN2A0ML6v6cxspaRngQ9K+gVhv8Hb4uBbYp3zJe1B+Kp9qZl1pixrfI7n9ycza0883hf4maTuRFsX4Q2xN+FNmqn3dUkbcyxvCuGrbBr7AntL2pxoG0bYeqf3cgndRbn0Z7lviOv+s4R/iumS7gY+Z2brsoy+N7DJzLb0qmlW4vGGxP2twKtm1pV4DKFrZW/CFuh6SZnx6+j5fJP3+3oeayX9GpgPvF3SmYSwghBi7x9AfX0915cT9/8CjJBU38f/U+9pRuYZt3etvR9npt0bWGNmyffuHwkffH0td1/gyF7vwXrC/11Wks4CPkcITuK8kv/nPV43M1sm6XXgbyStJ2xYLM4x+3uBRklHxppnAj+Ly92VkFvHEbpuAEZJGpZ4DdPYl77fezupyJCX1Aj8HTBMUuZFbgD2kHQY4Untk+ONaVlm+Trhq1LGxMSy3kXo2z0aaDazbkmthK6SNH5C+DStA54xs5UAMcz/Dfi3uAP5l4R+w+tTzjeX3s9vDfAxM3uo94jxjXlQ4vGuhK+O2awhfC1Ou8xVZrZ/jvHXE8K7OT7eJ8d4mXmdkWNYztcNwMxuA26LR6b8kNCN9ZEs9a4DxkoalQi/fQh9mv21hrA1letDmCzL70s9sB+Amd1K+EY4UIN9rv2tfTDWAVMk1SWCfh/g9ymmXQPcZ2bvyzG8x/OQtC+hy+loYKmZdUlaTs//82zP/SZCd+7LwJ29NrB2TBhyYwHhvbyBsA8xs/4vIHQvHmlmL0uaCfyO7BmT7z2f5r23k0o9uuYkwtbowYRPxJmEsHqA0Lf3CCFIvi5pN0kjJM2O024AJkvaJTG/5cDJknaVNA04JzFsFKEv7k9AvaQvE7bk05oPHAOcR/i2AYCkuZIOlTSMsEO3Mz6nQvsBcGV8EyPpTZJOjMPuBP5W0lFxfXyF3K/5rcB7Jf2dpHpJ4+KbEcI6fUti3EeAP0u6SFKjpGGSDpH0V3H4AuASSWMkTSZ8Zc/lLmCipM9KapA0Km4NQXjdjpc0VtJEwv4H4vN8q6T3xENr2wlbiJn1uwGYKqkOwMzWELrOrorvlRmE90C/w9TM1gO/Ab4labSkOkn7SfqbtPOQdKakfRTsC1wJ3NPfWnLUN9jn2vu1LqZlhFC7UNJwSXMIXVHzU0x7F3CApI/EaYdL+itJmY2a3s9jN0KI/wlA0j8Ch6RYzi3AhwhBf3Mf495G6EY6k0QWEDJmK7BZ0ljgsjzzWA68O74/did0gwIDf+9VasifTejffcnMXs7cCEfQnEn4BPwg4evTS4QjTv4+TnsvYQvyZUmZrp5rCH3RGwifzMk3/N2EIwF+T/iq2E7/vm6vB5YCfw3cnhg0kRCyfyb0m99H6LJB0g8k/SDtMvrwH4SvkL+RtIWwE/bIWFszYQfQbYQPxVbCusr2PF4i9HleQNjZtZywkw3Ct4+DJW2W9PP4FfODhA/fVYQdXj8i7PmH8A3mj3HYb8jzFTpu7bwvzu9l4AVgbhx8C2EH++o4n+T6bSDs4H01TrcnYQcehB1bABslPRHvn0H4mr6O8DX6MjNbkquuPpxF2FH4DGGd3knYF5LWwYQgzhx98jxh52mhDOa5XgV8Mb7W/1rAmnZiZtsIXZzvJ7yO3yP0Yz+XYtothI2r0wnP82V2HJAAO79nnwG+Rfhf3UDYN7DTt98sy2kBniB8QDzQx7iZD629CZmS8e+EHbmvEv4/f51nHksI7/MVhIMb7uo1Sr/fe4qd984557KQdAOwzsy+WO5aBqIi++Sdc64SxP1pJ7PjgIqqU6ndNc45V1aSriD8xuMbZraq3PUMlHfXOOdcDfMteeecq2Ee8s45V8N8x2vC+PHjberUqf2a5vXXX2e33XYrTkFF5HWXltddWqWse+vWrWzevJl169a9amZvKslC+8FDPmHq1Kk89thj/ZqmqamJOXPmFKegIvK6S8vrLq1S1d3c3MzChQuZPHky55xzTr7Td5SNd9c459wAJAP+zDPPLHc5OXnIO+dcP/UO+IaGVBeuKwsPeeec64dqCnjwkHfOudSqLeDBQ94551KpxoAHD3nnnOtTtQY8eMg751xe1Rzw4CFfMhvbOnhyzWY2tnWUuxTnXErVHvDgP4YqiUXL13LRwhUMr6ujs7ubq0+ZwQkzJ/U9oXOubGoh4MG35ItuY1sHFy1cQXtnN1s6ttPe2c2FC1f4Fr1zFaxWAh485IuupXUrw+t6rubhdXW0tG4tU0XOuXxqKeDBQ77oJo9ppLO7u0dbZ3c3k8c0lqki51wutRbw4CFfdONGNnD1KTMYMbyOUQ31jBhex9WnzGDcyOp/8zhXS2ox4MF3vJbECTMnMXvaeFpatzJ5TKMHvHMVplYDHjzkS2bcyAYPd+cqUC0HPHh3jXNuCKv1gAcPeefcEDUUAh485J1zQ9BQCXjwkHfODTFDKeDBQ945N4QMtYAHD3nn3BAxFAMePOSdc0PAUA148JB3ztW4oRzw4CHvnKthQz3gocghL2mKpN9KelZSs6TPxPbLJa2VtDzejk9Mc4mklZKel3Rsov1wSU/FYd+RpNjeIOn22L5M0tTENGdLeiHezi7mc3XOVRYP+KDYpzXYDlxgZk9IGgU8LmlJHHaNmX0zObKkg4HTgenA3sD/SjrAzLqA7wPnAg8DvwSOA34FnAO0mtk0SacD84C/lzQWuAyYBVhc9mIzay3yc3bOlVl7e7sHfFTULXkzW29mT8T7W4BngXyXRDoRmG9mHWa2ClgJHCFpL2C0mS01MwNuBk5KTHNTvH8ncHTcyj8WWGJmm2KwLyF8MFQMvySgc4XX3NxMa2urB3xUshOUxW6UtwHLgNnApySdBTxG2NpvJXwAPJyYrCW2dcb7vduJf9cAmNl2Sa8B45LtWaZJ1nUu4RsCEyZMoKmpqV/Pq62trd/TALy2tZOW1q2I8DVj8phGdm8c3u/5DNRA6y43r7u0qq3u9vZ2WltbaWxsZOLEiSxdurTcJZVdSUJe0khgIfBZM/uzpO8DVxDy7QrgW8DHAGWZ3PK0M8BpdjSYXQtcCzBr1iybM2dO3ufSW1NTE/2dZmNbB7Pn3Ut757A32kYM385DF727ZGeqHEjdlcDrLq1qqjvZBz9x4kTmzp1b7pIqQtGPrpE0nBDwt5rZTwHMbIOZdZlZN3AdcEQcvQWYkph8MrAutk/O0t5jGkn1wO7ApjzzKju/JKBzhdV7J2s8LsNR/KNrBFwPPGtm306075UY7UPA0/H+YuD0eMTMm4H9gUfMbD2wRdI74jzPAhYlpskcOXMqcG/st78bOEbSGEljgGNiW9n5JQGdKxw/iia/YnfXzAY+AjwlaXls+wJwhqSZhO6T1cAnAMysWdIC4BnCkTnnxyNrAM4DbgQaCUfV/Cq2Xw/cImklYQv+9DivTZKuAB6N433FzDYV5Vn2U+aSgBcuXMHwujo6u7v9koDODYAHfN+KGvJm9iDZ+8Z/mWeaK4Ers7Q/BhySpb0dOC3HvG4Abkhbbyn5JQGdGxwP+HT88n9l5JcEdG5gPODT89MaOOeqigd8/3jIO+eqhgd8/3nIO+eqggf8wHjIO+cqngf8wHnIO+cqmgf84HjIO+cqlgf84HnIO+cqkgd8YXjIO+cqjgd84XjIO+cqigd8YXnIO+cqhgd84XnIO+cqggd8cXjIO+fKzgO+eDzknXNl5QFfXB7yzrmy8YAvPg9551xZeMCXhoe8c67kPOBLx0PeOVdSHvCl5SHvnCsZD/jS85B3zpWEB3x5eMg754rOA758POSdc0XlAV9eHvLOuaLxgC8/D3nnXFF4wFcGD3nnXMF5wFcOD3nnXEF5wFcWD3nnXMF4wFceD3nnXEF4wFcmD3nn3KB5wFcuD3nn3KB4wFc2D3nn3IB5wFc+D3nn3IB4wFcHD3nnXL95wFcPD3nnXL94wFcXD3nnXGoe8NXHQ945l4oHfHWqzzdQ0hbAkk3xsQAzs9FFrM05VyE84KtXX1vy9wDPAF8FDjGzUWY2OvO3r5lLmiLpt5KeldQs6TOxfaykJZJeiH/HJKa5RNJKSc9LOjbRfrikp+Kw70hSbG+QdHtsXyZpamKas+MyXpB0dr/WjHMO8ICvdnlD3sxOAo4F/gRcJ+k+SZ+UNDbl/LcDF5jZQcA7gPMlHQxcDNxjZvsTPkguBojDTgemA8cB35M0LM7r+8C5wP7xdlxsPwdoNbNpwDXAvDivscBlwJHAEcBlyQ8T51zf2tvbPeCrXJ998mb2mpn9N/B+4AfAV4CPppm5ma03syfi/S3As8Ak4ETgpjjaTcBJ8f6JwHwz6zCzVcBK4AhJewGjzWypmRlwc69pMvO6Ezg6buUfCywxs01m1gosYccHg3OuD83NzbS2tnrAV7m8ffIAkv4aOAN4F/Ag8CEze6C/C4rdKG8DlgETzGw9hA8CSXvG0SYBDycma4ltnfF+7/bMNGvivLZLeg0Yl2zPMk2yrnMJ3xCYMGECTU1N/XpebW1t/Z6mEnjdpVVtdbe3t9Pa2kpjYyMTJ05k6dKl5S6pX6ptfRdTXzteVwObgfmEINwe298OkNlK74ukkcBC4LNm9ufYnZ511Cxtlqd9oNPsaDC7FrgWYNasWTZnzpxctWXV1NREf6epBF53aVVT3ck++IkTJzJ37txyl9Rv1bS+i62vLfnVhGA8FjiGnsFpwHv6WoCk4YSAv9XMfhqbN0jaK27F7wW8EttbgCmJyScD62L75CztyWlaJNUDuwObYvucXtM09VWvc0NZ752s1bYF73aWN+TNbM5gZh77xq8HnjWzbycGLQbOBr4e/y5KtN8m6dvA3oQdrI+YWZekLZLeQejuOQv4z17zWgqcCtxrZibpbuBriZ2txwCXDOb5OFfL/Cia2pSmT34igJm9LOlNhL7558zsmRTznw18BHhK0vLY9gVCuC+QdA7wEnBaXEazpAWEwza3A+ebWVec7jzgRqAR+FW8QfgQuUXSSsIW/OlxXpskXQE8Gsf7ipltSlFzwW1s66CldSuTxzQybqT/47jK4wFfu/rqk/8E4fBGSZpHOKqmGbhK0tVmdn2+6c3sQbL3jQMcnWOaK4Ers7Q/BhySpb2d+CGRZdgNwA35aiy2RcvXctHCFQyvq6Ozu5urT5nBCTN32v/rXNl4wNe2vrbkP0U4Zr0R+CMwLW7RjwF+S9iKdjlsbOvgooUraO/spp1uAC5cuILZ08b7Fr2rCB7wta+v4+Q7zewvZrYR+IOZvQwQjzvf6UgV11NL61aG1/VcxcPr6mhp3VqmipzbwQN+aOgr5Lvj0TEAH8g0ShqRYtohb/KYRjq7u3u0dXZ3M3lMY5kqci7wgB86+grqk4lb7GaW/DHSOOCCYhVVK8aNbODqU2YwYngdoxrqGTG8jqtPmeFdNa6sPOCHlr4OoXwpR/taYG3msaSlZvbOAtdWE06YOYnZ08b70TWuInjADz19HkKZ0ogCzacmjRvZ4OHuys4DfmgqVL+674R1roJ5wA9dvvPUuRrnAT+0FSrkc55xzDlXPh7wLnXIS9pX0nvj/UZJoxKDP1Lwypxzg+IB7yBlyEv6OOGCHD+MTZOBn2eGm9nTBa/MOTdgHvAuI+2W/PmEk439GcDMXgD2zDuFc64sPOBdUtqQ7zCzbZkH8bztfkSNcxXGA971ljbk75P0BaBR0vuAO4BfFK8s51x/ecC7bNKG/MXAn4CngE8AvwS+WKyinHP94wHvckn1i1cz6wauizfnXAXxgHf5pAp5SavIfhHstxS8Iudcah7wri9pz10zK3F/BOFKTGMLX45zLi0PeJdGqj55M9uYuK01s38H3lPc0pxzuXjAu7TSdte8PfGwjrBlPyrH6M65IvKAd/2RtrvmW4n724HVwN8VvBrnXF4e8K6/0h5dM7fYhTjn8vOAdwORN+QlfS7fcDP7dmHLcc5l4wHvBqqvLXnvd3euzDzg3WD0dY3XfytVIc65nXnAu8FKe3TNCOAcYDqJ67ma2ceKVJdzQ54HvCuEtOeuuQWYCBwL3Ec4n/yWYhXl3FDnAe8KJW3ITzOzLwGvm9lNwAeAQ4tXlnNDlwe8K6S0Id8Z/26WdAiwOzC1KBU5N4R5wLtCS/tjqGsljQG+BCwGRsb7zrkC8YB3xZA25P/bzLoI/fF+5knnCswD3hVL2u6aVZKulXS0JBW1IueGGA94V0xpQ/6twP8SLui9WtJ3JR1VvLKcGxo84F2xpT3V8FYzW2BmJwMzgdGErhvn3AB5wLtSSLslj6S/kfQ94AnCD6L8LJTODZAHvCuV/lz+bzmwAPi8mb1ezKKcq2Ue8K6U0h5dc5iZ/TnXQEmXmNlVBarJuZrlAe9KLW2ffM6Aj07L1ijpBkmvSHo60Xa5pLWSlsfb8Ylhl0haKel5Sccm2g+X9FQc9p3MET6SGiTdHtuXSZqamOZsSS/E29lpnqdzxeQB78ohdZ98H3IdVnkjcFyW9mvMbGa8/RJA0sHA6YSToB0HfE/SsDj+94Fzgf3jLTPPc4BWM5sGXAPMi/MaC1wGHAkcAVwWf8zlXFm0t7d7wLuyKFTIW9ZGs/uBTSnncSIw38w6zGwVsBI4QtJewGgzW2pmBtwMnJSY5qZ4/04gcxz/scASM9tkZq3AErJ/2DhXdM3NzbS2tnrAu7JI2yffl/7+QOpTks4CHgMuiEE8CXg4MU5LbOuM93u3E/+uATCz7ZJeA8Yl27NM07Nw6VzCtwQmTJhAU1NTv55IW1tbv6epBF53abS3t9Pa2kpjYyMTJ05k6dKl5S6pX6ptfWdUa93FkPbomrFmlm+L/I5+LPP7wBWErf8rCBcJ/xjZPygsTzsDnKZno9m1wLUAs2bNsjlz5uQpfWdNTU30d5pK4HUXX7IPfuLEicydW32XSq6m9Z1UrXUXQ9rummWS7pB0fLbTGpjZ19Iu0Mw2mFmXmXUD1xH6zCFsbU9JjDoZWBfbJ2dp7zGNpHrC2TE35ZmXcyXReyernw3ElUvakD+AsLX7EWClpK9JOmAgC4x97BkfAjJH3iwGTo9HzLyZsIP1ETNbD2yR9I74AXMWsCgxTebImVOBe2O//d3AMZLGxB2ux8Q254rOj6JxlSRVd00MziXAEklzgR8Dn5T0JHCxmWXtaJT0E2AOMF5SC+GIlzmSZhK6T1YDn4jLaJa0AHgG2A6cH898CXAe4UidRuBX8QZwPXCLpJWELfjT47w2SboCeDSO95U+upucKwgPeFdp0vbJjwM+TNiS3wB8mrAVPZPQH//mbNOZ2RlZmq/PtRwzuxK4Mkv7Y8AhWdrbyXGMvpndANyQa1nOFZoHvKtEaY+uWUq4zutJZpY80uUxST8ofFnOVRcPeFep+gz5+IOku8zsimzDzWxewatyrop4wLtK1ueO19gvflgJanGu6njAu0qXtrtmuaTFhP73N85AaWY/LUpVzlUBD3hXDdKG/FhgI/CeRJsBQz7ku7qNJ9dsZvKYRsaN9H/yocID3lWLtIdQ/mOxC6lGi5avpeXlLfzgvmV0dndz9SkzOGFm1rMnuBriAe+qSdpDKEcQzvg4nXBVKADM7GNFqqvibWzr4KKFKzj/QGNLx3YALly4gtnTxvsWfQ3zgHfVJu0vXm8BJhLO7ngf4TQBW4pVVDVoad3K8Lqeq294XR0trVvLVJErNg94V43Shvw0M/sS8LqZ3QR8ADi0eGVVvsljGuns7u7R1tndzeQxjWWqyBWTB7yrVmlDvjP+3SzpEMKJwKYWpaIqMW5kA1efMoM6iVEN9YwYXsfVp8zwrpoa5AHvqlnao2uujSf6+iLhdAYjgS8VraoqccLMSdyz6ff8+F1v86NrapQHvKt2aUP+nnhhj/uBtwDEM0UOecPqxGFT9ih3Ga4IPOBdLUjbXbMwS9udhSzEuUriAe9qRd4teUkHEg6b3F3SyYlBo0kcSulcLfGAd7Wkr+6atwJ/C+wBfDDRvgX4eJFqcq5sPOBdrckb8ma2CFgk6Z25LgziBmZjWwctrVt9h20F8YB3tSjtjteNku4BJpjZIZJmACeY2VeLWFvNWrR8LRctXMHwujo/HUKF8IB3tSrtjtfrgEuIx8ub2QripfZc/2ROh9De2c2Wju20d3Zz4cIVbGzrKHdpQ5YHvKtlaUN+VzN7pFfb9kIXMxT46RAqiwe8q3VpQ/5VSfsRTi+MpFOB9UWrqob56RAqhwe8GwrShvz5wA+BAyWtBT4LnFesompZ5nQII4bX+ekQysgD3g0Vac8n/yLwXkm7AXVmNqTPQDlYJ8ycxOxp4/3omjLxgHdDSdrzyTcApxBOSlYvCQAz+0rRKqtiaQ6PHDeywcO9DDzg3VCT9hDKRcBrwOOAHwaShx8eWbk84N1QlDbkJ5vZcUWtpAYkD49sJ+xc9atFVQYPeDdUpd3x+n+ShvRFQtLwwyMrkwe8G8rSbskfBXxU0ipCd40AM7MZRausCvnhkZXHA94NdWlD/v1FraJGZA6PvLBXn7x31ZSHB7xz6Q+h/KOkw4B3xaYHzOzJ4pVVvfzwyMrgAe9ckKpPXtJngFuBPePtx5I+XczCqtm4kQ0cNmUPD/gy8YB3boe03TXnAEea2esAkuYBS4H/LFZhzg2EB7xzPaU9ukZAV+JxV2xzrmJ4wDu3s7Rb8v8NLJP0s/j4JOD6olTk3AB4wDuXXdodr9+W1EQ4lFLAP5rZ74pZmHNpecA7l1vaLXmAVYRzyNcDkvR2M3uiOGU5l44HvHP5pT1B2RXAR4E/EM8pH/++pzhlOdc3D3jn+pZ2S/7vgP3MbFsxi3EuLQ9459JJe3TN08Ae/Z25pBskvSLp6UTbWElLJL0Q/45JDLtE0kpJz0s6NtF+uKSn4rDvKJ7rWFKDpNtj+zJJUxPTnB2X8YKks/tbu6tcHvDOpZc25K8CfifpbkmLM7cU090I9D575cXAPWa2P3BPfIykgwkXB58ep/mepGFxmu8D5wL7x1tmnucArWY2DbgGmBfnNRa4DDgSOAK4LPlh4qpXe3u7B7xz/ZC2u+YmQoA+BXT3Me4bzOz+5NZ1dCIwJzHfJuCi2D7fzDqAVZJWAkdIWg2MNrOlAJJuJhzC+as4zeVxXncC341b+ccCS8xsU5xmCeGD4Sdpa3eVp7m5mdbWVg945/ohbci/ambfKdAyJ5jZegAzWy9pz9g+CXg4MV5LbOuM93u3Z6ZZE+e1XdJrwLhke5ZpXBXKdNFMnz6dk08+2QPeuZTShvzjkq4CFpO4MlSBD6HM9gtay9M+0Gl6LlQ6l9AVxIQJE2hqauqz0KS2trZ+T1MJqqnu9vZ2WltbmT59OrvssgtLly4td0n9Vk3rO8nrrn5pQ/5t8e87Em0DPYRyg6S94lb8XsArsb0FmJIYbzKwLrZPztKenKZFUj2wO7Apts/pNU1TtmLM7FrgWoBZs2bZnDlzso2WU1NTE/2dphJUS93Jnawnn3wyS5curYq6e6uW9d2b1139Uu14NbO5WW5vBHw/j15ZDGTGP5tw/dhM++nxiJk3E3awPhK7drZIekfsbz+r1zSZeZ0K3GtmBtwNHCNpTNzhekxsc1XEj6JxbvD684vXfD5D2Inag6SfELaox0tqIRzx8nVggaRzgJeA0wDMrFnSAuAZwi9rzzezzEnRziMcqdNI2OH6q9h+PXBL3Em7iXB0Dma2Kf6A69E43lcyO2FddfCAd64wChXyWc9IaWZn5Bj/6BzjXwlcmaX9MeCQLO3txA+JLMNuAG7IsXxXwTzgnSuctMfJ9yXrTk3n+ssD3rnCKlTI+7nl3aB5wDtXeGkv//fmPtoeKlhFbkjygHeuONJuyS/M0nZn5o6Zfaow5bihyAPeueLJu+NV0oGEc8nsLunkxKDRwIhiFuaGBg9454qrr6Nr3gr8LeEMlB9MtG8BPl6kmtwQ4QHvXPHlDXkzWwQskvTOzAnCnCsED3jnSiNtn/xGSfdkzgsvaYakLxaxrqq1sa2DJ9dsZmNbR98jD1Ee8M6VTtqQvw64hHBGSMxsBfHXpW6HRcvXMnvevXz4R8uYPe9eFi9fW+6SKo4HvHOllTbkdzWzR3q1bS90MdVs5YYtfP7OFbR3drOlYzvtnd1cuHCFb9EneMA7V3ppQ/5VSfsRf9kq6VRgfdGqqjKLlq/l+O88wLbtPa+nMryujpbWrWWqqrJ4wDtXHmnPXXM+4XS8B0paC6wCPly0qqpIV7dx0cIVbOva+cwOnd3dTB7TWIaqKosHvHPlkyrkzexF4L2SdgPqzGxLccuqHtu6uhleV0d7r6si7lJfx9WnzGDcyKEdaB7wzpVXqpCX9LlejwFeAx43s+WFL6t67DKsjs7uXgE/TPzy00cxbcKoMlVVGTzgs9vY1kFL61Ymj2kc8hsBrvjS9snPAv6ZcJ3USYTL5c0BrpN0YXFKqw7D6sTVp8xgxPA6RjXUM2J4Hd887TAPeA/4rPwILFdqafvkxwFvN7M2AEmXEc5d827gceDq4pRXHU6YOYnZ08b71lnkAZ/dxrYOLloYjsDKdO9duHAFs6eNH/LvGVc8aUN+H2Bb4nEnsK+ZbZXkxwgC40Y2+D8qHvD5tLRu3Wn/TeYILH/vuGJJG/K3AQ9Lylxb9YPAT+KO2GeKUpmrOh7w+U0e07jT/hs/AssVW5998vHi2TcSTki2mbDD9Z/N7Ctm9rqZnVnUCl1V8IDv27iRDTvtv/EjsFyx9bklb2Ym6edmdjih/925Hjzg0/P9N67U0nbXPCzpr8zs0aJW46qOB3z/+f4bV0ppQ34u8AlJfwReJ1zT1cxsRtEqcxXPA965ypc25N9f1Cpc1fGAd646pD2twR8BJO2JX/ZvyPOAd656pPrFq6QTJL1AODHZfcBq4FdFrMtVKA9456pL2tMaXAG8A/i9mb0ZOBp4qGhVuYrkAe9c9Ukb8p1mthGok1RnZr8FZhavLFdpPOCdq05pd7xuljQSuB+4VdIrxEsBuiB5ZkGgpo6D9oB3rnqlDfkngb8A/wKcCewOjCxWUdVm0fK1XLRwBcPr6tjauR1JjKgfRmd3N1efMoMTZk4qd4kD5gHvXHVLfZy8mXUD3cBNAJJWFK2qKtKxvZvP3/Ek27osceIpo7MrXAK3ms8y6AHvXPXLG/KSzgM+CezXK9RH4TteWbR8LWteaWNb17Cc41TrWQY94J2rDX1tyd9GOFTyKuDiRPsWM9tUtKqqQObc4OcfuPO1XZOq8SyDHvDO1Y68IW9mrxHOOnlGacqpHi2tW6mv007tEtTX9eyTr6ateA9452pL2j5518vTa1+jraNrp/bG+jq6zDj33W/hH47cxwPeOVdWaY+Tdwkb2zq44n+yXyvlL53ddGw3/qtpZYmrGhwPeOdqk4f8AGQu45bPMImW1q0lqmhwPOCdq10e8gMweUwj27q6847z+rYunl73WokqGjgPeOdqW9lCXtJqSU9JWi7psdg2VtISSS/Ev2MS418iaaWk5yUdm2g/PM5npaTvxMsVIqlB0u2xfZmkqYWqfdzIBj41d1qf433lF83c//tX2NhWmdc694B3rvaVe0t+rpnNNLNZ8fHFwD1mtj9wT3yMpIOB04HpwHHA9yRlDk7/PnAusH+8HRfbzwFazWwacA0wr5CF/8OR+9BQv/PRNUkd241//vETzJ53L4uXry3k4getvb3dA965IaDcId/bicRf1Ma/JyXa55tZh5mtAlYCR0jaCxhtZkvNzICbe02TmdedwNGZrfxCGDeygW+cehh1fczyL9u6aO/s5sKFKypmi765uZnW1lYPeOeGgHKGvAG/kfS4pHNj2wQzWw8Q/+4Z2ycBaxLTtsS2SfF+7/Ye05jZdsLx/uMK+QROmDmJfcftyoj6vldj5pev5Zbpotlll1084J0bAsp5nPxsM1sXrza1RNJzecbNtrlsedrzTdNzxuED5lyACRMm0NTUlLfonWa4bSufPtjotvy/fK1TF6++8Dua/lCwLxP91t7eTmtrK9OnT2eXXXZh6dKlZatloNra2vr9GlUCr7u0qrXuYihbyJvZuvj3FUk/A44ANkjay8zWx66YV+LoLcCUxOSTgXWxfXKW9uQ0LZLqCWfO3OlUDGZ2LXAtwKxZs2zOnDn9eh5NTU1MmbI/F9zxJJ1dIejr60Kf/YLHWhheV/fGL1+PLuPZKJM7WU8++WSWLl1Kf59rJWhqavK6S8jrrn5lCXlJuwF1ZrYl3j8G+AqwGDgb+Hr8uyhOshi4TdK3gb0JO1gfMbMuSVskvQNYBpwF/GdimrOBpcCpwL2x377gTpg5idnTxtO87jVATN97NONGNvCZow8o+3nlN7Z1cP/jzTzS9Gv2n+J98M4NNeXakp8A/CzuB60HbjOzX0t6FFgg6RzgJeA0ADNrlrQAeAbYDpxvZplzCpwH3Ag0Ek6mlrn27PXALZJWErbgTy/mExo3soF3H7DnTm3lPK3BouVr+fwdT2JdnZhmMO/QQz3gnRtiyhLyZvYicFiW9o2E68dmm+ZK4Mos7Y8Bh2Rpbyd+SJRD8kpR5Qj6jW0db5znHurB4NLFzzDnoIlVdT4d59zg+AnKiiB5pahyXR3q/sebsa5Oki9xtZ7b3jk3cJV2nHzVy5xnvr2zmy0d28tyjHxzc+iDN/W8mEk5zm2/sa2DJ9dsrpjfCDg31HjID8LGtg62dnb1CLBsJy8r5THymaNo9p8ykXknH8qI4XWMaqhnxPC6kp/bftHytcyedy8f/tGyivzVr3NDgXfXDFCmS+b/HdTJv8y7940umcljGuns7nnyslJtQWc7F82cgyaWZd9A8htN5tq31Xy9W+eqlW/JD0AywLrMenTJjBvZwNWnzCj5FnSuk42NG9nAYVP2KHmwlvsbjXMu8C35AcgEWGYLFXacP37cyIY3jpsv1RZ0JZ5NspzfaJxzO/iW/ABkC7DXt3WxbNXGNx6Xagu6EgMeKNs3GudcT74lPwDjRjbwpQ8czKU/f7pH+9d++Ry7NdRz5pH7lqSOSg34jFJ/o3HO7cy35AeopfUvWdu/9POnWblhS9GXX+kBn1GufQLOucBDfgA2tnXwowdXZR3WbXD8dx4o6uGC1RLwzrny85AfgJbWrTTkOYf8ti4r2g+gPOCdc/3hIT8Ak8c0sr07/wktM0fbFJIHvHOuvzzkByB55EiuKwq+vq2Lp9e9VrBlesA75wbCQ36ATpg5iYcueg977z6C+rrsQX/FXc8UpMvGA945N1Ae8oMw71fPsnbz1pxdN4X4hacHvHNuMDzkB+iH9/2BBY/nP4JmsL/w9IB3zg2Wh/wAbGzr4Ju/eT7vOA31g/uFpwe8c64Q/BevA9DSupVdhtXR2dWVdfiuw4fxg48czrsPeNOA5u8B75wrFN+SH4BwCGV3zuGdXV28+KctA/rlqwe8c66QPOQHYNzIBj41d/+cwzu74fJfPMt7r7mfLy96KvV8PeCdc4XmIT9A/3DkPjkPnUy6eelLqbboPeCdc8XgIT8IXX386jVj+ZrNeYd7wDvnisVDfoCa1/2ZdBEPM6fskXs+HvDOuSLykB+gP2/dlmq8s965D9MmjMo6zAPeOVdsfgjlAM1/5KWcw+rrxBc/cBBHTRvvAe+cKysP+QHY2NbBg3/YlHP43LeO54OH7Z3zh1Ae8M65UvHumgFY+oeNeYc3Pf8nZs+7N+uFQzzgnXOl5CE/AK/2cWbJzm5o7+zuceGQjW0d/Oy+J/jxnYs84J1zJePdNQNw1LTxqcbLnIXywZWv8vk7nsS6OjHNYN6hh/YI+I1tHX6xa+dcUXjIF9G2ri5222UYn7/jSbZ1GVAPBpcufoY5B01k3MgGFi1fy0ULVzC8ro7O7m6uPmUGJ8ycVO7SnXM1wrtrBqCvHzdlHDxxNEuffA7r6uzRntnC39jWwUULV9De2c2Wju07dfE459xg+Zb8AOS5hncPv2t5jRUt3XQzrEd75jzzLa1bGV5XRzs7TnaW+QDwbhvnXCF4yA/AgsfWpB63izqGDxN1gl2GDXujSyYT4p29zmY52AuNOOdckof8ADy+urVf4w8fFi4gMmXsrj12rmYuCH5hrz5534p3zhWKh/wAdOQ+lXxWf9nWxQV3LOcbpx7GYb3OY3PCzEnMnjbej65xzhWF73gtkY7tlnOn6riRDRw2ZQ8PeOdcwXnIl1Bmp6pzzpVKzYe8pOMkPS9ppaSLy1mL71R1zpVaTYe8pGHAfwHvBw4GzpB0cDlqaaiX71R1zpVcre94PQJYaWYvAkiaD5wIPFOqAgR87n0H8A9H7uMB75wruVoP+UlA8qD2FuDIUi38wD1349Zz3+nh7pwrG5mlvYhd9ZF0GnCsmf1TfPwR4Agz+3RinHOBcwEmTJhw+Pz58/uc71NrX3vj/oRG2JBlX+qE0SPYc1TlhntbWxsjR44sdxn95nWXlted3ty5cx83s1klXWgKtb4l3wJMSTyeDKxLjmBm1wLXAsyaNcvmzJmTd4bNzc1879cb2MpugLjg0O1866meq/HxL7634rfem5qa6Ou5ViKvu7S87upX0ztegUeB/SW9WdIuwOnA4oHOLHPBj88f8Dqht72nU9+2F6u//oGKD3jn3NBR01vyZrZd0qeAu4FhwA1m1jyQefW+otPHGhqY/bUlwHYmjd6Fh77wvkKW7pxzBVHTIQ9gZr8EfjmYeeS6ZN9DX3gfTU1NfPrMOQWo1DnnCq/Wu2sGza/J6pyrZh7yeXjAO+eqnYd8Dh7wzrla4CGfhQe8c65WeMj34gHvnKslHvIJW7du9YB3ztUUD/mEzZs3e8A752pKTZ+7pr8k/Qn4Yz8nGw+8WoRyis3rLi2vu7TKUfe+ZvamEi+zTx7ygyTpsUo8KVFfvO7S8rpLq1rrLgbvrnHOuRrmIe+cczXMQ37wri13AQPkdZeW111a1Vp3wXmfvHPO1TDfknfOuRrmIT9Ako6T9LyklZIuLmMdqyU9JWm5pMdi21hJSyS9EP+OSYx/Saz5eUnHJtoPj/NZKek7khTbGyTdHtuXSZo6wDpvkPSKpKcTbSWpU9LZcRkvSDq7AHVfLmltXOfLJR1fSXVLmiLpt5KeldQs6TOxvaLXd566K3p9Vzwz81s/b4QLkPwBeAuwC/AkcHCZalkNjO/VdjVwcbx/MTAv3j841toAvDk+h2Fx2CPAOwmXvPoV8P7Y/kngB/H+6cDtA6zz3cDbgadLWScwFngx/h0T748ZZN2XA/+aZdyKqBvYC3h7vD8K+H2sraLXd566K3p9V/rNt+QH5ghgpZm9aGbbgPnAiWWuKelE4KZ4/ybgpET7fDPrMLNVwErgCEl7AaPNbKmFd/zNvabJzOtO4OjMVlF/mNn9wKYy1HkssMTMNplZK7AEOG6QdedSEXWb2XozeyLe3wI8C0yiwtd3nrpzqYi6K52H/MBMAtYkHreQ/81YTAb8RtLjks6NbRPMbD2Efxxgz9ieq+5J8X7v9h7TmNl24DVgXIFqL0WdxXqtPiVpRezOyXR7VFzdsTvibcAyqmh996obqmR9VyIP+YHJtiVbrsOUZpvZ24H3A+dLeneecXPVne/5lOO5FrLOYtT/fWA/YCawHvjWIGooWt2SRgILgc+a2Z/zjTqAGkpZd1Ws70rlIT8wLcCUxOPJwLpyFGJm6+LfV4CfEbqSNsSvrMS/r8TRc9XdEu/3bu8xjaR6YHfSd1/0pRR1Fvy1MrMNZtZlZt3AdYR1XlF1SxpOCMpbzeynsbni13e2uqthfVe0cu8UqMYb4QLoLxJ29mR2vE4vQx27AaMS9/+P0I/4DXruYLs63p9Ozx1VL7JjR9WjwDvYsaPq+Nh+Pj13VC0YRL1T6bkDs+h1EnakrSLsTBsT748dZN17Je7/C6FfuGLqjsu4Gfj3Xu0Vvb7z1F3R67vSb2UvoFpvwPGEvf9/AC4tUw1viW/yJ4HmTB2EPsZ7gBfi37GJaS6NNT9PPOIgts8Cno7DvsuOH8qNAO4g7NR6BHjLAGv9CeGrdidhq+mcUtUJfCy2rwT+sQB13wI8BawAFvcKobLXDRxF6GpYASyPt+MrfX3nqbui13el3/wXr845V8O8T94552qYh7xzztUwD3nnnKthHvLOOVfDPOSdc66Gecg751wN85B3BSNpjqS74v0TlOcUzJL2kPTJASzjckn/Opg6C0nSSZIOLncdSYVeR5L2jedGWh5PAfzPiWFNkl5KnrRO0s8ltRVq+W5wPORdnyQN6+80ZrbYzL6eZ5Q9CKd9rXYnEU55m1r8OX01WQ/8tZnNBI4ELpa0d2L4ZmA2hA9vwimDXYXwkB/iJE2V9Jykm+JZ/u6UtKvCxUi+LOlB4DRJx0haKukJSXfEk0hlLp7yXBzv5MR8Pyrpu/H+BEk/k/RkvP018HVgv7h1+I043uclPRrr+LfEvC6NF4X4X+CtfTyfJknXSLpf4eITfyXpp/FCEF9NjPc5SU/H22cT6+JZSdfFLdbfSGqMw/aT9Ou4RfuApAPj8zgB+EZ8HvtJ+nh8Dk9KWihp1zj9jZK+Lem3cfwXJL0pDqtTuIjF+CzPZ/f4WtTFx7tKWiNpeK5lZVkfs+L98ZJWx/vDJH0jsb4/kWudmtk2M+uIDxvYOTfmE04RAOE98FNc5Sj3T279Vt4b4bwsRjibJcANwL8SLkZyYWwbD9wP7BYfXwR8mfAT8TXA/oRzhCwA7orjfBT4brx/O+GMghAuuLI7O58P5hjCxZdFCJG7CBfsOJzwk/ZdgdGEn5zvdAGJxHya2HExjM8QTjK1FyGcWgg/7c/MczdgJOGUEG+LNW0HZsbpFwAfjvfvAfaP948E7o33bwROTSx/XOL+V4FPJ8a7ix3nVrkssU6OARbmeU6LgLnx/t8DP+pjWZdn1lFcH7MSr+PqeP9c4IvxfgPwGPDmPDVMIZxW4C/A+b3W95Fx2DDgN3E9tpX7ve23cKu2r42uONaY2UPx/o+B/xfv3x7/voPQJfFQ7HrdBVgKHAisMrMXACT9mBAevb0HOAvAzLqA15S49Fx0TLz9Lj4eSfjwGAX8zMz+EpexOMXzyYzzFNBs8Rzqkl4khNVRcZ6vx/afAu+K060ys+Vx+seBqfFby18DdyS6nhtyLPuQ+I1hj/gc7k4MuyM+fwgfpouAfyecM+W/8zyf2wnh/lvCFvP3UiyrL8cAMySdGh/vTljfq7KNbGZr4vh7Az+XdKeZbYiDu4AHY42NZrZa/b+ujCsSD3kHO583O/P49fhXhKvmnJEcSdLMLNMOlICrzOyHvZbx2QEsI9O10J24n3lcT/Zzh/eeFkJ4NRK+WWy20CfdlxuBk8zsSUkfBeYkhmXWJ2a2RtIGSe8hbAmfmWeei4GrJI0lfAu5N8WyMrazo3tlRKJdhC3//nwwYGbrJDUTPhTvTAyaTzjV9eX9mZ8rPu+TdwD7SHpnvH8GYass6WFgtqRp8Ea/8AHAc8CbJe2XmDabe4Dz4rTDJI0GthC20jPuBj6W6OufJGlPQjfRhyQ1ShoFfHAwTzS6HzgpPo/dgA8BD+Qa2cKFK1ZJOi3WJkmHxcG9n8coYL3CedHzBTfAjwjfnBYktvCzLb+NcMbE/yB0h2XGTbOs1YQPBoBTE+13A+fFaZF0QFwXO5E0ObFvYgxhJ+vzvUZ7ALiKcNZOV0E85B2Ea2meLWkF4bza308ONLM/EfrYfxLHeRg40MzaCd0z/6Ow4/WPOeb/GWCupKcIXSDTzWwjofvnaUnfMLPfALcBS+N4dxLOlf8EobtiOeFiEjnDOK04zxsJwbmM0Mf9u7wThRA9R1LmtM4nxvb5wOcl/S5+2H0pznMJ4UMwn8WEbpZ8XTUZtwMfZkcXGimX9U1CmP8foU8+40fAM8ATkp4Gfkjub/YHAcvic78P+KaZPZUcwYJvmtmrKZ6LKyE/1fAQp3AtzbvM7JBy1zLUxKNerjGzd5W7Fle7vE/euTJQ+KHYefTdpePcoPiWvKtKkv6L+AOchP8wszRdHxVJ0qXAab2a7zCzK0u0/EMJV2FK6jCzI0uxfFccHvLOOVfDfMerc87VMA9555yrYR7yzjlXwzzknXOuhnnIO+dcDfv/T3G4DZLbxrwAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 360x360 with 1 Axes>"
       ]
@@ -1066,10 +1096,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "1ff6b5be",
+   "execution_count": 21,
+   "id": "6338ac1f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW0AAAFACAYAAAB3My3KAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAoUElEQVR4nO3dfZxcZX338c83u5AHCEgAIxBMqGC7YamhbMFbYps1GggtJfZGTWoFy7ZRilsfUAG3t1hxq7wqUh9KFN2UB3EBUSFQMATYVUPlISAWkpWSmoQEAggJkKQQ2M3v/uNcG06W3Z3ZPM2ezPf9es1rzlznXNf5nTNnfnPNdc7MKCIwM7NiGFHpAMzMrHxO2mZmBeKkbWZWIE7aZmYF4qRtZlYgTtpmZgVSdUlb0hckfb/ScewsklZKenea/pyk7+2GdU6TtGZXr8d2PkmTJIWk2krHsqeS1Cnpb3dV+7s9aacNWi9pZJnLf1jS4l0d166Se5FsTLeVks7fFeuKiH+OiJIHi6QrJH1pV8SwKwz3N1pJsyU9KukFSc9IulLSfpWOC7Z9Uy+yoh2zu9JuTdqSJgHvBAL4i9257mHgDRGxLzAH+Lykk/su4N7P8DfAc3Q3cGJE7A/8HlALOMEMI3vUaysidtsN+DzZAf414JY+8w4Hfgz8DngO+BZQB7wM9AAbgefTsp3A3+bqfhhYnHv8dWA18CLwAPDO3LwvAN8fIL4u4M9zj2uBZ4E/AkYB30+xPQ/cD4wvY5snkb1J1ebK7gc+DUwD1gDnAU8BV5O9kZ4P/E9a1/XAuFzdDwGr0rwWYCXw7v62DZgK/GeKd3XaT3OBV4FX0j69OS17KPCjtP9XAP+Qa2c0cAWwHlgGfAZYM8g2Hw0sAtYBTwOfS+VXAF/KLTct307aD08AG4BHgenAySnWV1O8v87FuyCtYznwd32e4x+m52sD8DDwVuAC4Jm0L2bklt8faAPWpvV/CajJHVt3A5emdX1poO1Oy+8LXAXcOsgyQ42v1LZen9a5AVgKNKR5VwNbgJfSvvssrx2PZwKPkx3fLYPEegVwGXBbauNu4E3Av6bj4TfAsbnl68hen8+nWP6iT1v/BvxHivVe4C25+X/Aa8fNo8D7U/lAx2zv62QD2XH53j45If+8fTndH5Nb5o1p3xzcZ5tHpvjrc2UHp2XfCBwA3EL2Wlmfpifklu0k5Sde/5rs3f+1pY69AZ+TXZWgBzgAlgN/DxyXnoTxqbwG+HXawfuQJcipuZ2/uE87W3dKf8sAfw0cSJZ0zyVLiKP624l92v08cE3u8Z8Bv0nTHwFuBsakeI8D9itjm7c+SYCAE4H/JUtI04Bu4OJ0oIwGPgHcA0xIZd8B2lNbk8kO2j9J876W6r8uaQNvJjuY5wB7pf0xZYDkOYLsze3zwN5kvcXfAiel+V8BfgGMI3tzfYQBkjYwNh2A56bncSxwwgDrndbbDvD7ZMnq0Nx+e8tAzxnwM7JkMgqYQvYCmp5b/mXgpLTfryJ7I2pJ++LvgBW5tm5M+3kfshflfcBHcsdWN9Cc2ho9wHZPBV5Iz/Umckm3n2WHGl8523oK2XH5ZeCeXN2VpOOjz/H4XbLj7W3AZqBugFivIEvsx6X135ViPSOt70tAR1p2L7LX+OfIjqN3kR2Dv59rax1wfNrua4Br07x90vP/N2neH6X1Ht3fsZPK3kf2hjYC+EDa74cM9LylfXhxrv7HSW8A/Wz3fKA19/gc4Kdp+kDg/5LlgrFkb8A39pefKJ20b2SAY2/A42dnJ+ZBDtSpZIn6oPT4N8An0/T/SQdibT/1PswQk3Y/bawH3jZQAsgtd2Q6yMakx9cAn0/TZ5H1Wv9wiNvd+yQ9n+LoIvViyZLWK6Q3lFTWRXpBpseHpP1WS5ZUr83N2yfV7y9pXwD8ZJAXYj55ngA83meZC4B/T9O/BU7OzZvLwEl7DvCrMtc7jdeS9pFkvcx3A3v1qdf3wD+c7NPX2FzZl4Ercssvys07lezNrrf3PDY9J28AxpMlrdF9tqEjd2w93t/2DLCNh6X1v3WQZYYSXznbekdu3mTgpdzjlfSftPM9w/uA2YM8Z9/NPW4GunKPj+G1T8DvJOsgjcjNbwe+kGvre7l5p/Bap+gDwC/6rPs7wIX9HTsDxPoQcNpAzxvZcb66Nz5gCak3309b7wZ+m3t8N3DGAMtOAdbnHndSRtIudewNdNud4zxnArdHxLPp8Q9S2aVkB+aqiOjeGSuSdC7wt2TvwgHsBxxUql5ELJfUBZwq6Waycfdj0+yrU5zXSnoD2Ufbloh4tcywDhpg+34XES/nHk8EfiJpS66sh+wJPpTsoOuNd5Ok5wZY3+FkHx3LMRE4VNLzubIast41fddLNjwzkKGsd6u07z9BdpAfLWkh8KmIeLKfxQ8F1kXEhj4xNeQeP52bfgl4NiJ6co8hG8o4lKyHuFZS7/Ij2HZ789OltuMJST8FrgX+SNIHyZIPZElp5nbEV2pbn8pN/y8wSlJtiddT3zr7DrJs31j7Pu6teyiwOiLyx+4qsjeyUuudCJzQ5xisJXvd9UvSGcCnyBIhqa3863yb5y0i7pW0CfhTSWvJOgoLBmj+LmC0pBNSzFOAn6T1jiHLWyeTDZUAjJVUk3sOyzGR0sfe6+yWpC1pNPB+oEZS75M2EniDpLeRBfnmAQ606KfJTWQfTXq9Kbeud5KNjU4HlkbEFknryYYmytFO9m43AlgWEcsBUnL+J+Cf0gnVW8nG3drKbHcgfbdvNXBWRNzdd8F0oNXlHo8h+6jWn9VkH0PLXeeKiDhqgOXXkiXjpenxmwdYrretOQPMG/B5A4iIHwA/SFdefIds2OhD/cT7JDBO0thcMnsz2ZjgUK0m6+0M9KZKP+svpRZ4C0BEXEP2iW177ei2DjX2HfEkcLikEbnE/Wbgv8uouxr4WUS8Z4D522yHpIlkQzzTgV9GRI+kh9j2dd7ftl9JNnz6FHBDnw7TaxWzvHE92bH8NNk5uN79fy7ZcN4JEfGUpCnAr+g/xwx2zJdz7L3O7rp6ZBZZb3Ey2TvWFLLk8wuysbH7yBLDVyTtI2mUpBNT3aeBCZL2zrX3EPCXksZIOhJoys0bSzaW9TugVtLnyXra5boWmAGcTfZpAABJjZKOkVRDdoLz1bRNO9u3gdZ0UCLpYEmnpXk3AH8uaWraH19k4OfwGuDdkt4vqVbSgenggmyf/l5u2fuAFyWdJ2m0pBpJ9ZL+OM2/HrhA0gGSJpB9RB7ILcCbJH1C0khJY1NvBbLn7RRJ4yS9iWz8nrSdvy/pXelS0JfJenC9+/dpYJKkEQARsZpsqOrL6Vj5Q7JjYMjJMSLWArcDl0jaT9IISW+R9KfltiHpg5LerMxEoBW4c6ixDBDfjm5r3+d6V7qXLEl9VtJekqaRDf1cW0bdW4C3SvpQqruXpD+W1NtJ6bsd+5Al5d8BSPoboL6M9VwNvJcscV9VYtkfkA3bfJBcLiDLMS8Bz0saB1w4SBsPAX+Sjo/9yYYdge0/9nZX0j6TbHz08Yh4qvdGdoXIB8neoU4l+7jyONkVFR9Ide8i6+E9Jal3aOVSsrHcp8neOfMH8EKyM93/TfbR7GWG9vF2LfBL4B3AdblZbyJLmi+SjTv/jGyIBEnflvTtctdRwtfJPrLdLmkD2UnJE1JsS8lOiPyA7E1uPdm+6m87HicbMzyX7OTPQ2QnnSD7dDBZ0vOSbkwf6U4lezNdQXYC6HtkZ7Yh+4SxKs27nUE+sqbeyHtSe08BjwGNafbVZCecV6Z28vt3JNkJz2dTvTeSndCC7EQPwHOSHkzTc8g+Fj9J9rH1wohYNFBcJZxBduJsGdk+vYHsXEK5JpMl1t6rKx4lO5m4s+zItn4Z+Mf0XH96J8b0OhHxCtmQ4kyy5/EysnHg35RRdwNZZ2k22XY+xWsn6OH1x+wy4BKy1+rTZGPrr/t02s961gAPkiX8X5RYtvdN6FCynNLrX8lObD5L9vr86SBtLCI7zv+L7GT/LX0WGfKxpzT4bWZWFSTNB56MiH+sdCzbY8+54NzMrIR0Puovee0Cg8Kput8eMbPqJOkisu8Y/EtErKh0PNvLwyNmZgXinraZWYE4aZuZFcgedyLyoIMOikmTJlU6DCuITZs2sc8++1Q6DCuABx544NmIOLjScexxSXvSpEksWbKk0mFYQXR2djJt2rRKh2EFIGmwn2/YbTw8YmZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViBO2mZmBeKkbWZWIE7aVpXa29upr69n+vTp1NfX097eXumQzMqyx325xqyU9vZ2WlpaaGtro6enh5qaGpqasj8/mjNnoH9KMxse3NO2qtPa2kpbWxuNjY3U1tbS2NhIW1sbra2tlQ7NrCQnbas6XV1dTJ06dZuyqVOn0tXVVaGIzMrnpG1Vp66ujsWLF29TtnjxYurq6gaoYTZ8OGlb1WlpaaGpqYmOjg66u7vp6OigqamJlpaWSodmVpJPRFrV6T3Z2NzcTFdXF3V1dbS2tvokpBXCHvd3Yw0NDeGfZrVy+adZrVySHoiIhkrH4eERM7MCcdI2MysQJ20zswJx0jYzKxAnbTOzAnHSNjMrECdtM7MCcdI2MysQJ20zswIpmbQlHS6pQ1KXpKWSPp7KvyDpCUkPpdspuToXSFou6VFJJ+XKj5P0cJr3DUlK5SMlXZfK75U0KVfnTEmPpduZO3XrzcwKppzfHukGzo2IByWNBR6QtCjNuzQivppfWNJkYDZwNHAocIekt0ZEDzAPmAvcA9wKnAzcBjQB6yPiSEmzgYuBD0gaB1wINACR1r0gItbv2GabmRVTyZ52RKyNiAfT9AagCzhskCqnAddGxOaIWAEsB46XdAiwX0T8MrIfPLkKmJWrc2WavgGYnnrhJwGLImJdStSLyBK92Q7x341ZUQ3pV/7SsMWxwL3AicDHJJ0BLCHrja8nS+j35KqtSWWvpum+5aT71QAR0S3pBeDAfHk/dfJxzSXrwTN+/Hg6OzuHsllWZe68807a2tr4zGc+wxFHHMGKFSs499xzWbZsGdOnT690eGaDKjtpS9oX+BHwiYh4UdI84CKyYYuLgEuAswD1Uz0GKWc767xWEHE5cDlkv/LnX22zwXzsYx/jmmuuobGxkc7OTj75yU8yZcoUmpubueiiiyodntmgyrp6RNJeZAn7moj4MUBEPB0RPRGxBfgucHxafA1weK76BODJVD6hn/Jt6kiqBfYH1g3Sltl289+NWZGVc/WIgDagKyK+lis/JLfYe4FH0vQCYHa6IuQI4CjgvohYC2yQ9PbU5hnATbk6vVeGnA7clca9FwIzJB0g6QBgRioz227+uzErsnKGR04EPgQ8LOmhVPY5YI6kKWTDFSuBjwBExFJJ1wPLyK48OSddOQJwNnAFMJrsqpHbUnkbcLWk5WQ97NmprXWSLgLuT8t9MSLWbc+GmvXq/buxtrY2enp6tv7dmP+N3YrA/1xjVam9vZ3W1tatfzfW0tLivxuzQQ2Xf65x0raq5r8bs3INl6Ttr7GbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBlEzakg6X1CGpS9JSSR9P5eMkLZL0WLo/IFfnAknLJT0q6aRc+XGSHk7zviFJqXykpOtS+b2SJuXqnJnW8ZikM3fq1puZFUw5Pe1u4NyIqAPeDpwjaTJwPnBnRBwF3Jkek+bNBo4GTgYuk1ST2poHzAWOSreTU3kTsD4ijgQuBS5ObY0DLgROAI4HLsy/OZiZVZuSSTsi1kbEg2l6A9AFHAacBlyZFrsSmJWmTwOujYjNEbECWA4cL+kQYL+I+GVEBHBVnzq9bd0ATE+98JOARRGxLiLWA4t4LdGbmVWd2qEsnIYtjgXuBcZHxFrIErukN6bFDgPuyVVbk8peTdN9y3vrrE5tdUt6ATgwX95PnXxcc8l68IwfP57Ozs6hbJZVsY0bN/p4sUIpO2lL2hf4EfCJiHgxDUf3u2g/ZTFI+fbWea0g4nLgcoCGhoaYNm3aQLGZbaOzsxMfL1YkZV09ImkvsoR9TUT8OBU/nYY8SPfPpPI1wOG56hOAJ1P5hH7Kt6kjqRbYH1g3SFtmZlWpnKtHBLQBXRHxtdysBUDv1RxnAjflymenK0KOIDvheF8aStkg6e2pzTP61Olt63TgrjTuvRCYIemAdAJyRiozM6tK5fS0TwQ+BLxL0kPpdgrwFeA9kh4D3pMeExFLgeuBZcBPgXMioie1dTbwPbKTk/8D3JbK24ADJS0HPkW6EiUi1gEXAfen2xdTmdkOaW9vp76+nunTp1NfX097e3ulQzIrS8kx7YhYTP9jywDTB6jTCrT2U74EqO+n/GXgfQO0NR+YXypOs3K1t7fT0tJCW1sbPT091NTU0NTUBMCcOXMqHJ3Z4PyNSKs6ra2ttLW10djYSG1tLY2NjbS1tdHa+rp+htmw46RtVaerq4upU6duUzZ16lS6uroqFJFZ+Zy0rerU1dWxePHibcoWL15MXV1dhSIyK5+TtlWdlpYWmpqa6OjooLu7m46ODpqammhpaal0aGYlDekbkWZ7gt6Tjc3NzXR1dVFXV0dra6tPQlohKLsces/R0NAQS5YsqXQYVhD+RqSVS9IDEdFQ6Tg8PGJmViBO2mZmBeKkbWZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViBO2mZmBeKkbWZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViBO2mZmBeKkbWZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViBO2mZmBeKkbWZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViBO2mZmBeKkbWZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViAlk7ak+ZKekfRIruwLkp6Q9FC6nZKbd4Gk5ZIelXRSrvw4SQ+ned+QpFQ+UtJ1qfxeSZNydc6U9Fi6nbnTttrMrKDK6WlfAZzcT/mlETEl3W4FkDQZmA0cnepcJqkmLT8PmAsclW69bTYB6yPiSOBS4OLU1jjgQuAE4HjgQkkHDHkLzcz2ICWTdkT8HFhXZnunAddGxOaIWAEsB46XdAiwX0T8MiICuAqYlatzZZq+AZieeuEnAYsiYl1ErAcW0f+bh5lZ1ajdgbofk3QGsAQ4NyXWw4B7csusSWWvpum+5aT71QAR0S3pBeDAfHk/dbYhaS5ZL57x48fT2dm5A5tl1WTjxo0+XqxQtjdpzwMuAiLdXwKcBaifZWOQcrazzraFEZcDlwM0NDTEtGnTBgnd7DWdnZ34eLEi2a6rRyLi6YjoiYgtwHfJxpwh6w0fnlt0AvBkKp/QT/k2dSTVAvuTDccM1JaZWdXarqSdxqh7vRfovbJkATA7XRFyBNkJx/siYi2wQdLb03j1GcBNuTq9V4acDtyVxr0XAjMkHZBOQM5IZWZmVavk8IikdmAacJCkNWRXdEyTNIVsuGIl8BGAiFgq6XpgGdANnBMRPamps8muRBkN3JZuAG3A1ZKWk/WwZ6e21km6CLg/LffFiCj3hKiZ2R5JWad2z9HQ0BBLliypdBhWEB7TtnJJeiAiGiodh78RaWZWIE7aZmYF4qRtZlYgTtpmZgXipG1Vqb29nfr6eqZPn059fT3t7e2VDsmsLDvyNXazQmpvb6elpYW2tjZ6enqoqamhqakJgDlz5lQ4OrPBuadtVae1tZW2tjYaGxupra2lsbGRtrY2WltbKx2aWUlO2lZ1urq6mDp16jZlU6dOpaurq0IRmZXPSduqTl1dHYsXL96mbPHixdTV1VUoIrPyOWlb1WlpaaGpqYmOjg66u7vp6OigqamJlpaWSodmVpJPRFrV6T3Z2NzcTFdXF3V1dbS2tvokpBWCf3vEqpp/e8TK5d8eMTOzIXPSNjMrECdtM7MCcdK2quSvsVtR+eoRqzr+GrsVmXvaVnX8NXYrMidtqzr+GrsVmZO2VR1/jd2KzEnbqo6/xm5F5hORVnX8NXYrMve0zcwKxD1tqzq+5M+KzD1tqzq+5M+KzEnbqo4v+bMic9K2quNL/qzInLSt6viSPysyn4i0quNL/qzI/M81VtX8zzVWLv9zjZmZDZmTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFUjJpC1pvqRnJD2SKxsnaZGkx9L9Abl5F0haLulRSSflyo+T9HCa9w1JSuUjJV2Xyu+VNClX58y0jscknbnTttrMrKDK6WlfAZzcp+x84M6IOAq4Mz1G0mRgNnB0qnOZpJpUZx4wFzgq3XrbbALWR8SRwKXAxamtccCFwAnA8cCF+TcHM7NqVDJpR8TPgXV9ik8DrkzTVwKzcuXXRsTmiFgBLAeOl3QIsF9E/DKyr2Be1adOb1s3ANNTL/wkYFFErIuI9cAiXv/mYWZWVbZ3THt8RKwFSPdvTOWHAatzy61JZYel6b7l29SJiG7gBeDAQdoyM6taO/sHo9RPWQxSvr11tl2pNJds6IXx48fT2dlZMlAzgI0bN/p4sULZ3qT9tKRDImJtGvp4JpWvAQ7PLTcBeDKVT+inPF9njaRaYH+y4Zg1wLQ+dTr7CyYiLgcuh+wHo/wDQFYu/2CUFc32Do8sAHqv5jgTuClXPjtdEXIE2QnH+9IQygZJb0/j1Wf0qdPb1unAXWnceyEwQ9IB6QTkjFRmZla1Sva0JbWT9XgPkrSG7IqOrwDXS2oCHgfeBxARSyVdDywDuoFzIqInNXU22ZUoo4Hb0g2gDbha0nKyHvbs1NY6SRcB96flvhgRfU+ImplVlZJJOyIG+mX46QMs3wq87h9SI2IJUN9P+cukpN/PvPnA/FIxmplVC38j0sysQJy0zcwKxEnbzKxAnLTNzArESdvMrECctM3MCsRJ28ysQJy0rSq1t7dTX1/P9OnTqa+vp729vdIhmZVlZ/9glNmw197eTktLC21tbfT09FBTU0NTUxMAc+YM9F0ys+FB2c987DkaGhpiyZIllQ7DhrH6+npmzZrFjTfeSFdXF3V1dVsfP/LII6UbsKok6YGIaKh0HO5pW9VZtmwZmzZtYv78+Vt72meddRarVq2qdGhmJXlM26rO3nvvTXNzM42NjdTW1tLY2EhzczN77713pUMzK8k9bas6r7zyCt/61rc49thj6enpoaOjg29961u88sorlQ7NrCQnbas6kydP5qijjmLmzJls3ryZkSNHMnPmTMaMGVPp0MxKctK2qtPY2Mi3v/1tLr74YiZPnsyyZcs477zz+OhHP1rp0MxKctK2qtPR0cF5553H/Pnzt149ct5553HjjTdWOjSzknzJn1WdmpoaXn75Zfbaa6+t/xH56quvMmrUKHp6eko3YFVpuFzy56tHrOrU1dWxePHibcoWL15MXV1dhSIyK5+TtlWdlpYWmpqa6OjooLu7m46ODpqammhpaal0aGYleUzbqk7vV9Wbm5u3jmm3trb6K+xWCB7TtqrWO6ZtVorHtM3MbMictM3MCsRJ28ysQJy0zcwKxEnbzKxAnLTNzArESduqUnNzM6NGjaKxsZFRo0bR3Nxc6ZDMyuIv11jVaW5u7vdX/gC++c1vVjg6s8H5yzVWdUaNGsXpp5/OQw89tPUbkVOmTOGGG27g5ZdfrnR4NkwNly/XuKdtVWfz5s3cfffdr/uPyM2bN1c6NLOSPKZtVUcSM2fO3OY/ImfOnImkSodmVpKHR6zqSEISI0aM2NrT3rJlCxHBnvZ6sJ1nuAyPuKdtVWfcuHFExNaetSQignHjxlU4MrPSnLSt6rz44ovsu+++TJgwAUlMmDCBfffdlxdffLHSoZmV5KRtVae7uxtJPPHEE0QETzzxBJLo7u6udGhmJfnqEataCxcu3Dqmfdppp1U6HLOy7FDSlrQS2AD0AN0R0SBpHHAdMAlYCbw/Itan5S8AmtLy/xARC1P5ccAVwGjgVuDjERGSRgJXAccBzwEfiIiVOxKzGcCGDRt417veVekwzIZsZwyPNEbElNxZ1fOBOyPiKODO9BhJk4HZwNHAycBlkmpSnXnAXOCodDs5lTcB6yPiSOBS4OKdEK8ZACNGjNjm3qwIdsXRehpwZZq+EpiVK782IjZHxApgOXC8pEOA/SLil5Fdb3VVnzq9bd0ATJcvprWdYPTo0dxxxx0sWrSIO+64g9GjR1c6JLOy7OiYdgC3SwrgOxFxOTA+ItYCRMRaSW9Myx4G3JOruyaVvZqm+5b31lmd2uqW9AJwIPDsDsZtVW7MmDGcddZZrFq1iokTJzJmzBheeumlSodlVtKOJu0TI+LJlJgXSfrNIMv210OOQcoHq7Ntw9JcsuEVxo8fT2dn56BBm02cOJF169ZtvVZ74sSJPPfccz52bNjboaQdEU+m+2ck/QQ4Hnha0iGpl30I8ExafA1weK76BODJVD6hn/J8nTWSaoH9gXX9xHE5cDlk34j0v2vbYGbMmMHtt9/O2WefzSmnnMKtt97KvHnzmDFjhv+Z3Ya97R7TlrSPpLG908AM4BFgAXBmWuxM4KY0vQCYLWmkpCPITjjel4ZSNkh6exqvPqNPnd62TgfuCn/P2HbQwoULOeaYY5g3bx6nnnoq8+bN45hjjmHhwoWVDs2spB3paY8HfpI+XtYCP4iIn0q6H7heUhPwOPA+gIhYKul6YBnQDZwTET2prbN57ZK/29INoA24WtJysh727B2I1wyA9vZ2Nm7cyF133bX1Ou2mpiba29uZM2dOpcMzG5R/MMqqTn19PbNmzeLGG2/c+nvavY8feeSRSodnw9Rw+cEofyPSqs6yZcvYtGnT635Pe9WqVZUOzawkJ22rOnvvvTcnnngizc3NW3vaJ554ImvXrq10aGYlOWlb1dm8eTPt7e0cfPDBbNmyhWeffZb29na2bNlS6dDMSvL3d63q1NbWMnr0aEaPHs2IESO2TtfWug9jw5+PUqs63d3dHHTQQduMaf/VX/0VmzZtqnRoZiU5aVtVOv7445k5cyabN29m5MiRnHTSSSxYsKDSYZmV5KRtVWfcuHHcfPPNW3/dr7u7m5tvvtl/N2aF4KRtVWfz5s1EBD092Xe7eu83b95cybDMyuITkVZ1eseua2pqtrn3mLYVgXvaVpXGjh3LTTfdtM3fjW3YsKHSYZmV5J62VaW+P9+wp/2cg+253NO2qrRx40b/R6QVknvaVnVGjhwJsPUPEHrve8vNhjMnbas6PT09jBgxYuuQSEQwYsSIrVeRmA1nHh6xqtPd3f26si1btvi3R6wQ3NO2qnXJJZdw2223cckll1Q6FLOyuadtVeuzn/3s1kv+zIrCPW0zswJx0raq1ffqEbMicNK2qtV7QrK/E5Nmw5WTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWIk7aZWYE4aZuZFYiTtplZgThpm5kViJO2mVmBOGmbmRWI/yPS9jg78k80g9WNiO1u12xnKURPW9LJkh6VtFzS+ZWOx4a3iBj0tr11zYaDYZ+0JdUA/wbMBCYDcyRNrmxUZmaVUYThkeOB5RHxWwBJ1wKnAcsqGpXtdm/7p9t54aVXd7idiefdwqqL/7zf8knn/8cOt7//6L349YUzdrgds/4UIWkfBqzOPV4DnFChWKyCtkw6l7E7qa36K+r7Kd05I29bAHh4p7Rl1lcRknZ/Z4a2GWCUNBeYCzB+/Hg6Ozt3Q1i2u31z4jfLWq6xsXGXrL+jo6PsZX0M2q5ShKS9Bjg893gC8GR+gYi4HLgcoKGhIaZNm7bbgrPhZygnDTs7O/HxYkUy7E9EAvcDR0k6QtLewGxgQYVjMjOriGHf046IbkkfAxYCNcD8iFha4bDMzCpi2CdtgIi4Fbi10nGYmVVaEYZHzMwscdI2MysQJ20zswJx0jYzKxAnbTOzAnHSNjMrECdtM7MC0Z72O8GSfgesqnQcVhgHAc9WOggrhIkRcXClg9jjkrbZUEhaEhENlY7DrFweHjEzKxAnbTOzAnHStmp3eaUDMBsKj2mbmRWIe9pmZgXipG1mViBO2lVG0hsk/f1uWM8sSZN39XqGYpjG9AVJn96J7U2U9ICkhyQtlfTR3LxOSY9LUq7sRkkbd9b6bddz0q4+bwDKTtrKbM9xMgsYVgmS7YhJUiH+KCRnLfCOiJgCnACcL+nQ3PzngRMhewMHDtnN8dkOctKuPl8B3pJ6YpdKulPSg5IelnQagKRJkrokXQY8CBwu6f9J+o2kRZLae3uHkt4i6aepd/cLSX8g6R3AXwD/ktbzlv4CST2/SyX9PK3vjyX9WNJjkr6UW+5Tkh5Jt0/0ifG7qUd5u6TRQ4lJ0t9Jul/SryX9SNKYVP8KSV+T1JGWf0zSwWneCEnLJR3Uz/bsL2ll75ucpDGSVkvaa6B19bM/GtL0QZJWpukaSf+S6v+XpI8M9ORGxCsRsTk9HMnrX+PXkv3PKsBfAj8eqC0bpiLCtyq6AZOAR9J0LbBfmj4IWA4oLbMFeHua1wA8BIwGxgKPAZ9O8+4EjkrTJwB3pekrgNNLxNIJXJymPw48SdbzGwmsAQ4EjgMeBvYB9gWWAsemGLuBKan+9cBfDyUm4MDc9JeA5txytwA16fGFwCfS9AzgR4Ns001AY5r+APC9Euv6Qm5fdgINuedjZZqeC/xjmh4JLAGOGCSGw4H/Av4XOKfP/j4hzasBbk/7cWOlj0vfyr8V7aOf7VwC/lnSn5Al6cOA8Wneqoi4J01PBW6KiJcAJN2c7vcF3gH8MDdMOnKIMSxI9w8DSyNibWr7t2TJZyrwk4jYlMp/DLwz1VsREQ+l+g8Ak4YYU33q0b+B7A1hYW7eDyOiJ03PJ0vG/wqcBfz7INtzHVmy7iDr0V5WxrpKmQH8oaTT0+P9gaOAFf0tHBGr0/KHAjdKuiEink6ze4DFKcbREbEyt5+sAJy0q9sHgYOB4yLi1fRxfFSatym33ECv6hHA85GNn26v3o/yW3LTvY9rB1l3vi5kyWj0EGO6ApgVEb+W9GFgWm7e1u2PiNWSnpb0LrKe6gcHaXMB8GVJ48g+JdxVxrp6dfPacMaoXLnIeuZDSfRExJOSlpK9yd2Qm3Ut8BOyXr4VjMe0q88GsiEOyHpsz6SE3QhMHKDOYuBUSaNST/bPACLiRWCFpPfB1pOWb+tnPTvi58CsND68D/Be4BcDLTzEmMYCayXtxeCJGOB7wPeB63M98P7WvxG4D/g6cEtu2XLWtZIs0QOcnitfCJyd6iLprWlfvI6kCbmx/QPITjo+2mexXwBfBtoH2g4bvpy0q0xEPAfcLekRYArQIGkJWSL5zQB17ifrQf6a7MTVEuCFNPuDQJOkX5ONN5+Wyq8FPiPpVwOdiCwz3gfJeqn3AfeSjRH/qkS1cmP6f6nNRQyw7TkLyIY1Bhsa6XUd8Nfpvlc56/oqWXL+T7Ix7V7fA5YBD6bn7TsM/Cm5Drg3bfvPgK9GxMP5BSLz1YjwT9IWkL/GbmWRtG9EbExXPfwcmJsSalVIV3VcGhHvrHQsVt08pm3lulzZF1NGAVdWWcI+Hzib0kMoZruce9q2y0n6N9IXOnK+HhHlDDUMS5JagPf1Kf5hRLTupvUfA1zdp3hzRJywO9ZvleOkbWZWID4RaWZWIE7aZmYF4qRtZlYgTtpmZgXipG1mViD/H43g5svnU4MFAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 360x360 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "ax = baseline.plot(kind='box',\n",
     "                   x='predicted_monetary_value_3M', \n",
@@ -1081,7 +1124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89b96001",
+   "id": "51177a87",
    "metadata": {},
    "source": [
     "## Train a TensorFlow model locally"
@@ -1089,7 +1132,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08defa7f",
+   "id": "3d958062",
    "metadata": {},
    "source": [
     "Now that you have a simple baseline to benchmark your performance against, train a TensorFlow Regressor to predict CLV."
@@ -1097,16 +1140,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 605,
-   "id": "76121604",
+   "execution_count": 22,
+   "id": "7f6d06c7",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 579.56query/s] \n",
-      "Downloading: 100%|██████████| 3/3 [00:01<00:00,  2.08rows/s]\n"
+      "Query complete after 0.00s: 100%|██████████| 2/2 [00:00<00:00, 925.38query/s]                         \n",
+      "Downloading: 100%|██████████| 3/3 [00:01<00:00,  2.36rows/s]\n"
      ]
     },
     {
@@ -1137,13 +1180,13 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>TRAIN</td>\n",
-       "      <td>2638</td>\n",
+       "      <td>TEST</td>\n",
+       "      <td>339</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>TEST</td>\n",
-       "      <td>339</td>\n",
+       "      <td>TRAIN</td>\n",
+       "      <td>2638</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1156,12 +1199,12 @@
       ],
       "text/plain": [
        "  data_split   f0_\n",
-       "0      TRAIN  2638\n",
-       "1       TEST   339\n",
+       "0       TEST   339\n",
+       "1      TRAIN  2638\n",
        "2   VALIDATE   353"
       ]
      },
-     "execution_count": 605,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1170,22 +1213,22 @@
     "%%bigquery\n",
     "\n",
     "SELECT data_split, COUNT(*)\n",
-    "FROM dougkelly-vertex-demos.online_retail.online_retail_clv_ml\n",
+    "FROM dsparing-sandbox.online_retail.online_retail_ml\n",
     "GROUP BY data_split"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 612,
-   "id": "78ce7bc6",
+   "execution_count": 23,
+   "id": "755b6107",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 822.57query/s] \n",
-      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2507.41rows/s]\n"
+      "Query complete after 0.00s: 100%|██████████| 1/1 [00:00<00:00, 525.67query/s]                          \n",
+      "Downloading: 100%|██████████| 3330/3330 [00:01<00:00, 2500.39rows/s]\n"
      ]
     }
    ],
@@ -1193,13 +1236,13 @@
     "%%bigquery clv\n",
     "\n",
     "SELECT *\n",
-    "FROM dougkelly-vertex-demos.online_retail.online_retail_clv_ml"
+    "FROM dsparing-sandbox.online_retail.online_retail_ml"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 613,
-   "id": "ca25509d",
+   "execution_count": 24,
+   "id": "46a7a131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1210,8 +1253,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1404,
-   "id": "fdd918d7",
+   "execution_count": 25,
+   "id": "8648b754",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1238,8 +1281,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1405,
-   "id": "e9494bd5",
+   "execution_count": 26,
+   "id": "1bb3dcd4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,8 +1292,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1406,
-   "id": "1c5c0b91",
+   "execution_count": 27,
+   "id": "7bdfdb24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1261,8 +1304,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1407,
-   "id": "f8922a8f",
+   "execution_count": 28,
+   "id": "1fe02860",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1273,8 +1316,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1408,
-   "id": "b72914f8",
+   "execution_count": 29,
+   "id": "bb46daaa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1292,8 +1335,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1409,
-   "id": "088a70ae",
+   "execution_count": 30,
+   "id": "1b52ed26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1327,8 +1370,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1410,
-   "id": "996259ad",
+   "execution_count": 31,
+   "id": "eb26938c",
    "metadata": {},
    "outputs": [
     {
@@ -1338,7 +1381,7 @@
        "<IPython.core.display.Image object>"
       ]
      },
-     "execution_count": 1410,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1349,8 +1392,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1411,
-   "id": "04c84b4f",
+   "execution_count": 32,
+   "id": "43d47589",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1369,8 +1412,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1412,
-   "id": "7b626035",
+   "execution_count": 33,
+   "id": "30719813",
    "metadata": {},
    "outputs": [
     {
@@ -1378,29 +1421,33 @@
      "output_type": "stream",
      "text": [
       "Epoch 1/10\n",
-      "  2/164 [..............................] - ETA: 4s - loss: 10593.9062 - mae: 10593.9062 - mse: 735473664.0000 - rmse: 26785.0820WARNING:tensorflow:Callbacks method `on_train_batch_end` is slow compared to the batch time (batch time: 0.0035s vs `on_train_batch_end` time: 0.0532s). Check your callbacks.\n",
-      "WARNING:tensorflow:Callbacks method `on_train_batch_end` is slow compared to the batch time (batch time: 0.0035s vs `on_train_batch_end` time: 0.0532s). Check your callbacks.\n",
-      "164/164 [==============================] - 1s 4ms/step - loss: 1944.2853 - mae: 1944.2853 - mse: 105602640.0000 - rmse: 4977.7876 - val_loss: 1165.3185 - val_mae: 1165.3185 - val_mse: 13002700.0000 - val_rmse: 2366.0540\n",
+      "  1/164 [..............................] - ETA: 0s - loss: 14110.5039 - mae: 14110.5039 - mse: 941772608.0000 - rmse: 30688.3145WARNING:tensorflow:From /opt/conda/lib/python3.7/site-packages/tensorflow/python/ops/summary_ops_v2.py:1277: stop (from tensorflow.python.eager.profiler) is deprecated and will be removed after 2020-07-01.\n",
+      "Instructions for updating:\n",
+      "use `tf.profiler.experimental.stop` instead.\n",
+      "WARNING:tensorflow:From /opt/conda/lib/python3.7/site-packages/tensorflow/python/ops/summary_ops_v2.py:1277: stop (from tensorflow.python.eager.profiler) is deprecated and will be removed after 2020-07-01.\n",
+      "Instructions for updating:\n",
+      "use `tf.profiler.experimental.stop` instead.\n",
+      "  2/164 [..............................] - ETA: 4s - loss: 10595.9688 - mae: 10595.9688 - mse: 734189696.0000 - rmse: 26818.1133WARNING:tensorflow:Callbacks method `on_train_batch_end` is slow compared to the batch time (batch time: 0.0089s vs `on_train_batch_end` time: 0.0516s). Check your callbacks.\n",
+      "WARNING:tensorflow:Callbacks method `on_train_batch_end` is slow compared to the batch time (batch time: 0.0089s vs `on_train_batch_end` time: 0.0516s). Check your callbacks.\n",
+      "164/164 [==============================] - 2s 10ms/step - loss: 1954.1333 - mae: 1954.1333 - mse: 105756544.0000 - rmse: 4979.8516 - val_loss: 1160.6403 - val_mae: 1160.6403 - val_mse: 12656630.0000 - val_rmse: 2302.7866\n",
       "Epoch 2/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1642.0222 - mae: 1642.0222 - mse: 96051920.0000 - rmse: 4514.5591 - val_loss: 1085.3497 - val_mae: 1085.3497 - val_mse: 12666133.0000 - val_rmse: 2322.3108\n",
+      "164/164 [==============================] - 1s 6ms/step - loss: 1645.8591 - mae: 1645.8591 - mse: 96317376.0000 - rmse: 4502.5361 - val_loss: 1076.3239 - val_mae: 1076.3239 - val_mse: 12706124.0000 - val_rmse: 2327.9380\n",
       "Epoch 3/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1596.7908 - mae: 1596.7908 - mse: 96331624.0000 - rmse: 4514.3633 - val_loss: 1041.7750 - val_mae: 1041.7750 - val_mse: 13028899.0000 - val_rmse: 2336.2056\n",
+      "164/164 [==============================] - 1s 6ms/step - loss: 1591.9353 - mae: 1591.9353 - mse: 95716584.0000 - rmse: 4484.1812 - val_loss: 1037.9153 - val_mae: 1037.9153 - val_mse: 13057153.0000 - val_rmse: 2334.7791\n",
       "Epoch 4/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1560.9375 - mae: 1560.9375 - mse: 95126792.0000 - rmse: 4462.5308 - val_loss: 1021.7502 - val_mae: 1021.7502 - val_mse: 13083770.0000 - val_rmse: 2327.4673\n",
+      "164/164 [==============================] - 1s 5ms/step - loss: 1552.6449 - mae: 1552.6449 - mse: 94284272.0000 - rmse: 4394.8853 - val_loss: 1022.2657 - val_mae: 1022.2657 - val_mse: 13554695.0000 - val_rmse: 2356.6636\n",
       "Epoch 5/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1542.6259 - mae: 1542.6259 - mse: 94003480.0000 - rmse: 4408.8760 - val_loss: 1018.1912 - val_mae: 1018.1912 - val_mse: 13910818.0000 - val_rmse: 2377.1240\n",
+      "164/164 [==============================] - 1s 6ms/step - loss: 1538.8103 - mae: 1538.8103 - mse: 93561504.0000 - rmse: 4388.4707 - val_loss: 1021.6874 - val_mae: 1021.6874 - val_mse: 14442642.0000 - val_rmse: 2407.8237\n",
       "Epoch 6/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1522.8849 - mae: 1522.8849 - mse: 93518576.0000 - rmse: 4383.8145 - val_loss: 1012.3921 - val_mae: 1012.3921 - val_mse: 13977303.0000 - val_rmse: 2380.1821\n",
+      "164/164 [==============================] - 1s 6ms/step - loss: 1522.9658 - mae: 1522.9658 - mse: 93488752.0000 - rmse: 4358.9893 - val_loss: 1010.1708 - val_mae: 1010.1708 - val_mse: 13987794.0000 - val_rmse: 2377.7764\n",
       "Epoch 7/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1498.6212 - mae: 1498.6212 - mse: 92280416.0000 - rmse: 4310.6851 - val_loss: 1010.1893 - val_mae: 1010.1893 - val_mse: 14495935.0000 - val_rmse: 2406.2073\n",
-      "Epoch 8/10\n",
-      "164/164 [==============================] - 0s 2ms/step - loss: 1490.8345 - mae: 1490.8345 - mse: 91274680.0000 - rmse: 4290.9722 - val_loss: 1011.7308 - val_mae: 1011.7308 - val_mse: 15687941.0000 - val_rmse: 2458.8572\n"
+      "164/164 [==============================] - 1s 5ms/step - loss: 1504.2220 - mae: 1504.2220 - mse: 92140440.0000 - rmse: 4296.6460 - val_loss: 1012.5723 - val_mae: 1012.5723 - val_mse: 14802929.0000 - val_rmse: 2420.7234\n"
      ]
     }
    ],
    "source": [
     "history = model.fit(trainds,\n",
-    "                    validation_data=evalds,\n",
+    "                    validation_data=devds,\n",
     "                    steps_per_epoch=STEPS_PER_EPOCH,\n",
     "                    epochs=N_CHECKPOINTS,\n",
     "                    callbacks=[[tensorboard_callback,\n",
@@ -1410,13 +1457,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1413,
-   "id": "ea61d204",
+   "execution_count": 34,
+   "id": "90ed29d2",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD4CAYAAAAAczaOAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAmWklEQVR4nO3deXxV1b338c/vnAwnIwEyQQIClUEGAY2or16pHazYa9VaVKwV6/Wpz6Otta1aa+1029r21qvex3u97fXVWuUWFUStdhC1tr3Up1gNkDBLERASpjAEEiDTyXr+2DvhEDITsk9yvu/Xa7/OPmsP/A7ib6291tp7m3MOERFJDKGgAxARkf6jpC8ikkCU9EVEEoiSvohIAlHSFxFJIElBB9CV3NxcN2bMmKDDEBEZUFasWLHPOZfXtjzuk/6YMWMoLS0NOgwRkQHFzN5vr1zdOyIiCURJX0QkgSjpi4gkkLjv0xeRxNPY2EhFRQV1dXVBhxL3IpEIxcXFJCcnd2t/JX0RiTsVFRVkZWUxZswYzCzocOKWc479+/dTUVHB2LFju3WMundEJO7U1dUxfPhwJfwumBnDhw/v0RWRkr6IxCUl/O7p6d/ToEz6zjkWv7OD19fvCToUEZG4Mij79JuaHQve2sau6jpmjp5NbmZq0CGJyACTmZlJbW1t0GH0uUHZ0k8Oh3jomhnU1DXxzRfXohfFiIh4BmXSB5hYmMVXPz6Bpet281LZzqDDEZEByjnHPffcw9SpU5k2bRqLFi0CYNeuXcyePZsZM2YwdepU/vKXvxCNRvnc5z7Xuu8jjzwScPQnG5TdOy0+f9E4Xlu3m2+/tJYLxg2ncEgk6JBEpIf++TfrWL/zcJ+ec/LIbL7zySnd2veFF16grKyM8vJy9u3bx3nnncfs2bN5+umnufTSS7n//vuJRqMcPXqUsrIyKisrWbt2LQDV1dV9GndfGLQtfYBwyHjo2hk0RJu59/nV6uYRkR578803uf766wmHwxQUFPChD32Id955h/POO49f/vKXfPe732XNmjVkZWUxbtw4tmzZwh133MHSpUvJzs4OOvyTDOqWPsDY3Azuu+wsvvPyOp59ZwfXzxoddEgi0gPdbZGfLh01FmfPns2yZcv43e9+x4033sg999zD/PnzKS8v59VXX+Wxxx5j8eLFPPHEE/0ccecGdUu/xY0XnMEHzxzOD367nh0HjgYdjogMILNnz2bRokVEo1GqqqpYtmwZs2bN4v333yc/P5/Pf/7z3HLLLaxcuZJ9+/bR3NzMpz/9ab7//e+zcuXKoMM/yaBv6QOEQsZP5k7n0keWcfdz5Tzz+QsIhXTjh4h07VOf+hTLly9n+vTpmBk/+clPKCws5KmnnuLBBx8kOTmZzMxMFixYQGVlJTfffDPNzc0A/OhHPwo4+pNZvPdzl5SUuL56icri0h18bclqvn35ZP7pH7r3nAoR6X8bNmzgrLPOCjqMAaO9vy8zW+GcK2m7b0J077S45txiPjopn39ZupH3qgbfTRciIl1JqKRvZvzo6mmkpYS5a3E5TdHmoEMSEelXCZX0AfKzI3z/yqmU7ajmv5ZtCTocEZF+lXBJH+CT00fyj2eP4N/+sIkNu/r2pg8RkXiWkEkf4PtXTmVIWgpfXVxOQ5O6eUQkMSRs0h+WkcKPrp7Ghl2HefSNvwcdjohIv0jYpA9wyeQC5p5bzH/+eTOrth8MOhwRkdMuoZM+wLc/OZnC7Ah3PVdOXWM06HBEZIDKzMzscNu2bduYOnVqP0bTsYRP+tmRZH4ydzpbqo7w4KvvBh2OiMhplRCPYejKP4zP5cYLzuCJ/7eVSyYXcMG44UGHJCItXvk67F7Tt+csnAaX/bjTXe69917OOOMMbr/9dgC++93vYmYsW7aMgwcP0tjYyA9+8AOuvPLKHv3RdXV13HbbbZSWlpKUlMTDDz/Mhz/8YdatW8fNN99MQ0MDzc3NPP/884wcOZJrr72WiooKotEo3/rWt7juuut6/bNBLf1WX79sEqOHpXPPknJq65uCDkdEAjZv3rzWF6YALF68mJtvvpkXX3yRlStX8qc//Ym77rqrx49sf+yxxwBYs2YNzzzzDDfddBN1dXX87Gc/484776SsrIzS0lKKi4tZunQpI0eOpLy8nLVr1zJnzpxT/l1q6fsyUpP412umc+1/LeeHv9/ADz81LeiQRAS6bJGfLjNnzmTv3r3s3LmTqqoqhg4dyogRI/jKV77CsmXLCIVCVFZWsmfPHgoLC7t93jfffJM77rgDgEmTJnHGGWewadMmLrzwQh544AEqKiq4+uqrGT9+PNOmTePuu+/m3nvv5fLLL+eiiy465d+lln6M88YM4/MXjePpv23nfzZVBR2OiARs7ty5LFmyhEWLFjFv3jwWLlxIVVUVK1asoKysjIKCAurq6np0zo6uDD7zmc/w8ssvk5aWxqWXXsof//hHJkyYwIoVK5g2bRr33Xcf3/ve9075Nynpt/HVSyZwZn4m9y5ZzaGjjUGHIyIBmjdvHs8++yxLlixh7ty5HDp0iPz8fJKTk/nTn/7E+++/3+Nzzp49m4ULFwKwadMmtm/fzsSJE9myZQvjxo3jS1/6EldccQWrV69m586dpKen89nPfpa77767T57Pr6TfRiQ5zMPXTqeqtp5//s26oMMRkQBNmTKFmpoaioqKGDFiBDfccAOlpaWUlJSwcOFCJk2a1ONz3n777USjUaZNm8Z1113Hk08+SWpqKosWLWLq1KnMmDGDjRs3Mn/+fNasWcOsWbOYMWMGDzzwAN/85jdP+Tcl1PP0e+Lh1zfx6Bt/52efPZc5U7vfXycip07P0+8ZPU+/D3zxw2cyZWQ297+4hv219UGHIyLSJ5T0O5CSFOKha6dTU9fE/S+u7fG0LBFJPGvWrGHGjBknLOeff37QYZ1AUzY7Makwm69cMoF/WbqRl8t3cuWMoqBDEkkYzjnMBta7rKdNm0ZZWVm//pk9bZB22dI3syfMbK+ZrY0pm2Fmb5lZmZmVmtmsmG33mdlmM3vXzC6NKT/XzNb42x61AfJf89bZ45g5Oodv/Xotew73bGqWiPROJBJh//79usLugnOO/fv3E4lEun1MlwO5ZjYbqAUWOOem+mWvAY84514xs08AX3POXWxmk4FngFnASOAPwATnXNTM3gbuBN4Cfg886px7pasAgxrIjbWlqpZPPPoXLhg3nF9+7rwB1/oQGWgaGxupqKjo8Rz4RBSJRCguLiY5OfmE8o4Gcrvs3nHOLTOzMW2LgWx/fQiw01+/EnjWOVcPbDWzzcAsM9sGZDvnlvvBLACuArpM+vFgXF4mX58zie/+Zj2L3tnBvFmjgw5JZFBLTk5m7NixQYcxKPV2IPfLwINmtgP4V+A+v7wI2BGzX4VfVuSvty1vl5nd6ncblVZVxcedsfMvHMOF44bz/d+uZ8eBo0GHIyLSK71N+rcBX3HOjQK+AvzCL2+v38N1Ut4u59zjzrkS51xJXl5eL0PsW6GQ8ZO5Z2Nm3LOknOZm9TWKyMDT26R/E/CCv/4cXh8+eC34UTH7FeN1/VT4623LB5RRw9L51uVn8daWAzy1fFvQ4YiI9Fhvk/5O4EP++keAlpfMvgzMM7NUMxsLjAfeds7tAmrM7AJ/1s584KVTiDsw15aM4sMT8/jxKxt5r6o26HBERHqkO1M2nwGWAxPNrMLMbgE+DzxkZuXAD4FbAZxz64DFwHpgKfAF51zLOwhvA34ObAbeY4AM4rZlZvz402cTSQ5z93PlNEWbgw5JRKTb9OydXnqprJI7ny3ja3MmcvvFZwYdjojICfTsnT52xfSRfGJaIY+8vomNuw8HHY6ISLco6feSmfH9K6cyJC2Zry4qp6FJ3TwiEv+U9E/B8MxUHvjUNNbvOsx//PHvXR8gIhIwJf1TdOmUQq4+p4jH/vwe5Tuqgw5HRKRTSvp94DufnEJeZip3PVdOXWO06wNERAKipN8HhqQl85O5Z7N5by0PvfZu0OGIiHRISb+PzJ6Qxw3nj+bnb27l7a0Hgg5HRKRdSvp96BufOItRQ9O5+7lyjtQ3BR2OiMhJlPT7UEZqEv96zXR2HDzKj17ZEHQ4IiInUdLvY7PGDuN//cNYfvXWdpZtio/HQouItFDSPw3u+vhEzszP5N7nV3PoWGPQ4YiItFLSPw0iyWEeumY6e2vq+d5v1gcdjohIKyX902T6qBy+cPEHeH5lBa+t2x10OCIigJL+afXFj4xn8ohsvvHiGg4caQg6HBERJf3TKSUpxMPXTefQsUa++es1xPtjrEVk8FPSP80mFWbzlUsm8Ps1u/nN6l1BhyMiCU5Jvx/cetE4Zo7O4Vu/Xsvew3VBhyMiCUxJvx8khUM8dM106puifP0FdfOISHCU9PvJuLxM7p0ziT9u3Mvi0h1BhyMiCUpJvx/ddOEYLhg3jO/9Zj07DhwNOhwRSUBK+v0oFDIenDsdgK8tWU1zs7p5RKR/Ken3s1HD0vnW5ZNZvmU/C5ZvCzocEUkwSvoBuO68UVw8MY8fL93IlqraoMMRkQSipB8AM+NfPn02qUlh7nqunKi6eUSknyjpB6QgO8L3rpzCqu3VPL5sS9DhiEiCUNIP0BXTR3LZ1EIeeX0TG3cfDjocEUkASvoBMjN+cNVUsiJJfPnZMpau3cUe3bErIqdRUtABJLrhmak8eM3Z3L5wJf/nVysBKMpJY8boHGaOyuGcM4YyZWQ2qUnhgCMVkcHA4v2RACUlJa60tDToME67+qYo63YeZtX2alZuP0jZ9moqq48BkBIOMaUom5mjhjJztFcRjBwSwcwCjlpE4pWZrXDOlZxUrqQfv/YcrmPV9oOs2l7Nqu3VrK6spq6xGYD8rFSvAhg9lJmjhzKtaAhpKboaEBFPR0lf3TtxrCA7wpypI5gzdQQAjdFmNu6qYdWOg6x8/yCrdlTz6ro9ACSFjLNGZDNzdE5rZTB6WLquBkTkBGrpD3D7a+u9K4Ed3hVB+Y5qjjREARiWkdI6LjBzVA5nj8ohM1X1vEgiUEt/kBqemcrHJhfwsckFAESbHZv21LSODazafpA3Nu4FIGQwoSCLmaOHcs7oHGaOHsq43AxCIV0NiCSKLlv6ZvYEcDmw1zk3Nab8DuCLQBPwO+fc1/zy+4BbgCjwJefcq375ucCTQBrwe+BO143LDLX0T1310QbKdlQfHyTeUU1NXRMAQ9KSmTEqx+8WGsqMUTkMSUsOOGIROVWn0tJ/EvgPYEHMyT4MXAmc7ZyrN7N8v3wyMA+YAowE/mBmE5xzUeCnwK3AW3hJfw7wyqn8KOmenPQULp6Yz8UT8wFobnZs2VfLyvePdwv93zf+TksVfGZ+5vFuodE5jM/PIqyrAZFBocuk75xbZmZj2hTfBvzYOVfv77PXL78SeNYv32pmm4FZZrYNyHbOLQcwswXAVSjpByIUMs7Mz+LM/CyuPW8UADV1jayuOMSq7QdZub2aP2zYw3MrKgDITE1i+qghrVNGZ44eyrCMlCB/goj0Um/79CcAF5nZA0AdcLdz7h2gCK8l36LCL2v019uWt8vMbsW7KmD06NG9DFF6IiuSzAfPzOWDZ+YC4Jzj/f1H/XEB74rgp//zXuvD4Ypy0phYmMXEwiwmFWYxoSCLD+RlkpKkm7xF4llvk34SMBS4ADgPWGxm44D2+gBcJ+Xtcs49DjwOXp9+L2OUU2BmjMnNYExuBlefUwzA0YYm1lQcYuX2ajbsOsy7u2tYtqmKJr8iSAoZ4/IymFDgVQQTC7OZWJBF8dA0DRaLxIneJv0K4AV/IPZtM2sGcv3yUTH7FQM7/fLidsplAElPSeL8ccM5f9zw1rKGpma27jvCxt1eJbBpTw1lO6r57epdrftkpIQZX3D8imCSf4UwPDM1iJ8hktB6m/R/DXwE+LOZTQBSgH3Ay8DTZvYw3kDueOBt51zUzGrM7ALgb8B84N9PNXgJXkpSqLWbJ1ZtfROb9tTw7u7jy2vr9/DsO8dfCp+bmeIdW5DNxMJMJhZmM6Egk/QUzSQWOV26/L/LzJ4BLgZyzawC+A7wBPCEma0FGoCb/Fb/OjNbDKzHm8r5BX/mDniDv0/iTdl8BQ3iDmqZqUmcM3oo54we2lrmnKOqtp5Nu2tPuDJ45u3tHGv0/pmYwaih6SeMFUwqzGJsbgZJYY0XiJwq3ZErgWtudmw/cJSNfiXw7u4aNu4+zLb9R1sHjlPCIT6Qn8nEAu+KYFJhFhMKs/TgOZEO6I5ciVuh0PFB4zlTC1vL6xqjvFdV63UP+ZXB37Ye4Ndlx4eDsiJJTCzwKoBJhVlMLPC6mnLSNaVUpD1K+hK3IslhpowcwpSRQ04oP3SskU17arwrA3+84LflO3n6b02t+xRkp/qzhzIZn59FXnYqeZmp5GamMiwjRVNLJWEp6cuAMyQtmfPGDOO8McNay5xz7Dlc3zpW0HJ18NSW/TQ0Nbd7jtzMFHIzU8nNSiU3I2Y9M/X4tsxUPbJaBhUlfRkUzIzCIREKh0RaHzcB0BRtZmd1HVW19exrWWoa2H/k+PqGnYepqq1vfR5RWxkp4dbKYHhGSut6nl8xDG+pJLJSyUpN0hiDxDUlfRnUksIhRg9PZ/Tw9C73rW+Ksr+24YTKYd8R/9Mv27b/CCveP8iBow20NwciJSnkdyOlHK8M/CuG1isKv9LISUvWTWvS75T0RXypSWFG5qQxMiety32bos0cONrQWiHsj6kcvKuKBvYcrmPdzkPsr21ovWs5VjhkDM84Xjnk+RVDXmYqeVmp5Gelkp+dSl5mhOw0XUFI31DSF+mFpHCI/KwI+VmRLvdtbnYcOtboXy3EXEnEdDVV1TawpeoI+2rrqW9nDKLlCiI/26sMvEohcrxy8NdzM1N0P4N0Sklf5DQLhYyhGSkMzUhhfEHn+zrnqKlvoqqmnr2H69lbU0dVTX3rsremnq37jvD21gMcPNp40vFmMCw9xasMsiOtFcXxCuN4RZGht6glJP1XF4kjZkZ2JJnsSDIfyMvsdN+Gpmb21XoVgVch1LH3sNe91PK5eU8NVbX1NEZP7l5KTwmfcJWQlxXbrXS8whiWnqKxh0FESV9kgEpJCnVrDKKle+mEyiHmyqGqpo4Nuw+zbFM9NfUnz2AKh4zczJQTrhJiK4ciP4ah6ckadxgAlPRFBrnY7qW2D8Zr61hD1OtKqj3xqqGlm2nP4TrWVh5iX209bcemI8leJVTkLyNblwjFOekUDonoprg4oKQvIq3SUsLdmuIabXbsP+JVCJXVx9jpL5XVx6isrmPjxr1U1dSfcIwZ5GWmHq8YhqYxckiktXIoykkjR1cLp52Svoj0WDhkrbOXphYNaXef+qYou6rrWiuDndV1VFYfZWd1HRt2HeYPG/acNFMpPSUcUwlETrhiKMpJoyBbVwunSklfRE6L1KRw64P02uOc48CRhtYrhcrqOioP+lcNh46xfuch9tU2nHCMGRRkRRiZE2mtCNp+6p6Gzinpi0ggzIzh/mMszi7OaXefusao33XkXTFUxHQlra08xGvr9tAQPfFqISMl7HUdnVAhRBg5JI2c9BQiySHSksNEUsJEksIkhy2hKgklfRGJW5HkMOPyMhnXwfTV5mbHviP1rZVC5cFjx8cYDh2jfEd1u/czxAqHzKsEksOtFUKaXyFEUsKkJYeIJIdb92nZlpbi7Zvqb2s9ru3+fnlqUiguKhclfREZsEIxYwszRuW0u8/RhqbWSqGmroljjVHq/OVYQ5S6pijHGppPLPe3HTrWyJ5D0dZtLZ/t3ffQHa2VSmslc7yiiK0kWsrv+vgEUpP69imvSvoiMqilpyRxZn4mZ+Z3frNbTzRFm6lravYqjTYVRbvljVHqGptbK5q2FUxdYzMHjzSedMzdH5/YZzG3UNIXEemhpHCIzHCIzAH4KAvNfRIRSSBK+iIiCURJX0QkgSjpi4gkECV9EZEEoqQvIpJAlPRFRBKIkr6ISAJR0hcRSSBK+iIiCURJX0QkgSjpi4gkECV9EZEEoqQvIpJAukz6ZvaEme01s7XtbLvbzJyZ5caU3Wdmm83sXTO7NKb8XDNb42971OLhFTIiIgmmOy39J4E5bQvNbBRwCbA9pmwyMA+Y4h/zn2bW8tqXnwK3AuP95aRziojI6dVl0nfOLQMOtLPpEeBrQOx7w64EnnXO1TvntgKbgVlmNgLIds4td845YAFw1akGLyIiPdOrPn0zuwKodM6Vt9lUBOyI+V7hlxX5623LOzr/rWZWamalVVVVvQlRRETa0eOkb2bpwP3At9vb3E6Z66S8Xc65x51zJc65kry8vJ6GKCIiHejNCx4/AIwFyv2x2GJgpZnNwmvBj4rZtxjY6ZcXt1MuIiL9qMctfefcGudcvnNujHNuDF5CP8c5txt4GZhnZqlmNhZvwPZt59wuoMbMLvBn7cwHXuq7nyEiIt3RnSmbzwDLgYlmVmFmt3S0r3NuHbAYWA8sBb7gnIv6m28Dfo43uPse8Mopxi4iIj1k3mSa+FVSUuJKS0uDDkNEZEAxsxXOuZK25bojV0QkgSjpi4gkECV9EZEEoqQvIpJAlPRFRBKIkr6ISAJR0hcRSSBK+iIiCURJX0QkgSjpi4gkECV9EZEEoqQvIpJAlPRFRBKIkr6ISAJR0hcRSSBK+iIiCURJX0QkgSjpi4gkECV9EZEEoqQvIpJAlPRFRBKIkr6ISAJR0hcRSSBK+iIiCURJX0QkgSjpi4gkECV9EZEEoqQvIpJAlPRFRBKIkr6ISAJR0hcRSSBK+iIiCURJX0QkgSjpi4gkkC6Tvpk9YWZ7zWxtTNmDZrbRzFab2YtmlhOz7T4z22xm75rZpTHl55rZGn/bo2Zmff5rRESkU91p6T8JzGlT9jow1Tl3NrAJuA/AzCYD84Ap/jH/aWZh/5ifArcC4/2l7TlFROQ06zLpO+eWAQfalL3mnGvyv74FFPvrVwLPOufqnXNbgc3ALDMbAWQ755Y75xywALiqj36DiIh0U1/06f8T8Iq/XgTsiNlW4ZcV+etty9tlZreaWamZlVZVVfVBiCIiAqeY9M3sfqAJWNhS1M5urpPydjnnHnfOlTjnSvLy8k4lRBERiZHU2wPN7CbgcuCjfpcNeC34UTG7FQM7/fLidspFRKQf9aqlb2ZzgHuBK5xzR2M2vQzMM7NUMxuLN2D7tnNuF1BjZhf4s3bmAy+dYuwiItJDXbb0zewZ4GIg18wqgO/gzdZJBV73Z16+5Zz7P865dWa2GFiP1+3zBedc1D/VbXgzgdLwxgBeQURE+pUd75mJTyUlJa60tDToMEREBhQzW+GcK2lb3us+/bi39BsQGQIzb4AhxV3vLyKSAAbnYxiam2H/3+HPP4RHpsKvPg3rX4KmhqAjExEJ1OBs6YdCcMNzcHAbrFoIq34Fi+dDei5MnwfnzIe8iUFHKSLS7xKjT785CpvfgFUL4N1XoLkJRp3vJf8pn4KUjL4JVkQkTnTUp58YST9W7V4ofwZW/rfXBZSSBVOvhnNugqJzQM+BE5FBQEm/Ledg+1uwcgGsexGajkH+FDjnRjj7Okgf1vd/pohIP1HS70zdIVj7vNf637kSwikw6XKv+2fsh7wxAhGRASTxpmz2RGQIlPyTt+xe4yX/1Ytg3QuQMxpm3ggzboAhHT4jTkRkQFBLvyONdbDxt7DyKdi6DCwEZ37MqwAmXgbh5P6PSUSkm9TS76nkCEyb6y0HtnrTPssWwuIbISMPpl/vdf/kjg86UhGRblNLvyeiTfDeG97g76al3tTP0Rd6rf8pV2nqp4jEDQ3k9rWaPf7UzwVw4D1v6ue0ud7sn5Ga+ikiwVLSP12cg/f/Cqv+G9b92pv6WTDV6/qZdo2mfopIIJT0+0PdIVizxGv97yqDcCqc9UmvAhhzkaZ+iki/UdLvb7tWe63/1Yu8yiDnDK/rZ8YNkD0y6OhEZJBT0g9K4zHY4E/93PYXf+rnJV7rf8KlmvopIqeFpmwGJTkNzr7GW/a/50/9fBoW3QAZ+TDjepg5H3LPDDpSEUkAaukHIdoEm1/37vzdtBRc1Hvq5xkfhKJzvSV7RNBRisgAppZ+PAkneXf1TrwManZ7Lf/1v4a/PurN/QfIGgnF5x6vBEbOhNSsQMMWkYFPLf140njMe/ZPRSlUrvCWg1v9jQZ5k/xK4BwoLoH8yRoTEJF2qaU/ECSnwahZ3tLi6IHjFUDlCnj391D2K29bUgRGTIeiEq8iKDoXho7RjWEi0iG19Aca57zXQFaugMqVUFkKu8qhqc7bnj78eJdQy6IbxEQSjlr6g4UZDBvrLdPmemXRRti73qsIKvwrgr+/DvgV+tCxXvIvLvE+C6d5VxUiknCU9AeDcLLXzTNiuvdOAID6Gti56ni30PblsHaJty2UBAVT/G4h/2ogd4LuGBZJAEr6g1VqFoyd7S0tDu86cXxgzXNQ+gtvW0oWFM2M6RYq0bRRkUFIST+RZI+A7MvhrMu9783N3svhK1ccnzH0138/cdpoy0yhonNhxAyIZAcWvoicOiX9RBYKQd5Eb5nxGa+ssc6bNloZM21042/9A8zbt6jEu4M4sxCyCvzPQkgbqplDInFOSV9OlByBUed5S4ujB/yZQn4lsGkplO07+dhQMmQWxFQEHXxm5Hk3qIlIv9P/edK19GEw/mPe0qK+Fmr3eHcU1+72XioT+3lgC2z/Kxw72M4JzUv8J1UKhX6lUQiZ+V5ZcqTffqZIIlDSl95JzfSW4R/ofL+mer9y8CuD2PWWz91r4MhecM0nHx8Z0sFVQ2wFUeANXKtrSaRLSvpyeiWlQs5ob+lMcxSO7Gv/qqHGryy2v+V9RutPPj45/cRKIPYzPdeb1hpO9qarxi5ty1q/h73uqpYyVSgySCjpS3wIhb1WfFYBdDZT1Dmoq26nYoj53LMWNr8BDTV9F5+FYiqB2Ioj2Yu9tbJo+71thRJTmZxwrphzh1O8t64ltXz6SzjFX48cX++wzP+uey+kDSV9GVjMvFlCaUMhf1Ln+zYc8a4Sjh6A5kZvKmq00buqOOl7U0xZUwffY5ZoYwdl7Zy7qb6Dc0dPPk+0EaINtN5NfapCySdWBEkxFUpSpE3lktKm8minwmk9j78eTvEqMgt7FYyF/QqypSzs/TdrXY/dHmqnrBvHxONVl3Ne92Sni+vBfv76abhpssukb2ZPAJcDe51zU/2yYcAiYAywDbjWOXfQ33YfcAsQBb7knHvVLz8XeBJIA34P3Oni/cE/MrClZHhjDl2NO8Qb57wKoKneqwCa6mLW6/31+i7K6qCpwS9r+WxT1lTn7Vt3+OSy2PO03LcRLyzkL20rhdiy0IkVUUsZtJNk2yvrIAm3LLQpO13u3wOhvp3M0J2W/pPAfwALYsq+DrzhnPuxmX3d/36vmU0G5gFTgJHAH8xsgnMuCvwUuBV4Cy/pzwFe6asfIjJomB0fg4gHzc0dVyjRBm+7i3pXLi52PepXYNE2Zc2dHOMn0ROOadneHHN87HbXzvnb7NeybhZTaYSA2O9ttp20WDf262Bbj/6cln3M6/LrY12e0Tm3zMzGtCm+ErjYX38K+DNwr1/+rHOuHthqZpuBWWa2Dch2zi0HMLMFwFUo6YvEv1AIQml6SN8g0dvOogLn3C4A/zPfLy8CdsTsV+GXFfnrbcvbZWa3mlmpmZVWVVX1MkQREWmrr4f22xthcZ2Ut8s597hzrsQ5V5KXl9dnwYmIJLreJv09ZjYCwP/c65dXAKNi9isGdvrlxe2Ui4hIP+pt0n8ZuMlfvwl4KaZ8npmlmtlYYDzwtt8FVGNmF5iZAfNjjhERkX7SnSmbz+AN2uaaWQXwHeDHwGIzuwXYDlwD4JxbZ2aLgfVAE/AFf+YOwG0cn7L5ChrEFRHpd3pHrojIINTRO3J1j7aISAJR0hcRSSBx371jZlXA+708PBdo520fcWkgxQoDK96BFCsMrHgHUqwwsOI91VjPcM6dNOc97pP+qTCz0vb6tOLRQIoVBla8AylWGFjxDqRYYWDFe7piVfeOiEgCUdIXEUkggz3pPx50AD0wkGKFgRXvQIoVBla8AylWGFjxnpZYB3WfvoiInGiwt/RFRCSGkr6ISAIZlEnfzOaY2btmttl/s1fcMrMnzGyvma0NOpaumNkoM/uTmW0ws3VmdmfQMXXGzCJm9raZlfvx/nPQMXXFzMJmtsrMfht0LF0xs21mtsbMyswsrp+VYmY5ZrbEzDb6/34vDDqmjpjZRP/vtGU5bGZf7rPzD7Y+fTMLA5uAS/Ae6fwOcL1zbn2ggXXAzGYDtcCClncQxyv/MdojnHMrzSwLWAFcFcd/twZkOOdqzSwZeBPv3cxvBRxah8zsq0AJ3pvmLg86ns74b8Qrcc7F/c1OZvYU8Bfn3M/NLAVId85VBxxWl/x8Vgmc75zr7U2qJxiMLf1ZwGbn3BbnXAPwLN5rHOOSc24ZcCDoOLrDObfLObfSX68BNtDJG9CC5jy1/tdkf4nbVo6ZFQP/CPw86FgGEzPLBmYDvwBwzjUMhITv+yjwXl8lfBicSb+jVzZKH/LfmzwT+FvAoXTK7y4pw3vRz+vOuXiO99+ArwHNAcfRXQ54zcxWmNmtQQfTiXFAFfBLv+vs52aWEXRQ3TQPeKYvTzgYk36PXs0oPWdmmcDzwJedc4eDjqczzrmoc24G3tvaZplZXHahmdnlwF7n3IqgY+mBDzrnzgEuA77gd1XGoyTgHOCnzrmZwBEgrsf6APxuqCuA5/ryvIMx6Xf0ykbpA37f+PPAQufcC0HH013+5fyfgTnBRtKhDwJX+P3kzwIfMbNfBRtS55xzO/3PvcCLeF2r8agCqIi5yluCVwnEu8uAlc65PX150sGY9N8BxpvZWL+mnIf3Gkc5Rf7A6C+ADc65h4OOpytmlmdmOf56GvAxYGOgQXXAOXefc67YOTcG79/sH51znw04rA6ZWYY/mI/fVfJxIC5noDnndgM7zGyiX/RRvLf7xbvr6eOuHejG6xIHGudck5l9EXgVCANPOOfWBRxWh9p7HaVz7hfBRtWhDwI3Amv8fnKAbzjnfh9cSJ0aATzlz4AIAYudc3E/FXKAKABe9NoBJAFPO+eWBhtSp+4AFvoNwS3AzQHH0ykzS8ebgfi/+/zcg23KpoiIdGwwdu+IiEgHlPRFRBKIkr6ISAJR0hcRSSBK+iIiCURJX0QkgSjpi4gkkP8POCHisAvUO6EAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX0AAAD8CAYAAACb4nSYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAk+UlEQVR4nO3de3hV1Z3/8ff3JCc5gSQQIFzDTeUiBEWMaG9obR2x1XqpbWlrdfz501Eca/trrTJ9pnWmddqnndGpo9VxWouMVGEUp04Vbeul6FSLEIMBUaAoEEAJ90sIuX1/f+yd5CQkJIQk5+Scz+t59nP2WXvvk7Xx8fvda+211zZ3R0RE0kMk0RUQEZHeo6AvIpJGFPRFRNKIgr6ISBpR0BcRSSMK+iIiaaTDoG9mo83sJTNba2ZrzOzWsHyQmf3ezNaHnwVxx8wzsw1m9q6ZXRhXfqaZlYfb7jUz65nTEhGRtnTmSr8O+Ja7nwqcA9xsZlOAO4AX3H0C8EL4nXDbHGAqMBv4uZllhL/1AHADMCFcZnfjuYiISAc6DPruvt3dS8P1A8BaYBRwKfBIuNsjwGXh+qXA4+5+xN3fAzYAM81sBJDv7q958ETYgrhjRESkF2Qez85mNg44A/gzMMzdt0OQGMxsaLjbKOD1uMMqwrLacL11+TENGTLEx40bdzzVFBFJeytXrtzp7oWtyzsd9M0sF3gS+Ia77z9Gd3xbG/wY5W39rRsIuoEYM2YMK1as6Gw1RUQEMLNNbZV3avSOmUUJAv5Cd18SFn8YdtkQfu4IyyuA0XGHFwHbwvKiNsqP4u4PuXuJu5cUFh6VqEREpIs6M3rHgF8Ca9397rhNTwPXhOvXAL+JK59jZtlmNp7ghu3ysCvogJmdE/7m1XHHiIhIL+hM987HgK8B5WZWFpb9HfBjYLGZXQdsBr4A4O5rzGwx8DbByJ+b3b0+PO4mYD6QAywNFxER6SWW7FMrl5SUuPr0RdJLbW0tFRUVVFdXJ7oqSS8Wi1FUVEQ0Gm1RbmYr3b2k9f7HNXpHRKQ3VFRUkJeXx7hx49AznO1zd3bt2kVFRQXjx4/v1DGahkFEkk51dTWDBw9WwO+AmTF48ODjahEp6ItIUlLA75zj/XdK2aC/6I3NvPjOh4muhohIUknJoF9b38CC1zbxjcfL2LTrUKKrIyJ9UG5ubqKr0CNSMuhHMyI8eNWZmBl/858rqaqpS3SVRESSQkoGfYDRg/px75fP4N0PDzBvSTnJPjRVRJKTu3PbbbdRXFzMtGnTWLRoEQDbt29n1qxZTJ8+neLiYl555RXq6+v567/+66Z977nnngTX/mgpPWTz3ImFfOuCifzz79YxffRArv1Y54Y0iUjy+If/WcPb2/Z3629OGZnP9y+Z2ql9lyxZQllZGatWrWLnzp2cddZZzJo1i1//+tdceOGFfPe736W+vp6qqirKysrYunUrq1evBmDv3r3dWu/ukLJX+o3mnncKnz51GHc9s5Y33t+d6OqISB/z6quv8uUvf5mMjAyGDRvGueeeyxtvvMFZZ53Fr371K+68807Ky8vJy8vjpJNOYuPGjdxyyy0899xz5OfnJ7r6R0npK32ASMS4+0unc+l9/8vchaU8c8vHGZofS3S1RKSTOntF3lPa6xqeNWsWy5Yt45lnnuFrX/sat912G1dffTWrVq3i+eef5/7772fx4sU8/PDDvVzjY0v5K32A/FiUB686k4PVdcxdWEpNXUOiqyQifcSsWbNYtGgR9fX1VFZWsmzZMmbOnMmmTZsYOnQo119/Pddddx2lpaXs3LmThoYGPv/5z/ODH/yA0tLSRFf/KCl/pd9o0vA8fnLladzy2Jv807NrufNzib16EJG+4fLLL+e1117j9NNPx8z4yU9+wvDhw3nkkUf46U9/SjQaJTc3lwULFrB161auvfZaGhqCC8sf/ehHCa790dJuwrUf/PZtfvnqe9zzpdO5/Iyijg8QkV63du1aTj311ERXo89o69+rvQnX0qJ7J94dF03m7PGDmLekvNtHBIiIJLu0C/rRjAj3fWUGA3OyuPHRleyrqk10lUREek3aBX2Awrxsfn7VDLbvO8w3Fr1JQ0Nyd3GJiHSXtAz6ADPGFPC9S6by0ruV/OyF9YmujohIr0jboA9w1dlj+PyMIn72wnpeWKsZOUUk9aV10Dcz7rq8mKkj8/nGojLe36kZOUUktaV10AeIRTN48KozyYgYNz6qGTlFJLWlfdCHcEbOOZqRU0S67ljz77///vsUFxf3Ym3ap6AfmhXOyPmbsm3M/9P7ia6OiEiPSJtpGDpj7nmnULZlH3c9s5biUQM4a9ygRFdJRJbeAR+Ud+9vDp8GF/34mLvcfvvtjB07lrlz5wJw5513YmYsW7aMPXv2UFtbyw9/+EMuvfTS4/rT1dXV3HTTTaxYsYLMzEzuvvtuPvnJT7JmzRquvfZaampqaGho4Mknn2TkyJF88YtfpKKigvr6ev7+7/+eL33pS10+bdCVfguNM3KOHtSPuQtL+XB/598wLyKpZc6cOU0vTAFYvHgx1157LU899RSlpaW89NJLfOtb3zru7uD7778fgPLych577DGuueYaqqurefDBB7n11lspKytjxYoVFBUV8dxzzzFy5EhWrVrF6tWrmT179gmfl670W2mckfOy+4OpmB+7/hyyMpUbRRKmgyvynnLGGWewY8cOtm3bRmVlJQUFBYwYMYJvfvObLFu2jEgkwtatW/nwww8ZPnx4p3/31Vdf5ZZbbgFg8uTJjB07lnXr1vGRj3yEu+66i4qKCq644gomTJjAtGnT+Pa3v83tt9/OxRdfzCc+8YkTPi9FszY0zsi5ctMe7nrm7URXR0QS5Morr+SJJ55g0aJFzJkzh4ULF1JZWcnKlSspKytj2LBhVFcfX49Aey2Dr3zlKzz99NPk5ORw4YUX8uKLLzJx4kRWrlzJtGnTmDdvHv/4j/94wuekK/12XHL6SFZt2csvXn2P6WMGakZOkTQ0Z84crr/+enbu3Mkf//hHFi9ezNChQ4lGo7z00kts2rTpuH9z1qxZLFy4kPPPP59169axefNmJk2axMaNGznppJP4+te/zsaNG3nrrbeYPHkygwYN4qqrriI3N5f58+ef8Dkp6B/DHRdNpnzrPuYtKWfSsHymjEy+V5+JSM+ZOnUqBw4cYNSoUYwYMYKvfvWrXHLJJZSUlDB9+nQmT5583L85d+5cbrzxRqZNm0ZmZibz588nOzubRYsW8eijjxKNRhk+fDjf+973eOONN7jtttuIRCJEo1EeeOCBEz6ntJtP/3hVHjjCJf/2KtFM43/+9uMM7JeVsLqIpAvNp398NJ9+N2qckfODfdV8Y1GZZuQUkT5NQb8TGmfkfPndSv5VM3KKSDvKy8uZPn16i+Xss89OdLVaUJ9+J1119hhWbdnLvS+s5/SiAXzq1GGJrpJISnN3zCzR1Tgu06ZNo6ysrFf/5vF20etKv5PMjB9eVkzxKM3IKdLTYrEYu3bt0jxYHXB3du3aRSwW6/QxHd7INbOHgYuBHe5eHJZNBx4EYkAdMNfdl4fb5gHXAfXA1939+bD8TGA+kAM8C9zqnfgvmugbua1t2V3FJfe9yvD8GEvmfpR+WWosiXS32tpaKioqjnsMfDqKxWIUFRURjUZblLd3I7czQX8WcBBYEBf0fwfc4+5LzewzwHfc/TwzmwI8BswERgJ/ACa6e72ZLQduBV4nCPr3uvvSjk4o2YI+wLJ1lVzzq+V87vSR/OuXpve5JqiIpL4uj95x92XA7tbFQOOg9QHAtnD9UuBxdz/i7u8BG4CZZjYCyHf318Kr+wXAZV06kyQQPyPnr/73/URXR0Sk07raN/EN4Hkz+2eCxPHRsHwUwZV8o4qwrDZcb13eZzXOyPlPzwYzcs4crxk5RST5dfVG7k3AN919NPBN4JdheVv9HH6M8jaZ2Q1mtsLMVlRWVnaxij1LM3KKSF/U1aB/DbAkXP8vgj58CK7gR8ftV0TQ9VMRrrcub5O7P+TuJe5eUlhY2MUq9rz8WJR//9qZVNXUMXdhKTV1DYmukojIMXU16G8Dzg3Xzwcan1h6GphjZtlmNh6YACx39+3AATM7x4K7nlcDvzmBeieNicM0I6eI9B0d9umb2WPAecAQM6sAvg9cD/zMzDKBauAGAHdfY2aLgbcJhnLe7O714U/dRPOQzaXhkhIuPm0kZZuDGTlPHz2QK2ZoRk4RSU6acK2b1NU38NVf/JmyLXtZMvejTB05INFVEpE0pgnXelhmRoT7vjKDgn5Z3PjoSvZW1SS6SiIiR1HQ70aakVNEkp2CfjebMaaA72tGThFJUgr6PeCrZ4/hyjOLuPeF9byw9sNEV0dEpImCfg/QjJwikqwU9HtILJrBA189k4yI8Tf/uZKqmrpEV0lEREG/J40e1I9755zBuh0HuOPJcs0NLiIJp6Dfw2ZNLOTbfzWJp1dpRk4RSTwF/V5w07knc8GUYfzTs2tZ/l7rWapFRHqPgn4viESMf/ni6YzRjJwikmAK+r0kPxblwXBGzpseXakZOUUkIRT0e1HjjJylm/fyQ83IKSIJoKDfyy4+bST/9+PjWfDaJpaUVnR8gIhIN1LQT4A7LprMOScNYt6SctZs25fo6ohIGlHQTwDNyCkiiaKgnyBDcptn5Lz18TLqNSOniPQCBf0EapyR84/rKvnZH9YlujoikgYU9BOsaUbOFzfwh7c1I6eI9CwF/QSLn5Hzm4s1I6eI9CwF/SSgGTlFpLco6CcJzcgpIr1BQT+JaEZOEelpCvpJpnFGzrueXcufN+5KdHVEJMUo6CeZxhk5xw7qx82/flMzcopIt1LQT0KakVNEeoqCfpKaOCyPn155umbkFJFulZnoCkj7PnvaCMq2jOc/XnmPVRX7mDFmIDPGFHDm2AJGDsxJdPVEpA9S0E9yt8+eTF4syqvrd/LY8s1No3qG58c4I0wCM8YOZOrIAcSiGYmtrIgkPUv28eAlJSW+YsWKRFcjKdTWN7B2+35KN+2hdPNeSjfvoWLPYQCyMiJMHZUfJIEwEYwYoNaASLoys5XuXnJUuYJ+37bjQDWlm/by5uY9lG7ew1sV+zgS3vgdMSDGjDEFQYtgbAFTR+aTnanWgEg6aC/oq3unjxuaF2N28XBmFw8HoKYubA1sDlsDm/bwTPl2IGgNFDe2BsYGLYLhA2KJrL6I9DJd6aeBHfurWySBt7buaxoGOnJAjDPUGhBJObrST2ND82PMLh7B7OIRQNAaeLvp3sAe3ty8t7k1kBmheKRaAyKpqsMrfTN7GLgY2OHuxXHltwB/C9QBz7j7d8LyecB1QD3wdXd/Piw/E5gP5ADPArd6J5oZutLvHR/ur25KAqWb91LeujUQJoAZY4KRQlmZesRDJJmdyJX+fOA+YEHcj30SuBQ4zd2PmNnQsHwKMAeYCowE/mBmE929HngAuAF4nSDozwaWnshJSfcZlh/jomkjuGhac2tgzbZ9TaOE3ty0h2feam4NTBs1oOm5gRljCxiWr9aASF/QYdB392VmNq5V8U3Aj939SLjPjrD8UuDxsPw9M9sAzDSz94F8d38NwMwWAJehoJ+0sjIjYV9/AdcxHoAP9oX3BsIWwSN/2sR/vPIeAKMG5sQ9N1DAlBH5ag2IJKGu9ulPBD5hZncB1cC33f0NYBTBlXyjirCsNlxvXd4mM7uBoFXAmDFjulhF6W7DB8T4zLQRfCZsDRypq2fNtuDewJub97Jy0x5+G7YGshtbA2MLmloEQ9UaEEm4rgb9TKAAOAc4C1hsZicB1sa+fozyNrn7Q8BDEPTpd7GO0sOyMzOaHgZrtH3fYUo37Q3vDexh/v++z0PLgnsDja2BicPymDA0l1OG5jJ2cH+1CER6UVeDfgWwJLwRu9zMGoAhYfnouP2KgG1heVEb5ZJiRgzI4bOn5fDZ09puDZRt2dvUGgDIjBhjB/djwtA8Thmay4RhuZxcGCw5WRo6KtLduhr0/xs4H3jZzCYCWcBO4Gng12Z2N8GN3AnAcnevN7MDZnYO8GfgauDfTrTykvzaag1U1dSxsfIQ63ccYMOOg6z/8CDrdhzg92s/pL4haNiZQVFBTlMyiF/yY9FEnY5In9dh0Dezx4DzgCFmVgF8H3gYeNjMVgM1wDXhVf8aM1sMvE0wlPPmcOQOBDd/5xMM2VyKbuKmrX5ZmRSPGkDxqAEtyo/U1bNpVxXrPzwYJIMwKby6YWeLdwoMy88+KhlMGJrL4Nzs3j4VkT5HT+RK0qtvcLbsrmL9juZk8JcdB1m/4yBVNfVN+xX0izJhaB4nh0mgsbtoeH4Ms7ZuK4mkLj2RK31WRsQYN6Q/44b054Ipw5rK3Z3t+6qbksGGsGWwdPV2HquqbdovNzuTk4fmckphkAQaE0JRQT8yIkoGkl4U9KXPMjNGDsxh5MAczp1Y2FTu7uw6VBN2E4X3DXYc5JX1lTxZ2jxyODszwkmFca0CjSiSNKCgLynHzBiSm82Q3Gw+cvLgFtv2Ha5t0SpYv+MgpZv38PSq5sFkGlEkqUxBX9LKgJwoZ44NXjkZrysjiooKcsiLZZKXHSUvlkluLJP8WLienUlmhloLknwU9EU48RFFbcmJZpAbywwSQyxKXnbjeia5YaLIi9uem93ye14sk5xohm5CS7dS0Bc5huzMDCYOy2PisLwW5XX1DeyuquFgdR0Hqus4eKSOA9W1HAi/B2Vx38PtH+6vDstqORQ38qg9GRFrSga52UFLIjd2jOSR3bw9P0wkubFMomp1SEhBX6QLMjMiDM2LMTSv433bU9/gTcki+GyZOOITycHqOvZXNyeODTuat9fWdzzsOhaNNLUeghZHfMsiSn5OkCQG5IRLv2iL77FoRC2OFKGgL5IgGRFrCqpd5e4cqWtokTB6otWRlREJEkNOcyJokSRygsQRfMZt7xd0aylhJA8FfZE+zMyIRTOIRTMozOv6E8l19Q3sr65j/+Fa9sUt+6vj1g/Xsv9wHfsO17LrYA0bKw+xvzoobzhGYyNikN9OkohPIm0lkryYboh3NwV9ESEzI8Kg/lkM6p913Mc2NDgHa+rYV9WcJOITRFsJZNu+w+w/HCSZmvpj3xDPzW5uQeTHMlsljtaJJEpBvyiD+meRH4sS0cN3R1HQF5ETEokY+bFolybCc3eqaxtaJoWqo5PEvjCJ7D9cy6ZdVU3bqo7RLRUxKOiXxcAwCRT0C5JaQf8sCvpFW3wf1C/4zI+lfleUgr6IJIyZkZOVQU5WBsMHHP9LdmrqGpq6mBqTw96qWnYfqmFPVU3T555DtWzeXUXZlr3sqapp9+Z3RsSaEkJzMohLEOFnUyLpn9Xn7lko6ItIn5WVGWl6+rqz3INRU3sO1QaJoaqGPYfiEkRVbdP3jTsPsntTsF99OzcuMiPWlCDik0Fj66GgX7Tpe+O2/lmJe/5CQV9E0oqZhcNXo4wZ3K9Tx7g7B47UtUgOuw/VsreqpmWr4lAt63ccZG+YPNpLFFkZkTa6ncIWRlxy+OjJg7v9GQsFfRGRDpg137cYO7h/p45paHAOVNexO0wILRNE2JqoCsrf+WB/0MKoqiF+tvt3fjCbaDdP96SgLyLSAyIRY0C/4FmF8UM6lyjqG5z9h2vDbqYaYt0d8VHQFxFJGhnh/YGCLgyd7Sw99SAikkYU9EVE0oiCvohIGlHQFxFJIwr6IiJpREFfRCSNKOiLiKQRBX0RkTSioC8ikkYU9EVE0oiCvohIGlHQFxFJIwr6IiJpREFfRCSNKOiLiKQRBX0RkTTSYdA3s4fNbIeZrW5j27fNzM1sSFzZPDPbYGbvmtmFceVnmll5uO1e60uvjxcRSRGdudKfD8xuXWhmo4ELgM1xZVOAOcDU8Jifm1nj+74eAG4AJoTLUb8pIiI9q8Og7+7LgN1tbLoH+A4Q/7r3S4HH3f2Iu78HbABmmtkIIN/dX3N3BxYAl51o5UVE5Ph0qU/fzD4HbHX3Va02jQK2xH2vCMtGheuty9v7/RvMbIWZraisrOxKFUVEpA3HHfTNrB/wXeB7bW1uo8yPUd4md3/I3UvcvaSwsPB4qygiIu3I7MIxJwPjgVXhvdgioNTMZhJcwY+O27cI2BaWF7VRLiIivei4r/Tdvdzdh7r7OHcfRxDQZ7j7B8DTwBwzyzaz8QQ3bJe7+3bggJmdE47auRr4TfedhoiIdEZnhmw+BrwGTDKzCjO7rr193X0NsBh4G3gOuNnd68PNNwG/ILi5+xdg6QnWXUREjpMFg2mSV0lJia9YsSLR1RAR6VPMbKW7l7Qu1xO5IiJpREFfRCSNKOiLiKQRBX0RkTSioC8ikkYU9EVE0oiCvohIGlHQFxFJIwr6IiJpREFfRCSNKOiLiKQRBX0RkTSioC8ikkYU9EVE0oiCvohIGlHQFxFJIwr6IiJpREFfRCSNKOiLiKQRBX0RkTSioC8ikkYU9EVE0oiCvohIGlHQFxFJIwr6IiJpREFfRCSNKOiLiKQRBX0RkTSioC8ikkYU9EVE0oiCvohIGlHQFxFJIwr6IiJppMOgb2YPm9kOM1sdV/ZTM3vHzN4ys6fMbGDctnlmtsHM3jWzC+PKzzSz8nDbvWZm3X42IiJyTJ250p8PzG5V9nug2N1PA9YB8wDMbAowB5gaHvNzM8sIj3kAuAGYEC6tf1NERHpYh0Hf3ZcBu1uV/c7d68KvrwNF4fqlwOPufsTd3wM2ADPNbASQ7+6vubsDC4DLuukcRESkk7qjT///AEvD9VHAlrhtFWHZqHC9dXmbzOwGM1thZisqKyu7oYoiIgInGPTN7LtAHbCwsaiN3fwY5W1y94fcvcTdSwoLC0+kiiIiEiezqwea2TXAxcCnwi4bCK7gR8ftVgRsC8uL2igXEZFe1KUrfTObDdwOfM7dq+I2PQ3MMbNsMxtPcMN2ubtvBw6Y2TnhqJ2rgd+cYN1FROQ4dXilb2aPAecBQ8ysAvg+wWidbOD34cjL1939RndfY2aLgbcJun1udvf68KduIhgJlENwD2ApIiLSq6y5ZyY5lZSU+IoVKxJdDRGRPsXMVrp7SetyPZErIpJGUjfov7sUtr8FSd6SERHpTV0evZPU3OHZ22DfFhgyEYqvhGlXwuCTE10zEZGESs0rfTO44Y9w8T3Qfyi8/CP4txnw0Hnwp/tgv0aLikh6So8bufu2wpqnYPUTsO1NwGDsx2Da52HKZdBvUHdUVUQkabR3Izc9gn68XX+B8ieCBLBzHUQy4eTzgy6gyZ+B7Lzu+1siIgmioN+aO3xQHgT/1UuC/v/MHJh4YdD/f8oFEI11/98VEekFCvrH0tAAFcuh/L9gzX9D1U7IHgCnXhJ0AY2bBRmpec9bRFKTgn5n1dfBey9D+ZPwzm/hyH7oXwhTLw+6gEbPDG4Ui4gkMQX9rqithvW/C7qA1j0PddUwYAwUXxF0AQ0rVgIQkaSkoH+iqvfDO88ECeAvL4HXQ+Hk4Oq/+Ao9AyAiSUVBvzsd2glv/3fQBbT5T0HZyBnB1f/UKyB/REKrJyKioN9T9lUEo39WPwHbVwEG4z4OxZ+HKZfqGQARSQgF/d6wc33zMwC7NoTPAHwKpn0BJl0E2bmJrqGIpAkF/d7kHlz1Nz4DsH9r8AzApIvCZwA+DZnZia6liKQwBf1EaWiALa8HLYA1T8Hh3RALnwEovhLGz4JIRqJrKSIpRkE/GdTXwsaXgwTwzm+h5mAwIdzUy4MWQNFZGgIqIt2ivaCvx0x7U0YUJlwQLLWHg7H/q5+AlfNh+b/DwDHBDeBpX4BhUxNdWxFJQbrSTwbV+4JnAMr/Czb+MXwG4NRgCojiK2HQ+ETXUET6GHXv9BUHK8NnAJ4I7gVA8AzA6JnBC2EKJwWf/QvVFSQi7VL3Tl+RWwgzrw+WvZuD0T9r/wdKF0BtVfN+sYFhEpgIQyY1rw8cqxvDItIuXen3FQ0NwdDPne8GzwNUhp8734VDlc37ZWTD4FPCZBC/TIBoTuLqLyK9Slf6fV0kAgNHB8spn265rWp3cwLYuQ4q18G2smCaaBqTugU3ipu6iCYELYTCSXpqWCSNKOingn6DYMzZwRKvtjp4Mnjnuualch28/0owY2jT8YPDLqIJYUII1weMDpKNiKQMBf1UFo3B8OJgiddQH7wprLIxGbwbrK99Gkr3NO+XmQNDTml5z2DIpGBGUT1RLNInKeino0gGFIwLlol/1XLboZ1hiyDunsGW5cHzBI0sEhzbeL+gcUTRkImQM7D3zkNEjpuCvrTUf0iwjP1oy/KaKti1Pu4mcpgU/vIi1NfEHT+01T2DMBnkj9IQU5EkoKAvnZPVD0acHizx6utg76ajWwflT8KRfXHH5wajigafDDmDghZBbGAwD1FO+Bn/PStP9xNEeoCCvpyYjMwgkA8+OZhFtJE7HNzR8p7BznWwdSUc3hs8hcwxhgtbBLLz45LCwHYSRMHRCSM2QPccRNqhoC89wwzyhgXL+E8cvb2hAWoONCeA6vAz/nvrbZUfNH+PH33UlsyctlsQHX4fCNl56oqSlKWgL4kRiYQBd0DXjq+tDhNA64Sxt+2EcWA7VL4Tft9Ph62MxrodK0FE+wEWlyDCT7NW67Ra7+wx1sVj6GC/No7JjAUv+cnqH3TFZfWHjCwlvxSkoC99UzQWLHnDjv/YhgY4sr/zLYzDe+HAB83fO2plpIpIZpgE8sLP/s1JoXWCaFpv/b1/uK8SSbJQ0Jf0E4kEV+o5A4Gxx398YyujtoqmFkP8dCZN695yvWlb62O8i8fQwX4d/J34/eqOBO93qDkERw42rzctcWX7K5rLjxyE2kMd/5s1OlYiaZ0gmpa8o/fL6h90w/VEInEHbwieZ/H6uPWG5qXpexvb29zmrb4fa1vcsVMu6/a5tDoM+mb2MHAxsMPdi8OyQcAiYBzwPvBFd98TbpsHXAfUA1939+fD8jOB+UAO8Cxwqyf7xD8ibWlsZUigoSFIgK2TQ9P3xgRxoHOJpHFbZzUlktywy424INrQRgA+1rYGjtn119u++9neD/oEgfo+YEFc2R3AC+7+YzO7I/x+u5lNAeYAU4GRwB/MbKK71wMPADcArxME/dnA0u46ERFJkEgkuELPzgW60N3WlqMSSRuJovH7kbjvtYcI7mtEgmBpEbCMoCUQ/71pPdLGvo3frdW+bWxrfeyxtlkk+Lc6qg5tbGs8NiOre/4943QY9N19mZmNa1V8KXBeuP4I8DJwe1j+uLsfAd4zsw3ATDN7H8h399cAzGwBcBkK+iLSlp5IJAJAV59+Gebu2wHCz6Fh+ShgS9x+FWHZqHC9dXmbzOwGM1thZisqKyvb201ERI5Tdz/y2NbdFD9GeZvc/SF3L3H3ksLCwm6rnIhIuutq0P/QzEYAhJ87wvIKYHTcfkXAtrC8qI1yERHpRV0N+k8D14Tr1wC/iSufY2bZZjYemAAsD7uADpjZOWZmwNVxx4iISC/pzJDNxwhu2g4xswrg+8CPgcVmdh2wGfgCgLuvMbPFwNtAHXBzOHIH4Caah2wuRTdxRUR6nd6RKyKSgtp7R67mrhURSSMK+iIiaSTpu3fMrBLY1MXDhwA7u7E6iZQq55Iq5wE6l2SVKudyoucx1t2PGvOe9EH/RJjZirb6tPqiVDmXVDkP0Lkkq1Q5l546D3XviIikEQV9EZE0kupB/6FEV6Abpcq5pMp5gM4lWaXKufTIeaR0n76IiLSU6lf6IiISJyWDvpnNNrN3zWxD+JKXPsvMHjazHWa2OtF1ORFmNtrMXjKztWa2xsxuTXSdusrMYma23MxWhefyD4mu04kwswwze9PMfpvoupwIM3vfzMrNrMzM+vRj/GY20MyeMLN3wv9nPtJtv51q3TtmlgGsAy4gmN3zDeDL7v52QivWRWY2CzgILGh8XWVfFM7GOsLdS80sD1gJXNYX/7uEkwb2d/eDZhYFXiV4/efrCa5al5jZ/wNKCF50dHGi69NV4cuaSty9z4/RN7NHgFfc/RdmlgX0c/e93fHbqXilPxPY4O4b3b0GeJzgjV59krsvA3Ynuh4nyt23u3tpuH4AWMsxXqSTzDzQ+BLXaLj0yasnMysCPgv8ItF1kYCZ5QOzgF8CuHtNdwV8SM2g397buyRJhK/fPAP4c4Kr0mVhl0gZwbskfu/uffVc/hX4DtCQ4Hp0Bwd+Z2YrzeyGRFfmBJwEVAK/CrvdfmFm/bvrx1Mx6B/XW7qkd5lZLvAk8A1335/o+nSVu9e7+3SCFwLNNLM+1/VmZhcDO9x9ZaLr0k0+5u4zgIuAm8Ou0b4oE5gBPODuZwCHgG67N5mKQb+9t3dJgoX9308CC919SaLr0x3CZvfLwOzE1qRLPgZ8LuwLfxw438weTWyVus7dt4WfO4CnCLp6+6IKoCKu9fgEQRLoFqkY9N8AJpjZ+PAGyByCN3pJAoU3P38JrHX3uxNdnxNhZoVmNjBczwE+DbyT0Ep1gbvPc/cidx9H8P/Ji+5+VYKr1SVm1j8cIEDYFfJXQJ8c8ebuHwBbzGxSWPQpghdTdYsO35zV17h7nZn9LfA8kAE87O5rElytLmvrzWXu/svE1qpLPgZ8DSgP+8IB/s7dn01clbpsBPBIOFIsAix29z493DEFDAOeCq4tyAR+7e7PJbZKJ+QWYGF44boRuLa7fjjlhmyKiEj7UrF7R0RE2qGgLyKSRhT0RUTSiIK+iEgaUdAXEUkjCvoiImlEQV9EJI0o6IuIpJH/D02nQHi6FiIFAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -1435,8 +1482,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1414,
-   "id": "4af66559",
+   "execution_count": 35,
+   "id": "bba697d2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1447,8 +1494,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1415,
-   "id": "837e901a",
+   "execution_count": 36,
+   "id": "709f7383",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1459,13 +1506,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1416,
-   "id": "dabde518",
+   "execution_count": 37,
+   "id": "58f40b3e",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6EAAAEzCAYAAADAagVLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABmwUlEQVR4nO3de5wcVZ338c9vLkyGXEgIEiATBUy8EIQgEdC4GogrrJegAmsUBXZh2fVBxfVCYH1WUZd9ANf7hRWBBRQFJCLRFREJEwRDMGoIhItELskkEWSYwHTMDDPTv+ePOp3UdLp7umf6Ut3zfb9e/Zru01XVp6qrzvS3LqfM3RERERERERGphqZaV0BERERERETGD4VQERERERERqRqFUBEREREREakahVARERERERGpGoVQERERERERqRqFUBEREREREamacR9CzexWMzu91vVoNGZ2oJm5mbXUui4icWbWaWZn1boeUj1qjySp1B6JmZ1hZnfXuh4i2cL/zdmVmn5dhlAzS8UeaTPbEXt9ainTcve/c/drKlXXYpjZk2b2llrWod4lvRE3s2PN7AEz22Zm3WZ2s5nNjL3fGTb2w7PG+0koX1jtOpfCzK42s/+odT2SJmzbO8ysN3z3vzGzfzGzxLa9ao/GTu1Rbak9Kqycv6HC9KoSpLUzqTySvn2Y2cfM7HEze8HMtpjZV+LfeVgHns4qazGzZ8zMa1Pr4ul/7C6J/SFUiLtPyjyAjcA7Y2XXZYZTQ1U+WpbFy7OsHgKOd/epwAHAY8BlWcP8ETgtNp3pwDHAXypT0+Ro8PXrne4+GXgZcDGwFLiytlWqbw2+vpSV2qPSNfr6VexvKCmdReryt3Ut5NnWfgq81t2nAIcChwMfzRpmG/B3sddvA3oqUcekMbPmWtehbNy9rh/Ak8BbwvOFQBfRj7w/A98DpgE/I/rH2ROed8TG7wTOCs/PAO4G/isM+wTwdyXU5XzgT0Av0T/5d2e9/0/Aw7H3XxvqmAZ2ACngvBzTfRh4R+x1C/BsGH8C8H2gm2ij/C0wo4i6Hgg4cDawBdgKfCL2/oXATWHaLwBnAXsR/XjeCmwG/gNoDsM3h+X2LPA4cE6Yfkuez58F/Dh8L93AN2Of+/0c9WyJfUePh2X4BHAq8GqgDxgKy3BbGHYv4NrwGU8B/xdoik3nHuArYbk9DrwhlG8CngFOj9WjLczfRuBp4L+B9nzr3QjLvg34f8BDWevhZ8J0Msv0w0Q/DLuAhXmmdTXwbeDWMO/3APsBXyVahx8BjogN/+rwWduA9cDirGl9C/jfsHxXAy+Pvf8q4HbgOeBR4O9D+dnAAPBiqMNPR9oespb/c2F5PAe8JjbMvkTbxUtyLL9twKGxspeEYfeltG3+Qgqvb3nX+VLbp1jZUUTb/KFFrFt5t321R2qP8qwzC1F7pPZoFG0U0YGJzHLqBm4E9g7v5dy2gYuI1vW+sLy/WeTn/oho/XweuAuYG3uvHfgS0XbyPNHvsnai9d3D56SA12dN84Cw3PeOlR1B1A60ArOBlWGazwI3FFnXzPrxjTDuI8CirO/wojDMjvA5OdfPMPx0YDlRW3Yf8AXg7gKf/0bgN2G5bwLOyF53YvW8Ozw3ovX5mVDndUSBLt/2MdK2WMp2fQCwjGidfwL4aKG2fIRlPx34FfDtWJkTtZ8/ipXdBHwa8BHW9U+FZbGdaFuaEearN3zOtNjwi8Oy2BaWzauzpvXJMK3ngRuACbH33wGsDeP+BjgslOf8H0vh7eFqorb356HenyJq91tiw5wErM0xz8eE6TbHyt4NrAvPjwJWhXpuBb4J7JG1rGePtL4VapMLfr9jabyS8GD3EDoIXEL0j6E9rMAnAXsCk8MX/ZOsxiMeQgeIfpw1Ax8i+kFk4f3zgZ8VqMspRBtfE/DesLLsH3tvM/A6osZhNvCy7HnIM93PANfFXr8deCQ8/2eivUZ7hjofCUwpYrkdGFauHwITgdcQNRiZZXlhWBbvCvPTDvwE+E4Yfl+ixvOfw/D/QtQQzQL2Bu4kz4++UM/7iRrIiUT/3N4Y+9yc/4TDsC8Arwzv7U/YULM3hlB2LXBL+N4PJNqzf2Zs+EHgH0J9/oPoH9y3iNadtxI1SpPC8F8l+qexd5jeT4H/l2+9y7PMX0q0oafDsj0jez0EfknY8RGW7+sZ+Uffs+F7nwCsIGr0T4vN151h2FZgA/BvwB7AcWEeXxmb1nNEjVILcB1wfXhvItE/v38I7702fO7c2Lj/UcL2kFn+HwnTayf6J3dJbPxzCf8gc8z3VcBFsdfnAL8Iz0vZ5i+k8I++n5BnnS+1fcoq3wh8qIh1q9C2r/ZI7ZHaI7VHRbdHI7VRwMeAe4GOsO58B/jhSNs2WT9OQ9nPgPMLfO4/huXRRrQ+r429960wzZnhs94Qhhu2PPJMdwXwT7HXXwT+Ozz/IVFQaSK2nRexjDLrx78SrbfvJQoLe8fmfyMwN6w/e1F4/byeKOBPJAqGm8kTQom2017gfeGzpwPzci13hofQ44HfAVOJ2vhXs2t9v5rY9kFx22Kx23VT+NzPhGkdTLRT7fh8bXme+X4/UfvqRP8LDo+952G5PR3mb2p4figjh9B7iYLnTKKA/nuiHRVtYb4+G4Z9BVEb8bdh+ZwXltEesWndR9Sm7E20c/ZfwnuvDdM+Oiyf08PwbdnbXJHbw9VE69sCdq27DxE7SAbcTGzHbda0/wT8bez1jwjbZvhOjyFaTw8M8/GxrGU9YghlhDY573cylsYrCQ92D6EvEtsbkWP4eUBP7PXOhRoW6IbYe3uGL2C/UdZtLXBieH4bcO5I85Dn/dlEDcKe4fV1wGdiK+7OvSwl1O3AMG+vipVdClwZnl8I3BV7bwbQT6zBIGoU7wzPVxA2wPD6reT/0fd6okYl13sXUvhH3zaif+jtWePt3BjC6+ZQ30NiZf8MdMaGfyz23mvC58yIlXWH9cWIGqOXZ83DE8Wud1l13ZvoKMUx2esh8AGif5SvBP4Y3hvpR993Y68/AjycNV/bwvO/Idoj1hR7/4fAhbFpXRF7723sChfvBX6d9dnfYVeDfTVZP/pG2B7OADZmvX80USOWOTq0hjx70oC3AI/HXt8DnJZn2Hnk3+YLrW8F1/kiv+snyR1C7yX6MTTSupV32y/1gdojtUe5l73ao3HSHuWpz5Ps+g31MMOP8O1PFBhaKLBtkyOElliHqWE+9yL6kb2DWOjItTwKTOssYEV4buE7fFN4fS1wObEj0UXW7wxiByRC2X3AB2Pz//nYe3nXT6K2YIDhbd1/kj+EXgDcnOe9Ycud4aHgOKIdXccQ28ZybR8Uty0Wu10fze7b0gXA/8TW8btyzU+eeZxDdKR4v1iZE/0fuoKoHf0X4LuhzEdY10+NvV4GXJY1Xz8Jz/8duDH2XhPRzoKFsWl9IPb+peza2XEZ8IWsz34UeHP2NjfS9hBb/tdmDbOUsDOYqA3/K2EnQ47p/QdwVXg+mej/x8vyDPux+PpG8SG0YJuc79GI1z38xd37Mi/MbE+iPdwnEJ0WAzDZzJrdfSjH+H/OPHH3v5oZwKRiPtjMTgM+TtRQZsbbJzyfRbQ3omTuvsHMHgbeaWY/JTpF4Ijw9vfCtK83s6lEpzh82t0Hipz8ptjzp4gak1zvvYxob9DWsEwg2igzwxyQY1r5zAKecvfBIusIgLtvN7P3Ep0CcaWZ3UO05+eRHIPvQ7QXLl6Pp4j2fmU8HXu+I3xGdtkkolOr9gR+F5t3I/pnkjFsvRthPp4zs2uA+81sZtZy+DHRaUjdRN9tMbLrnGseIHxH7p6OvZ+9TP4ce/7X2LgvA442s22x91sK1XGE7QGGry+4+2oz2w682cy2Ev1DWZ5n8iuAdjM7OtR5HtGewNFs8/mMtM6PxUyiozwF160Rtv2C1B6pPSpyPtQeRcZzexT/jJvNLP6dDBEF4LFu2zuFa9ouIjo6/RKio/EQfR9tREd6RtU+EZ2W+Q0zO4AowDjw6/DeeUSB5j4z6wG+5O5XFTndzR5+WQdPEa3DGdntU7718yXheSntU8nLwt1XmNk3iY4qv9TMbgY+6e4v5Bi8mG2x2O36ZcABWfPezK7vAEpYZ939MTNbT3Rmwnuy3r6W6NR5IwplxSilfdr5vbh72sw2Ubh9yqwPLwNON7OPxN7fg+Hry04jbA/Ph+fZy+z7wMNmNgn4e6IAuDXX9IEfAL8xsw8RLcPfu/tT4bNfAXwZmE/0f6WF6Eh2qUpukzMDNBrPev0Jor24R7v7n81sHvAHopW2bMzsZUR7YhYBq9x9yMzWxj5nE/DyIuucyw+J9no2EV27swEg/AP4HPA5MzuQ6JzxRym+45NZRKetQXTax5Y89dpEtBd2nzw/1raGaWW8tMBnbiJqFFtyTGs70YaQsV/8TXe/DbjNzNqJ9u58l2gvXvYyfJZob+PLiE5byNRpc4F65fMsUeM0193zjV/MdxjXQnQ61RSiMBJNJNrxcSvRqeD51pfR2gLMMrOm2D+blxLtLR3JJmClu/9tnveHzX8R28Nu4wTXEB19+TNwU74f0uEfwo1E28TTRKel9oa3S9nmC61vI63zo2JmryP6R3Y3xa1bObf9ET5D7ZHao1KoPRqn7VGWTcA/uvs9ed7Pt22Xur69HziR6Ajyk0RHQHuIlsmzRNeXvpzoNPm4ET/H3beZ2S+Jfpi/muh0Yg/v/ZnocivM7I3Ar8zsrmLaVGCmmVksiL6U4TslstunnOtnCByD7N7W5bOJ6JT0XEZqn74OfN3M9iU6/fdTREf4spfjWLbFXPV9wt3nFBhmNO1Trvbn10RH653o/2k526gtxHaCWrTnZxbFtdmbiE7PvyjP+9nzX2h7yDmOu282s1VE13d+kN07losP+5CZPUXUkdP7iUJpxmVE7dH73L3XzD4GnJxnUiO1T4Xa5JzGQw9ek4n+YW8zs72JToeohInsOncdM/sHovPTM64APmlmR4be02aHf4wQ/dM6eITpX090StmHiK1AFnW1/5rQsL1A9EOnlL2r/25me5rZXKJzuW/INVDYw/JL4EtmNsXMmszs5Wb25jDIjcBHzazDzKYRXa+Wz31EPxIvNrOJZjbBzBaE99YCbzKzl5rZXkSncWTmdYaZLTaziUT/jFOxeX0a6DCzPUJ9h0KdLjKzyWFZf5xo71FJQqP8XeAroTHHzGaa2fHFTsPM3mNmrwzL7SVEe57+4O7P5Rj834hO23iy1LqOYDVRI3KembVadJuFdxKtWyP5GfAKM/tgGLfVzF5nZq8O72evwyNtD/l8j6hR/QDRXs5CfkB0CsipDG9US9nm15JnfStinS9JmMY7iJb39939gSLXrZzb/gjUHqk9ykvtkdqjPP6baB19GYCZvcTMTgzPC23bxbQZcZOJtpluoh+1/5l5I6zfVwFfNrMDzKzZzF5vZm1E31+6iM/6AdH1iicxvH06xcw6wsseonWi2PZpX6I2pdXMTiEKuD/PM2ze9TO0BT8GLgxt3SFE1wzmcx3wFjP7e4tuQzLdoh0ZEK0v7wnTmQ2cGZvX15nZ0WbWSrSdZTpLg92/r7Fsi9nuA14ws6Vm1h6+v0Mt2vlaFDM7K9a2HUK0HdyRPVzYIfBOok6USg22I7kReLuZLQrL8BNE6+xvihj3u8C/hOVv4f/K281scng/e/nn3R5GcC3R0f3XEM68KOAHRD0Mv4nomtD4Z78ApMzsVUT/0/NZS571jZHb5JzGQwj9KlEnA88SXYf1i9FOyMz+zaK9wrtx94eITltaRbSCvYboupDM+z8iOtz+A6LrqX5CdB43RKcT/F+L7tn2yTzT3xqm/QaG/zDbj+j0kxeIrudYSfhhY2b/bWb/PcJsrSS62PoO4L/c/ZcFhj2N6JSCh4ga8JuI9kJBtNHdRrTn8vdEjWxOoRF+J9HpTRuJrjF6b3jv9jB/64hOCfhZbNQmooZgC9He+jcD/ye8t4KoF7M/m9mzoewjRA3r40R7yX5A9M9tNJYSLad7zewFol7UXlnC+DOJ1r1e4AGif6TvzjWgu29x97tHWc+83P1FolMn/45oe/g20XVLuU4fzB63lyh0LCFa/n9mV8cnEO0NPySswz8ZaXso8DldROtP/BSqfMNm/nEeQNS7XcZXKXKbH2F9g8LrfLF+ama9RHsKP030g/8fYu8XXLfybftqj9QeofZI7VHp7VEhXyM6uvfL0GbdS3SNHxTYtsN4J5tZj5l9HcDMbjWzf8vzOdcSneq4OczLvVnvf5Jovfwt0bZ1CdH1in8l9EIbvttj8kx/OdGpuE+7e/xo6uuA1WaWCsOc6+5PhPqut8L3SF0dpvlsqMPJ7t6da8Ai1s8PE532+Wei6/3+J9+HuvtGouuhP0G0LNYS3bIEotO8XyRap68hCqwZU4jawR6iZd1N1KM27L59jHpbzFHfTHs6j6jzomeJdnruVcJkFgAPWHQ6/M/DI+e65O7r3X19qfUcibs/SrTz6RtE8/BOolsZvVjEuGuIjrh/k2j5byC6fjIj+3/sSNtDPjcTTqF39+0jDPtDov4CVrj7s7HyTxIdHe0lWl9y7vgN8q5vRazzOWV6fZVxxqLTaZ4AWit4ao9IyczsKmCLu//fWtdFqkPtkSSV2iMxszOIOmR5Y63rIhJnZn8i6iH7V7Wuy2g04jWhIlKnQhh5D0V2viMiUilqj0QkqczsJKKzNFbUui6jNR5OxxWROmBmXwAeBL6YOUVKRKQW1B6JSFKZWSdRp0Ln+PBejeuKTscVERERERGRqtGRUBEREREREakahVARERERERGpGnVMFOyzzz5+4IEHFj389u3bmThxYuUqVAb1UEdQPcupHuoIla/njh072LZtG62trTz11FPPuvtLKvZhVVBK+1Qv60AxNC/JpHkZvXQ6TXd3N4ODg2zZskVtU42pTiNLWn0geXVKWn1gdHXq7e2lt7eXrVu3Vqdtcnc93DnyyCO9FHfeeWdJw9dCPdTRXfUsp3qoo3tl6/nggw/65z73Ob/yyiu9r6/PgTWegDZmLI9S2qd6WQeKoXlJJs3L6KRSKf/2t7/tX/jCF/xPf/qT2qYEUJ1GlrT6uCevTkmrj3vpders7PTPfvazfvPNN1etbdLpuCLSMNavX8+yZcvo6Ojg1FNPpa2t4H2SRUSqYvv27Vx77bV0d3fz/ve/n4MPPrjWVRIRAWDlypXceeedzJs3j8WLF1ftcxVCRaQhKICKSBIpgIpIUmUH0Kam6kVDhVARqXsKoCKSRAqgIpJUtQygoBAqInVOAVREkkgBVESSqtYBFBRCRaSOKYCKSBIpgIpIUiUhgIJCqIjUKQVQEUkiBVARSaqkBFBQCK2K7lQ/92/aRneqv9ZVEWkICqAikkQKoMml32Iy3iUpgAK01PTTx4Fb1m5m6bJ1tDY1MZBOc+lJh7F43sxaV0ukbimAikgSKYAml36LyXiXtAAKOhJaUd2pfpYuW0ffQJre/kH6BtKct2yd9sKJjJICqIgkkQJocum3mIx3SQygoBBaUV09O2jN+qJbm5ro6tlRoxqJ1C8FUBFJIgXQZNNvMRnPkhpAQSG0ojqmtTOQTg8rG0in6ZjWXqMaidQnBVARSaJqBlAzm2pmN5nZI2b2sJm93sz2NrPbzeyx8HdabPgLzGyDmT1qZsfHyo80swfCe183MwvlbWZ2QyhfbWYHVmxmqki/xWS8SnIABYXQipo+qY1LTzqMCa1NTG5rYUJrE5eedBjTJ+kHtEixFEBFJIlqcAT0a8Av3P1VwOHAw8D5wB3uPge4I7zGzA4BlgBzgROAb5tZc5jOZcDZwJzwOCGUnwn0uPts4CvAJZWeoWrQbzEZj1KpVKIDKKhjoopbPG8mC2bvQ1fPDjqmtavREymBAqiIJFG1A6iZTQHeBJwB4O4vAi+a2YnAwjDYNUAnsBQ4Ebje3fuBJ8xsA3CUmT0JTHH3VWG61wLvAm4N41wYpnUT8E0zM3f3is5cFei3mIwnK1eupLe3N9EBFBRCq2L6pDY1eCIlUgAVkSSq0TWgBwN/Af7HzA4HfgecC8xw960A7r7VzPYNw88E7o2N3xXKBsLz7PLMOJvCtAbN7HlgOvBsvCJmdjbRkVRmzJhBZ2dnUTOQSqWKHraSemLPk1KnuKTVKWn1geTVKUn1SaVS9Pb20t7eztSpU7nrrrtqXaW8FEJFJHEUQEUkiWrYCVEL8FrgI+6+2sy+Rjj1Ng/LUeYFyguNM7zA/XLgcoD58+f7woULC1Rjl87OToodtlpUp5ElrT6QvDolpT4rV65kzZo1zJs3j6lTpyaiToUk8/isiIxbCqAikkQ17gW3C+hy99Xh9U1EofRpM9sfIPx9Jjb8rNj4HcCWUN6Ro3zYOGbWAuwFPFf2ORGRssvuhKgeKISKSGIogIpIEtX6Nizu/mdgk5m9MhQtAh4ClgOnh7LTgVvC8+XAktDj7UFEHRDdF07d7TWzY0KvuKdljZOZ1snAika4HlSk0SW9F9x8dDquiCSCAqiIJFGtA2jMR4DrzGwP4HHgH4gOJtxoZmcCG4FTANx9vZndSBRUB4Fz3H0oTOdDwNVAO1GHRLeG8iuB74VOjJ4j6l1XRBKsXgMoKISKSAIogIpIEiUogOLua4H5Od5alGf4i4CLcpSvAQ7NUd5HCLEiknz1HEBBp+OKSI0pgIpIEiUpgIqIxNV7AAWFUBGpIQVQEUkiBVARSapGCKBQwRBqZrPM7E4ze9jM1pvZuaH8QjPbbGZrw+NtsXEuMLMNZvaomR0fKz/SzB4I7309XExPuOD+hlC+2swOjI1zupk9Fh6nIyKJogAqIkmkACoiSdUoARQqe03oIPAJd/+9mU0Gfmdmt4f3vuLu/xUf2MwOIboIfi5wAPArM3tFuJD+MqIbI98L/Bw4gehC+jOBHnefbWZLgEuA95rZ3sBnia6d8PDZy909fo9iEamRvr4+BVARSRwFUBFJqkYKoFDBI6HuvtXdfx+e9wIPAzMLjHIicL2797v7E8AG4Khw36sp7r4qdBV+LfCu2DjXhOc3AYvCUdLjgdvd/bkQPG8nCq6J0p3q5/5N2+hO9de6KiJVs379enp6ehRARSRRFEBFJKkaLYBClXrHDafJHgGsBhYAHzaz04A1REdLe4gC6r2x0bpC2UB4nl1O+LsJwN0Hzex5YHq8PMc48XqdTXSElRkzZtDZ2Vn0PKVSqZKGz/b8jgG6enZgRIdqO6a1s1d766inl8tY61gtqmf5JL2OfX199PT00N7ezn777ceqVatqXSUREQVQEUmsRgygUIUQamaTgGXAx9z9BTO7DPgCUfb6AvAl4B8ByzG6FyhnlOPsKnC/HLgcYP78+b5w4cKC8xLX2dlJKcPHdaf6WXDJCvoGmneWTWgd5J6lb2L6pPIdFRpLHatJ9SyfJNcxfg3ofvvtx7HHHlvrKuVkZv8KnEXUZjxAdC++PYEbgAOBJ4G/z5zeb2YXEF0aMAR81N1vC+VHsutefD8HznV3N7M2ojM6jgS6gfe6+5PVmTsRyaYAKiJJ1agBFCrcO66ZtRIF0Ovc/ccA7v60uw+5exr4LnBUGLwLmBUbvQPYEso7cpQPG8fMWoC9iG6wnG9aidDVs4PWrJWotamJrp4dNaqRSGVld0IU+hZLHDObCXwUmO/uhwLNRNeqnw/c4e5zgDvC6+xr2U8Avm1mmb1LmWvZ54RH5pKAndeyA18hupZdRGognU4rgIpIIjVyAIXK9o5rwJXAw+7+5Vj5/rHB3g08GJ4vB5aEHm8PIvrRdp+7bwV6zeyYMM3TgFti42R6vj0ZWBGuG70NeKuZTTOzacBbQ1kidExrZyCdHlY2kE7TMa29RjUSqZw67AW3BWgPO7b2JNqBFb/+/BqGX5dermvZRaSKtm/fTnd3twKoiCROowdQqOyR0AXAB4Hjsm7Hcmm43co64FjgXwHcfT1wI/AQ8AvgnNAzLsCHgCuIfuD9iahnXIhC7nQz2wB8nHB0wt2fIzrV97fh8flQlgjTJ7Vx6UmHMaG1icltLUxobeLSkw4r66m4IklQbwHU3TcD/wVsBLYCz7v7L4EZYYcY4e++YZR815/PpMhr2YHMtewiUiWZU3AHBwcVQEUkUcZDAIUKXhPq7neT+9rMnxcY5yLgohzla4BDc5T3AafkmdZVwFXF1rfaFs+byYLZ+9DVs4OOae0KoNJw6i2AAoQzJ04EDgK2AT8ysw8UGiVH2WivZc+uy6g6Tkt651Sl0LwkU73PSzqdpru7m6lTpzJx4kQ2btzIxo0ba10tEZFxE0ChSr3jSm7TJ7UpfEpDqscAGrwFeMLd/wJgZj8G3gA8bWb7u/vWcKrtM2H4sVzL3pV1Lfswo+04LcmdU5VK85JM9Twv2Z0Qbdy4sW7nRUQay3gKoFDhjolEZPyp4wAK0Wm4x5jZnuE6zUVE9ziOX39+OsOvSy/XtewiUkHqBVdEkmq8BVDQkVARKaM6D6C4+2ozuwn4PTAI/IHoaOQk4EYzO5MoqJ4Shl9vZplr2QfZ/Vr2q4lu0XIrw69l/164lv05ot51RaSCFEBFJKnGYwAFhVARKZN6D6AZ7v5Z4LNZxf1ER0VzDV+2a9lFpPwUQEUkqcZrAAWdjisiZdAoAVREGosCqIgk1XgOoKAQKiJjpAAqIkmkACoiSTXeAygohIrIGCiAikgSKYCKSFIpgEbG51yLyJgpgIpIEimASi7dqX7u37SN7lR/rasi45gC6C7qmEhESqYAKiJJpAAqudyydjNLl62jtamJgXSaS086jMXzZta6WjLOKIAON77nXkRKpgAqIkmkACq5dKf6WbpsHX0DaXr7B+kbSHPesnU6IipVpQC6Oy0BESmaAqiIJJECqOTT1bOD1qwf/K1NTXT17KhRjWS8UQDNTUtBRIqiACoiSaQAKoV0TGtnIJ0eVjaQTtMxrb1GNZLxRAE0Py0JERmRAqiIJJECqIxk+qQ2Lj3pMCa0NjG5rYUJrU1cetJhTJ+k/2NSWQqghaljIhEpSAFURJJIAVSKtXjeTBbM3oeunh10TGtXAJWKUwAdmUKoiOSlACoiSaQAKqWaPqlN4VOqQgG0OFoqIpKTAqiIJJECqIgklQJo8bRkRGQ3CqAikkQKoCKSVAqgpdHSEZFhFEBFJInGewA1syfN7AEzW2tma0LZ3mZ2u5k9Fv5Oiw1/gZltMLNHzez4WPmRYTobzOzrZmahvM3Mbgjlq83swKrPpEidUgAtnZaQiOykACoiSTTeA2jMse4+z93nh9fnA3e4+xzgjvAaMzsEWALMBU4Avm1mzWGcy4CzgTnhcUIoPxPocffZwFeAS6owPyJ1L5VKKYCOgpaSiAAKoCKSTAqgBZ0IXBOeXwO8K1Z+vbv3u/sTwAbgKDPbH5ji7qvc3YFrs8bJTOsmYFHmKKmI5LZy5Up6e3sVQEdBveOKiAKoiCSSAugwDvzSzBz4jrtfDsxw960A7r7VzPYNw84E7o2N2xXKBsLz7PLMOJvCtAbN7HlgOvBsvBJmdjbRkVRmzJhBZ2dnUZVPpVJFD1stqtPIklYfSE6dUqkUvb29tLe3M3XqVO66665aV2mnpCyjQhRCRcY5BVARSSIF0N0scPctIWjebmaPFBg21xFML1BeaJzhBVH4vRxg/vz5vnDhwoKVzujs7KTYYatFdRpZ0uoDyajTypUrWbNmDfPmzWPq1Kk1r0+2JCyjkeiYscg4pgAqIkmkALo7d98S/j4D3AwcBTwdTrEl/H0mDN4FzIqN3gFsCeUdOcqHjWNmLcBewHOVmBeRepbdCZGMjkKoyDilACoiSaQAujszm2hmkzPPgbcCDwLLgdPDYKcDt4Tny4Elocfbg4g6ILovnLrba2bHhOs9T8saJzOtk4EV4bpREQnUC2756HRckXFIAVREkkgBNK8ZwM2hn6AW4Afu/gsz+y1wo5mdCWwETgFw9/VmdiPwEDAInOPuQ2FaHwKuBtqBW8MD4Erge2a2gegI6JJqzJhIvVAALS+FUJFxRgFURJJIATQ/d38cODxHeTewKM84FwEX5ShfAxyao7yPEGJFZDgF0PLTEhQZRxRARSSJFEBFJKkUQCtDS1FknFAAFZEkUgAVkaRSAK0cLUmRcUABVESSSAFURJJKAbSytDRFGpwCqIgkkQKoiCSVAmjlaYmKNDAFUBFJIgVQEUkqBdDq0FIVaVAKoCKSRAqgIpJUCqDVU7Ela2azzOxOM3vYzNab2bmhfG8zu93MHgt/p8XGucDMNpjZo2Z2fKz8SDN7ILz39XCDZcJNmG8I5avN7MDYOKeHz3jMzE5HZBxRABWRJFIAFZGkUgCtrkou3UHgE+7+auAY4BwzOwQ4H7jD3ecAd4TXhPeWAHOBE4Bvm1lzmNZlwNnAnPA4IZSfCfS4+2zgK8AlYVp7A58FjgaOAj4bD7sijUwBVESSSAFURJJKAbT6KraE3X2ru/8+PO8FHgZmAicC14TBrgHeFZ6fCFzv7v3u/gSwATjKzPYHprj7Knd34NqscTLTuglYFI6SHg/c7u7PuXsPcDu7gqtIw+rr61MAFZHEUQAVkaRSAK2NqizlcJrsEcBqYIa7b4UoqAL7hsFmAptio3WFspnheXb5sHHcfRB4HpheYFoiDWv9+vX09PQogIpIoiiAikhSKYDWTkulP8DMJgHLgI+5+wvhcs6cg+Yo8wLlox0nXreziU7zZcaMGXR2duar225SqVRJw9dCPdQRVM9y6Ovro6enh/b2dvbbbz9WrVpV6yoVlORlKSLlowAqIkmlAFpbFQ2hZtZKFECvc/cfh+KnzWx/d98aTrV9JpR3AbNio3cAW0J5R47y+DhdZtYC7AU8F8oXZo3TmV0/d78cuBxg/vz5vnDhwuxB8urs7KSU4WuhHuoIqudYxa8B3W+//Tj22GNrXaURJXVZikj5KICKSFIpgNZeJXvHNeBK4GF3/3LsreVAprfa04FbYuVLQo+3BxF1QHRfOGW318yOCdM8LWuczLROBlaE60ZvA95qZtNCh0RvDWUiDSW7E6ICZxqIiFSNAqiIJJUCaDJU8kjoAuCDwANmtjaU/RtwMXCjmZ0JbAROAXD39WZ2I/AQUc+657j7UBjvQ8DVQDtwa3hAFHK/Z2YbiI6ALgnTes7MvgD8Ngz3eXd/rkLzOaLuVD9dPTvomNbO9Em6Tk/KQ73gikgSKYCKSFIpgCZHxUKou99N7mszARblGeci4KIc5WuAQ3OU9xFCbI73rgKuKra+lXLL2s0sXbaO1qYmBtJpLj3pMBbPUx9JMjYKoCKSRAqgIpJUCqDJoqVfQd2pfpYuW0ffQJre/kH6BtKct2wd3an+WldN6pgCqIgkkQKoiCSVAmjy6BuooK6eHbRmreStTU109eyoUY2k3imAikgSKYCKSFIpgCaTvoUK6pjWzkA6PaxsIJ2mY1p7jWok9UwBVESSSAFURJJKATS59E1U0PRJbVx60mFMaG1iclsLE1qbuPSkw9Q5kZRMAVREkkgBVESSSgE02Sp6n1CBxfNmsmD2PuodV0ZNAVREkkgBVESSSgE0+fSNVMH0SW0cPmuqAqiUTAG0+sxsqpndZGaPmNnDZvZ6M9vbzG43s8fC32mx4S8wsw1m9qiZHR8rP9LMHgjvfT3c55hwL+QbQvlqMzuwBrMpMiYKoCKSVAqg9UHfikhCKYDWzNeAX7j7q4DDgYeB84E73H0OcEd4jZkdQnR/4rnACcC3zaw5TOcy4GxgTnicEMrPBHrcfTbwFeCSasyUSLmk02kFUBFJJAXQ+qFvRiSBFEBrw8ymAG8CrgRw9xfdfRtwInBNGOwa4F3h+YnA9e7e7+5PABuAo8xsf2CKu69ydweuzRonM62bgEWZo6QiSbd9+3a6u7sVQEUkcRRA64u+HZGEUQCtqYOBvwD/Y2Z/MLMrzGwiMMPdtwKEv/uG4WcCm2Ljd4WymeF5dvmwcdx9EHgemF6Z2REpn8wpuIODgwqgIpIoCqD1Rx0TiSSIAmjNtQCvBT7i7qvN7GuEU2/zyHUE0wuUFxpn+ITNziY6nZcZM2bQ2dlZoBq7pFKpoodNOs1LcqTTabq7u5k6dSoTJ05k48aNbNy4sdbVGrN6/15ERAG0XimEiiSEAmgidAFd7r46vL6JKIQ+bWb7u/vWcKrtM7HhZ8XG7wC2hPKOHOXxcbrMrAXYC3guuyLufjlwOcD8+fN94cKFRc1AZ2cnxQ6bdJqXZMjuhGjjxo11Oy/Z6vl7EREF0Hqmb0okARRAk8Hd/wxsMrNXhqJFwEPAcuD0UHY6cEt4vhxYEnq8PYioA6L7wim7vWZ2TLje87SscTLTOhlYEa4bFUkc9YIrIkmlAFrf9G2J1JgCaOJ8BLjOzNYB84D/BC4G/tbMHgP+NrzG3dcDNxIF1V8A57j7UJjOh4AriDor+hNwayi/EphuZhuAj1P4dF+RmlEATR4zaw7Xq/8svNbto2RcUgCtfzodV6SGFECTx93XAvNzvLUoz/AXARflKF8DHJqjvA84ZWy1FKksBdDEOpfotlFTwuvM7aMuNrPzw+ulWbePOgD4lZm9Iuwky9w+6l7g50S3j7qV2O2jzGwJ0e2j3lu9WRMpTiqVYs2aNQqgdU7fmkiNKICKSBIpgCaTmXUAbyc6wyJDt4+ScWXlypX09vYqgDYAHQkVqQEFUBFJIgXQRPsqcB4wOVY27PZRZha/fdS9seEyt4kaoMjbR5lZ5vZRz8Yr0Ug9d6tOI0tSfVKpFL29vbS3tzN16lTuuuuuWlcJSNYyykhinbIphIpUmQKoiCSRAmhymdk7gGfc/XdmtrCYUXKUleX2UY3Uc7fqNLKk1GflypU7T8GdOnVqIuqUkZRlFJfEOmXTMWyRKlIAFZEkUgBNvAXAYjN7ErgeOM7Mvk+4fRRAGW8fRaHbR4lUW3YnRNIYFEJFqkQBVESSSAE0+dz9AnfvcPcDiTocWuHuH0C3j5IGp15wG5dOxxWpAgVQEUkiBdC6dzFwo5mdCWwk9Lzt7uvNLHP7qEF2v33U1UA7Ua+48dtHfS/cPuo5orArUjMKoI1NIVSkwhRARSSJFEDrk7t3Ap3heTe6fZQ0IAXQxqdvVKSCFEBFJIkUQEUkqRRAxwd9qyIVogAqIkmkACoiSaUAOn7omxWpAAVQEUkiBVARSSoF0PFF365ImSmAikgSKYCKSFIpgI4/+oZFykgBVESSSAFURJJKAXR80rcsUiYKoCKSRAqgIpJUCqDjl75pkTJQABWRJFIAFZGkUgAd3/Rti4yRAqiIJJECqIgklQKo6BsXGQMFUBFJIgVQEUkqBVABhVCRUVMAFYHuVD/3b9pGd6q/1lWRQAFURJJKAVQyWmpdAZF6pAAqAres3czSZetobWpiIJ3m0pMOY/G8mbWu1rimACoiSaUAKnH69kVKpAAqEh0BXbpsHX0DaXr7B+kbSHPesnU6IlpDCqAiklQKoJKtYmuAmV1lZs+Y2YOxsgvNbLOZrQ2Pt8Xeu8DMNpjZo2Z2fKz8SDN7ILz3dTOzUN5mZjeE8tVmdmBsnNPN7LHwOL1S8yjjjwKoSKSrZwetWT8iWpua6OrZUaMajW8KoCKSVAqgkksl14KrgRNylH/F3eeFx88BzOwQYAkwN4zzbTNrDsNfBpwNzAmPzDTPBHrcfTbwFeCSMK29gc8CRwNHAZ81s2nlnz0Zb/r6+hRARYKOae0MpNPDygbSaTqmtdeoRuOXAqiIJJUCqORTsTXB3e8Cnity8BOB6929392fADYAR5nZ/sAUd1/l7g5cC7wrNs414flNwKJwlPR44HZ3f87de4DbyR2GRYq2fv16enp6FEBFgumT2rj0pMOY0NrE5LYWJrQ2celJhzF9kraNalIAFZGkUgCVQmrRMdGHzew0YA3wiRAUZwL3xobpCmUD4Xl2OeHvJgB3HzSz54Hp8fIc44iULHMK7ty5c3nPe96jACoSLJ43kwWz96GrZwcd09oVQKtMAVREkkoBVEZS7RB6GfAFwMPfLwH/CFiOYb1AOaMcZxgzO5voVF9mzJhBZ2dngaoPl0qlShq+FuqhjpDsevb19dHT08PcuXPZY489WLVqVa2rVFCSl2VcvdRTRjZ9UpvCZw0ogIpIUimASjEKhlAz6yV3gDPA3X1KKR/m7k/Hpv1d4GfhZRcwKzZoB7AllHfkKI+P02VmLcBeRKf/dgELs8bpzFOfy4HLAebPn+8LFy7MNVhOnZ2dlDJ8LdRDHSG59Yx3QvSe97yHVatWJbKecUldltkqWc/JkycT+i/LOMLMXmCU7ZZI0iiA1ie1TTIeKIBKsQqGUHefXM4PM7P93X1rePluINNz7nLgB2b2ZeAAog6I7nP3ITPrNbNjgNXAacA3YuOcDqwCTgZWuLub2W3Af8Y6I3orcEE550Man3rBrV+9vb3DXpvZH9x9fo2qI1JWCqD1S22TNDoFUClFSafjmtm+wITMa3ffWGDYHxIdkdzHzLqIeqxdaGbziI6uPgn8c5jOejO7EXgIGATOcfehMKkPEfW02w7cGh4AVwLfM7MNREdAl4RpPWdmXwB+G4b7vLsX20GSiAJo42kxs5dmXhRqt0SSTAG04ahtkoahACqlKiqEmtlious3DwCeAV4GPEx0S5Wc3P19OYqvLDD8RcBFOcrXAIfmKO8DTskzrauAq/J9lkg+CqCNY/ny5XziE58AeA2wkiLaLZGkUgBtHGqbpNEogMpoFLuWfAE4Bvijux8ELALuqVitRGpAAbSx/Pu//zv33nsvQL/aLalnCqCNRW2TNBIFUBmtYteUAXfvBprMrMnd7wTmVa5aItWlANp4WltbmT59OgBqt6ReKYA2HrVN0igUQGUsir0mdJuZTQLuAq4zs2eIrt0UqXsKoI1p6tSppFIpgF7UbkkdUgBtTGqbpBEogMpYFbvGnAjsAP4V+AXwJ+CdlapUPepO9XP/pm10p/prXRUpgQJo47rllltob28H2ITaLakzCqCNS22T1DsFUCmHoo6Euvv22MtrKlSXunXL2s0sXbaO1qYmBtJpLj3pMBbPm1nraskIFEAb28SJE3c+d3e1W1I3FEAbm9omqWcKoFIuRa054V6dL4RHn5kNhRssj3vdqX6WLltH30Ca3v5B+gbSnLdsnY6IJpwCaOObPHkyU6ZMgeiG8Gq3pC4ogDY+tU1SrxRApZyKPRI6Of7azN4FHFWJCtWbrp4dtDY10Ud6Z1lrUxNdPTuYPknBJokUQMeHzI3hMzeEV7slSacAOj6obZJ6pAAq5TaqNcjdfwIcV96q1KeOae0MpNPDygbSaTqmtdeoRlKIAuj4pXZLkkwBdPwqpm0yswlmdp+Z3W9m683sc6F8bzO73cweC3+nxca5wMw2mNmjZnZ8rPxIM3sgvPd1M7NQ3mZmN4Ty1WZ2YEVmWOqOAqhUQlFHQs3sPbGXTcB8wCtSozozfVIbl550GOdlXROqo6DJowA6vvz4xz/OPJ1qZiejdksSSgF0fBll29QPHOfuKTNrBe42s1uB9wB3uPvFZnY+cD6w1MwOAZYAc4EDgF+Z2SvcfQi4DDgbuBf4OXACcCtwJtDj7rPNbAlwCfDess241KVUKsWaNWsUQKXsir1FS7zXtkHgSaIecwVYPG8mC2bvQ1fPDjqmtSuAJpAC6Pjz05/+NPN0KnA8arckgRRAx5/RtE3u7kAqvGwNDw/jLQzl1wCdwNJQfr279wNPmNkG4CgzexKY4u6rAMzsWuBdRCH0RODCMK2bgG+amYXPlnFo5cqV9Pb2KoBKRRQbQq9w93viBWa2AHim/FWqT9MntSl8JpQC6Ph01llnsWDBAq6++uon3f2fQO2WJIsC6Pg02rbJzJqB3wGzgW+5+2ozm+HuWwHcfauZ7RsGn0l0pDOjK5QNhOfZ5ZlxNoVpDZrZ88B04NmsepxNdCSVGTNm0NnZWdR8p1KpooetFtWpcD16e3tpb29n6tSp3HXXXbWu0k5JWUYZSasPJLNO2YoNod8AXltEmUiiKICOXx/5yEf4/e9/n12sdksSQQF0/Bpt2xROpZ1nZlOBm83s0AKDW65JFCgvNE52PS4HLgeYP3++L1y4sEA1duns7KTYYatFdcpt5cqVO0/BnTp1as3rky0JyyguafWBZNYpW8EQamavB94AvMTMPh57awrQXMmKNaruVL9O260SBdDxadWqVfzmN7/hL3/5C1/+8pcBZoT2S+2WJIIC6PhUrrbJ3beZWSfRtZxPm9n+4Sjo/uw6mtoFzIqN1gFsCeUdOcrj43SZWQuwF/BcibMpdS67E6IkHQGVxjLSyd17AJOIwurk2OMF4OTKVq3x3LJ2MwsuWcEHrljNgktWsHzt5lpXqWEpgI5fL774IqlUisHBwcytEJpQuyUJoQA6fo2lbTKzl4QjoJhZO/AW4BFgOXB6GOx04JbwfDmwJPR4exAwB7gvnLrba2bHhF5xT8saJzOtk4EVuh50fFEvuFJNBY+EuvtKYKWZXe3uT1WpTg2pO9XP0mXr6BtI77yn6HnL1rFg9j46IlpmCqDj25vf/Gbe/OY3c8YZZ/Cyl72MCy+8cKu7f67Y8cN1V2uAze7+DjPbG7gBOJCoA5G/d/eeMOwFRD1KDgEfdffbQvmRwNVAO1Hvk+e6u5tZG3AtcCTQDbzX3Z8sw2xLHVAAHd/G2DbtD1wT2qcm4EZ3/5mZrQJuNLMzgY3AKQDuvt7MbgQeIupQ8pxwOi/Ah9jVPt0aHgBXAt8LnRg9R9S7rowTCqBSbcWuYVdk9sABmNk0M7utMlVqTF09O2jN2qBbm5ro6tlRoxo1JgVQyTjrrLPYtm3bztcltFvnAg/HXp9PdAuEOcAd4TVZt0A4Afh2+IEIu26BMCc8TgjlO2+BAHyF6BYIMg6k02kF0AbXnern/k3b6E71FxxuNG2Tu69z9yPc/TB3P9TdPx/Ku919kbvPCX+fi41zkbu/3N1f6e63xsrXhGm83N0/nDna6e597n6Ku89296Pc/fFRLQipOwqgUgvFrmX7uPu2zItwFGDf/INLto5p7Qyk08PKBtJpOqa116hGjUcBVOKeffZZpk6duvN1Me2WmXUAbweuiBWfSHTrA8Lfd8XKr3f3fnd/AsjcAmF/wi0Qwo+7a7PGyUzrJmBR5kbx0ri2b99Od3e3AmgDK+Vym9G0TSKVogAqtVLsmpY2s5dmXpjZgeim7yWZPqmNS086jAmtTUxua2FCaxOXnnSYTsUtEwVQydbU1MTGjRt3vi6y3foqcB4Q32M07BYI7PqxuPN2BkHmVgczKfIWCEDmFgjSoDKn4A4ODiqANqj45Ta9/YP0DaQ5b9m6vEdER9k2iZSdAqjUUrG3aPk0cLeZrQyv30S4R5QUb/G8mSyYvY96xy0zBVDJ5aKLLuKNb3wjwEFm9j1GaLfM7B3AM+7+OzNbWMRHVOwWCKE+DXMvvtGq93lJp9N0d3czdepUJk6cyMaNG4eFj3pV799LXDnmZcfAEB999QBDsT58ms24b9XdtLfu3unte9/7Xl73utdBkW2TSCUogEqtFRVC3f0XZjafqJFcS9STmi5mzKPQbVimT2pT+CwjBVDJ54QTTmDNmjXMmDGjj6hjoZHarQXAYjN7GzABmGJm36dGt0BopHvxjVY9z0t2J0QbN26s23nJVs/fS7ZyzEt3qp9/vWQFfQO7TqCY0NrEPYvfmPP//cKFCznjjDNKaZtEykoBVJKgqLXOzM4i6pDjE+HxPeDCylWrfuk2LNWjACqFXHHFFSxatAhgBkW0W+5+gbt3uPuBRB0OrXD3D6BbIEiJ1Avu+FLq5Taltk0i5aQAKklR7Om45wKvA+5192PN7FVA0bc8GC90G5bqUQCVkXzta1/jt7/9Le3t7S+Osd26GN0CQYqkADo+lXK5TRnbJpGSKIBKkhQbQvvcvc/MMLM2d3/EzF5Z0ZrVocxtWPpifZpkbsOiEFo+CqBSjAkTJjBhwgSAktstd+8EOsPzbmBRnuEuAi7KUb4GODRHeR8hxErjUQAd34q93GYsbZPIaCmAStIUG0K7wn1CfwLcbmY97LrGSQLdhqXyFEClWB0dHZl78W1D7ZZUmAKoFEttk1SbAqgkUbEdE707PL3QzO4k6kzjFxWrVZ3KXBdy3rJ1tDY1MZBO6zYsZaQAKqW4+eabM0+3AP+O2i2pEAVQKYXaJqkmBVBJqmKPhO7k7itHHmr80m1YKkMBVMZC7ZZUigKojIXaJqkkBVBJspJDqIxMt2EpLwVQEUkiBVARSSoFUEk6rZGSaAqgIpJECqAiklQKoFIPtFZKYimAilRed6qf+zdtozvVX+uq1A0FUBFJKgVQqRc6HVcSSQFUpPJuWbuZpVkdqS2eN7PW1Uo0BVARSSoFUKknWjslcRRARSqvO9XP0mXr6BtI09s/SN9AmvOWrdMR0QIUQEUkqRRApd5oDZVEUQAVqY6unh20Zv1IaW1qoqtnR41qlGwKoCKSVAqgUo+0lkpiKICKVE/HtHYG0ulhZQPpNB3T2mtUo+RSABWRpFIAlXpVsTXVzK4ys2fM7MFY2d5mdruZPRb+Tou9d4GZbTCzR83s+Fj5kWb2QHjv62ZmobzNzG4I5avN7MDYOKeHz3jMzE6v1DxK+SiAilTX9EltXHrSYUxobWJyWwsTWpu49KTDdHupLAqgIpJUCqBSzyrZMdHVwDeBa2Nl5wN3uPvFZnZ+eL3UzA4BlgBzgQOAX5nZK9x9CLgMOBu4F/g5cAJwK3Am0OPus81sCXAJ8F4z2xv4LDAfcOB3Zrbc3XsqOK8yBn19fQqgIjWweN5MFszeh66eHXRMa1cAzaIAKiJJpQAq9a5ia6y73wU8l1V8InBNeH4N8K5Y+fXu3u/uTwAbgKPMbH9giruvcncnCrTvyjGtm4BF4Sjp8cDt7v5cCJ63EwVXSaD169fT09OjACpSI9MntXH4rKkKoFkUQEUkqRRApRFU+xYtM9x9K4C7bzWzfUP5TKIjnRldoWwgPM8uz4yzKUxr0MyeB6bHy3OMM4yZnU10lJUZM2bQ2dlZ9IykUqmShq+FpNexr6+Pnp4e2tvb2W+//Vi1alWtq1RQ0pcn1EcdoX7qKeOTAqiIJJUCqDSKpNwn1HKUeYHy0Y4zvND9cuBygPnz5/vChQtHrGhGZ2cnpQxfC0muY/wa0P32249jjz221lUaUZKXZ0Y91BHqp54y/iiAikhSKYBKI6n22vt0OMWW8PeZUN4FzIoN1wFsCeUdOcqHjWNmLcBeRKf/5puWJER2J0ShrykRkZpSABWRpFIAlUZT7TV4OZDprfZ04JZY+ZLQ4+1BwBzgvnDqbq+ZHROu9zwta5zMtE4GVoTrRm8D3mpm00Lvu28NZZIA6gVXRJJIAVREkkoBVBpRxU7HNbMfAguBfcysi6jH2ouBG83sTGAjcAqAu683sxuBh4BB4JzQMy7Ah4h62m0n6hX31lB+JfA9M9tAdAR0SZjWc2b2BeC3YbjPu3t2B0lSAwqgIpJECqAiklQKoNKoKhZC3f19ed5alGf4i4CLcpSvAQ7NUd5HCLE53rsKuKroykrFKYCKSBIpgIpIUimASiPT2iwVpwAqIkmkACoiSaUAKo1Oa7RUlAKoiCSRAqjUEzObZWZ3mtnDZrbezM4N5Xub2e1m9lj4Oy02zgVmtsHMHjWz42PlR5rZA+G9r4c+Nwj9ctwQyleb2YFVn1EBFEBlfNBaLRWjACoiSaQAKnVoEPiEu78aOAY4x8wOAc4H7nD3OcAd4TXhvSXAXOAE4Ntm1hymdRnRPdLnhMcJofxMoMfdZwNfAS6pxozJcKlUSgFUxgWt2VIRCqAikkQKoFKP3H2ru/8+PO8FHgZmAicC14TBrgHeFZ6fCFzv7v3u/gSwATgq3B5viruvCncUuDZrnMy0bgIWZY6SSnWsXLmS3t5eBVAZF7R2S9kpgIpIEimASiMIp8keAawGZoTb2RH+7hsGmwlsio3WFcpmhufZ5cPGcfdB4HlgekVmQnaTOQW3vb1dAVTGhYr1jjtedaf66erZQce0dqZPGn/hSwFURJJIAVQagZlNApYBH3P3FwocqMz1hhcoLzROdh3OJjqdlxkzZtDZ2TlCrSOpVKroYaslKXVKpVI7j4C2tLRw11131bpKOyVlGcUlrU5Jqw8ks07ZFELL6Ja1m1m6bB2tTU0MpNNcetJhLJ43c+QRG4QCqIgkkQKoNAIzayUKoNe5+49D8dNmtr+7bw2n2j4TyruAWbHRO4AtobwjR3l8nC4zawH2IroP+zDufjlwOcD8+fN94cKFRdW/s7OTYoctxVh2/leqTqVYuXIla9as2XkK7l133VXzOsUlYRllS1qdklYfSGadsulYf5l0p/o576Z19A2k6e0fpG8gzXnL1tGd6q911apCAVREkkgBVBpBuDbzSuBhd/9y7K3lwOnh+enALbHyJaHH24OIOiC6L5yy22tmx4RpnpY1TmZaJwMrwnWjiXXL2s0suGQFH7hiNQsuWcHytZtrXaWSqBdcGc90JLRMrlu9kf7B9LCy1qYmunp2NPxpuQqgIpJECqDSQBYAHwQeMLO1oezfgIuBG83sTGAjcAqAu683sxuBh4h61j3H3YfCeB8CrgbagVvDA6KQ+z0z20B0BHRJhedpTLpT/SxdFu387yP6/XXesnUsmL1PXfzuUgCV8U4htAy6U/18687Hdit/cShNx7T2GtSoehRARSSJFEClkbj73eS+ZhNgUZ5xLgIuylG+Bjg0R3kfIcTWg66eHbQ2Ne0MoFA/O/8VQEV0Om5ZdPXsYI/m5t3KP3zs7MQ3hGNRywDanern/k3bxs3pziJSPAVQkcbXMa2dgfTwM9AG0snf+a8AKhLRkdAyyNUQtrUY7z/6pTWqUeXVMoCO9w6gRCQ/BVCR8WH6pDYuPekwzsv6PZDknf8KoCK7KISWQT02hGNR6yOg9XwNiIhUjgKoyPiyeN5MFszepy5ujacAKjKcQmiZ1FNDOBa1vga0nq8BEZHKUQAVaUwj3YJl+qS2xP//VwAV2Z1CaBnVQ0M4FrUOoFC/14CISOUogIo0pvjlNy8OpfnwsbN5/9EvravfWgqgIrlpS5CiJCGAwq5Tnye0NjG5rYUJrU0NfeqziBSmACrSmOKX3/T2D9I/mOZLt/+RN1x8R93cD1QBVCQ/HQmVESUlgGaMl1OfRaQwBVCRxpXr8huA/kGvi74gFEBFClMIlYKSFkAzGv3UZxEpTAFUpLHluvwmI+l9QSiAioxMW4XkldQAKiLjmwKoSOPLXH7T1rL7T9Uk9wWhACpSHG0ZkpMCqIgkkQKoyPixeN5MfnP+cXzib19BW4slvi8IBVCR4ul0XNmNAqiIJJECqMj4M31SGx9ZNIf3H/3SRPcFoQAqUhqFUBlGAVREkkgBVGR8it8n9PBZU2tdnZwUQEVKpxAqOymAikgSKYCKjE/x+4QOpNNcetJhLJ43s9bVGkYBVGR0tKWUSXeqn/s3baM71V/rqoyKAqgImNksM7vTzB42s/Vmdm4o39vMbjezx8LfabFxLjCzDWb2qJkdHys/0sweCO993cwslLeZ2Q2hfLWZHVj1Ga0jCqAi41P2fUL7BtKct2xdon5nKYCKjJ62ljK4Ze1mFlyygg9csZoFl6yom5soZyiAiuw0CHzC3V8NHAOcY2aHAOcDd7j7HOCO8Jrw3hJgLnAC8G0zaw7Tugw4G5gTHieE8jOBHnefDXwFuKQaM1aP0um0AqjIOJW5T2hc5tYsSaAAKjI22mLGqDvVz3k33Z/oPXWFKICK7OLuW9399+F5L/AwMBM4EbgmDHYN8K7w/ETgenfvd/cngA3AUWa2PzDF3Ve5uwPXZo2TmdZNwKLMUVLZZfv27XR3dyuAioxTue4TmpRbsyiAioydtpoxum71RvoHfVhZkvbUFaIAKpJfOE32CGA1MMPdt0IUVIF9w2AzgU2x0bpC2czwPLt82DjuPgg8D0yvyEzkkfTLBzKn4A4ODiqAioxTmfuETmhtKsutWcrV7imAipSHOiYag+5UP9+6c8Nu5S8ODSViT10hCqAi+ZnZJGAZ8DF3f6HAgcpcb3iB8kLjZNfhbKLTeZkxYwadnZ0j1DqSSqUKDvv8jgG6enZg4UM7prWzV3trUdOuhnQ6TXd3N1OnTmXixIls3LiRjRs31rpaYzbS91JPNC9SLYvnzWTB7H3GfGuWcnVwpAAqUj4KoaPQnepnx8AQ67c8zx7NTfQPDj9d5OTXzqpRzYqjACqSn5m1EgXQ69z9x6H4aTPb3923hlNtnwnlXUB8g+8AtoTyjhzl8XG6zKwF2At4Lrse7n45cDnA/PnzfeHChUXVv7Ozk3zDdqf6WXDJCvoGmneWTWgd5J6lb0rEffeyOyHauHFj3nmpN4W+l3qjeZFqmj6pbUztU7yDoz6i32vnLVvHgtn7lDQdBVCR8tIWVKJMJ0RP/GU7/3TtGvoGh3Yb5idhmCR2UKQAKpJfuDbzSuBhd/9y7K3lwOnh+enALbHyJaHH24OIOiC6L5yy22tmx4RpnpY1TmZaJwMrwnWjFZfkjj7UC66IVEI52j0FUJHy05HQEsT3pg250z/oNOU4sW77i1EwzexpS8IRBlAAFSnCAuCDwANmtjaU/RtwMXCjmZ0JbAROAXD39WZ2I/AQUc+657h7Zs/Uh4CrgXbg1vCAKOR+z8w2EB0BXVLhedopqR19KICKSKUUavd6ihhfAVSkMhRCS5DZm5Y5nQMgXeD4RWZPWxJCqAKoyMjc/W5yX7MJsCjPOBcBF+UoXwMcmqO8jxBiqy3T0cd5WddG1bKNUgAVkUoaS7unACpSOQqhJci1N62QJBxhAAVQEdmlXB19lIMCqIjk0p3qL6mNGmn40bR7CqAilVWTEGpmTwK9wBAw6O7zzWxv4AbgQOBJ4O/dvScMfwHRDd6HgI+6+22h/Eh2ne72c+Bcd3czayO6L9+RQDfwXnd/cqz1ju9NazajraWJoXSarH6JaDZobRlbV+LlogAqItnG2tFHOSiAikguhXqyzRU2i+35tpR2TwFUpPJquVUd6+7z3H1+eH0+cIe7zwHuCK8xs0OIrpmaC5wAfNvMMl07XkZ0C4M54XFCKD8T6HH32cBXgEvKVenF82Zyz9LjOOglE/nN+cdx3gmv2m2YIYfv/+NRo+r+u5z6+voUQEUkcRRARSSX7lQ/590U9b3R2z9I30Ca85atozvVv7NjyA9csXpn54/xvjqyhx8tBVCR6kjSlnUicE14fg3wrlj59e7e7+5PABuAo8JtEqa4+6rQs+S1WeNkpnUTsMgK3OivVNMntdHe2sz0SW3sveceOYd5svuv5fq4UVm/fj09PT0KoCKSKAqgIpLPdas37nbbuyaMVX/qzhk21295vqw9fiuAilRPra4JdeCXZubAd8L98GaE2xoQ7sW3bxh2JnBvbNyuUDYQnmeXZ8bZFKY1aGbPA9OBZ+OVGO3N4GHXDa4nD6b5xGsGd3t/8rbH6Oz8U9HTK6e+vj56enpob29nv/32Y9WqVTWpR7Hq5Wbh9VDPeqgj1E89pbwUQEUkn+5UP9+687Hdyv86MMTHbvgDLc27h02wsvX4rQAqUl21CqEL3H1LCJq3m9kjBYbNdQTTC5QXGmd4wShvBg/Db3B9zy0PcO2qjTvfO+31L+Ujb3lN0dMqh8x1Etuf2chdd/2Ejo4O9ttvP4499tiq1mM06uVm4fVQz3qoI9RPPaV8FEBFpJCunh3s0dxM/+DuO/YH0zCYI2zOPWBKWXr8VgAVqb6ahFB33xL+PmNmNwNHAU+b2f7hKOj+wDNh8C5gVmz0DmBLKO/IUR4fp8vMWoC9iO7HVxGfP/E1nHbMgazdtI15s6Yye8bkSn1UTpmL8ptw+geGOHG/l7P01JMTfwRURMYHBVCRsTOzq4B3AM+4+6GhLPGdOharmDsQ7NHcRFvL8LA51h6/FUBFaqPqW5qZTTSzyZnnwFuBB4HlwOlhsNOBW8Lz5cASM2szs4OIOiC6L5y622tmx4TrPU/LGiczrZOBFeG60YqZPWMyJ8+fVfUAGr8o/68DzhBN/PzZvUkNVLUaIlInulP93L9p224dd+QrHysFUJGyuZpdHTBm1EWnjsXI3IFgj+b8XXicu2g23zr1CO5Zetywzh+nT2rj8FlTSw6gqVRKAVSkRmpxJHQGcHPoJ6gF+IG7/8LMfgvcaGZnAhsJN3N39/VmdiPwEDAInOPuQ2FaH2LX3rxbwwPgSuB7ZraB6AjokmrMWFyp97gara6eHTRlnWnc2jz6i/JFpHHlu5VBsbc4KJUCqEj5uPtdZnZgVvGJwMLw/BqgE1hKrFNH4Inwe+iocIu8Ke6+CsDMMp063hrGuTBM6ybgm2Zmld6JH7d43kwO2X8Kb/v63bw4tPtR0W93/okh97K0UStXrqS3t1cBVKRGqh5C3f1x4PAc5d3AojzjXARclKN8DXBojvI+QoithUr9oMtl+zMb6R8YIn5QO3NRfk9FPlFE6lH8rIk+oh93n7xpHQfsNWG38vOWrWPB7H3GtANNAVSkKuqmU8dSOqT74htb2NSzg93zb3S96KaHfscdz/2R5qbR3fgglUrR29tLe3s7U6dO5a677hrVdCohaR33Ja0+kLw6Ja0+kMw6ZatVx0QNK9cPvXL8oMtl/fr1/Op/f8KJ+72cnz+7N63No78oX0QaW1fPDlqbmna2SwAvDqZZ8t17c/Y62dWzY9TtiAKoSM0lrlPHUjqk6071s37LC7ywY4BnU/188bZH2f7i0M73J7e18P2/OYLDZ00tanpxK1euZM2aNcybN4+pU6cmrpO8pHXcl7T6QPLqlLT6QDLrlE0hdIyyT7vN9UNvrD/oclm/fj3Lli2jo6ODpaeezKcHqMrpvyJSn/J1+pGv18nR3OIAFEBFqqxuO3XM55a1mznvpvtptiaGPM1n3jmXoawjouW6DUuSjoCKjDc6AX4Mblm7mQWXrOADV6xmwSUrWL52c84femP5QZdLPICeeuqptLW1jfqifBEZH3Z2+tGye7Pf1mzs0dLE5LYWJrQ2jfpsCgVQkaqr604ds3Wn+vnEjWvpH3T+OjBE/6Dz2Vse5N/ffggTWsfWRqkXXJFk0ZHQURpK+26n3X7qpvv5zfmLynLPqnxyBVARkWLs6vTj17w4tOu3pTUZ//vhN7L9xaFRn02hACpSWWb2Q6JOiPYxsy7gs8DFNFCnjuu3vMBg1gkbg2mYtfee3LP0ON2GRaSBKISO0otD6d1Ou+0fdH6weiMfWTRnTPesykcBVETGavaMyfzXKYfvtqNsLLeXUgAVqTx3f1+etxqiU0eAFQ8/necdZ/qktlH9nlIAFUkmhdBR2qO5if7Bwd3Kv/qrP/L+o1866sYyHwVQESmXsd7cPU4BVETK4bp7n+LqVU/tVt7SBHMP2GtU01QAFUkubY2jlOof3O2UEYAhhyt+/XhZP0sBVETKLXMdOcD9m7bRneoveRoKoCJSDt2pfi5c/mDO99JpuGfDsznfK+Snv+zkR3fcx+y5CqAiSaQjoaOQ6RE37c053//OXY9z1t8cXJYjoQqgIlIJ3al+rlu9kW/d+Rh7NDeXfE9jBVARKZeunh00h8sDsqUp/VZ3F//wV3z3/r/S2vxqfrWumSlztlbsfu0iMjraLTQKXT07ct5MKyPt0cX1Y6UAKiKVcMvazbzh4hV8+fY/0j/o9PYP0jeQ5rxl64o6IqoAKiLl1DGtHd/9lqQ7NZmxfsvzRU3rp7/s5Lv3/5UhmukbspLaNhGpHoXQUYgay8Je2PHimD5DAVREKqE71c/SZevoz3E9QeaexoUogIpIuU2f1MYXTz487w7+v744xD9du4blazcXnM7KlSu57e7f0to8/OdtMW2biFSXQugoTJ/URse0dia0NrHnHrkX4b/eeP+IjWU+CqAiUildPTtozXNt1Ej3NFYAFZFKWTB7n5z3Mc7oH/SCRzQznRAd85o50DT8cqly369dRMZOIXSU9mpv5eNveQX9A2lyXRk6MOR86qbST/9QABWRSuqY1p7zuqu2Fit4T2MFUBGppK6eHTQVutYJaDbLeUQz3gvu+09azKUnHcaE1iYmt7UwobWprPdrF5HyUMdEo/Tc9hf5z18/UnCY5qaosSy24VMAFZFKyXSo1jGtnUtPOmznfUJfHErz4WNn77y1VC4KoCJSaQ9ufp4dAzluOxAzMLT7Ec1ct2Ep522oRKQyFEJHoTvVz5bn+yDnMdBdhtJe9OkfCqAiUim3rN3M0qzQ+bMPv5HtLw6N+ANNAVREKq071c8X/vehEYc7840HDXtd6D6g5b5fu4iUl07HHYWRescFaG02vnhycad/KICKSKV0p/o576Z19A2k6e0fpH8wzZdu/yNv/8aveap7uwKoiNRcoWvVM5qA79+7kQWXrGD52s0FA6iIJJ+OhI5Cx7R23PP3j3vOwoN59f578fqXTx9xWgqgIlJJ163emLMn3EwnH/nuvacAKiLVMnGPZv46MFhwmDTQ2x8N88kb1/Ke1j9wzBEKoCL1SiF0FKZPamOfyW3AUM73v9X5OBAdDf3SKYfnvUGyAqiIVFJ3qp9v3flY3vebzfjp/Vs4+CWTmHvAlJ1hVAFURKrllrWb+eSP7meo8OWgw3h6kAPmvIbFi9+pACpSpxRCR+klk9potr8yVOCGoZkecnMdaVAAFZFK6+rZwR7NzfQP5j7CsP3FIS78aXQdVksTfPnv57FozlQFUBGpiszlAgOFfkzl0tTM+xYvUgAVqWPaeiss00NunAKoiFRDx7R2doxwilvGYBo+9aP7+e//+b4CqIhURVfPDtIFLm8CaDI47fUvZY8maGWQ1ibnv06Zx0um6L6fIvVMR0JHoTvVzwt9g7Q2GUMj7L3L7iFXAVREqsnMgOKOMgwNDbGxezvnflABVEQqb+IezSMeBf3ocbM5Yo8/82LrHzhgzmt43+JFCqAiDUAhtESZWx185NUD9A0VvkVLdg+5CqAiUk1dPTtobrKiT3VLA6ef/A4FUBGpikf+3DviMN9YsYFT9vgDxxxxqK4BFWkgCqEl6E71s3RZdKuDQqePnHj4/px0ZAdzD9hLAVREambiHs30jXDz94gDzgXHdfDaua+odLVERLju3qf49E8eHHG4IXfaZqkTIpFGoxBagsx9rPoo/KNu8eEH8KZX7LvztQKoiNTCFb9+vIihogC6R3MzM/bdd8ShRURGqzvVT1fPDlY/3s1/3vpI0eN9/08tHLlua967DYhI/VEILUHHtHYG0iMfVWhtad7Z0G5/ZiO/+t+fKICKSFVdd+9TXL+mq4ghDTBeHCp831ARkbF4fscAb7h4BWYUeYZGhjHk8Kmb7lf7JNJAFEJLMH1SG5eedBgfv/H+gsP9w//cR1OT0doE/QNDnLjfy1l66sm0tbXtDKcd09rVkIpIRWx4upfPLh/5NLdszRb15q22SUTKqTvVz6aeHfQPFu5LoyA31m95gTe94iXlq5iI1IxOri/R4nkzefe8/QsOM+TRPUL/OuAM0cTPn92b1EDUqdGCS1bwgStWs+CSFSxfu7lKtRaR8eL5HQO87Rt3M1jKgYZg+4tDPLjl+fJXSkTGtfVbnsdHuBXLSPqH0vzTtWv020mkQSiElqg71c+P/7ClpHFam5tYv+WFnZ0a9fYP0jeQ5rxl6+hO9VeopiIy3mTOtHhxNAk0+MLPHlK7JCJl9cKO4u5XPJL+Qf12EmkUCqEl6urZQZF3O9gpuo7Uac3q1a21qYmunh3lq5yIjGvlaE/ULolIuU1pL9/VX2qjRBqDrgkt0b2Pdxc97MQ9mhly59KTDmPuAXvt1qnRQDpNxzTdcFlEymPiHs0Fbx9VDLVLIlJum54rX2hUGyXSGHQktATdqX4uve3Roof/1PGv4J6lx7F43sydnRpNaG1iclsLE1qbuPSkw9QBiIiUzdJlhTtNy6e12dQuiUhFdKf6+cL/PjSmabSojRJpODoSWoL1W55nKF38UYanX+gf1lAunjeTBbP3Ue+4IlJ2G57u5Xcbn2fha4ofp9ng8+86lBPm7qd2SUQqoqtnR4m3ZNnd9WcdTWtLs9ookQaiEFqCzSVeg3Dl3Y9z1t8cPKzBnD6pTQ2oiJTdlXc/XvI4X1tyBO84/AAAtUsiUhHP9vaNafy/n9/B/IOml6k2IpIUDX06rpmdYGaPmtkGMzt/rNO767FnShq+palZF8+LyG7K3TYBLFvTVdLwzU3G61+uH3YiMly526dbH9w66nHPeMPLuPTkw8daBRFJoIYNoWbWDHwL+DvgEOB9ZnbIWKZ564OlhdAh18XzIjJcJdqmDU/38mKJ/RF9/sS5OvopIsNUon26bf3oQmhbSxMfOW7OWD5aRBKsYUMocBSwwd0fd/cXgeuBE6v14S1N8MWTD9ePPBHJVva26S1fuauk4f/tba/i1KNfNpaPFJHGVNb2acPTvfT2l95jd0uT8cWT1QGRSCNr5GtCZwKbYq+7gKMr/aFvnjOdM//m5cw9YIoaTxHJpSZtU8bJr53J2W96ebU+TkTqS1nbp9vW/7nkcVqa4Bfn/g2zZ0we7ceKSB0wH+M95ZLKzE4Bjnf3s8LrDwJHuftHYsOcDZwNMGPGjCOvv/76gtN8YPPzO5/PaIenc1zuecj+U2husjLMwdilUikmTZpU62qMSPUsn3qoI1S3nscee+zv3H1+VT6sCMW0TaG86PapmLYJoluxvGq/KWOcg+qpl/W5GJqXZKrlvCStbYLy/3b6S28/f34h6pioUNsUmzazprWzV3vrGOekOElcl5NWp6TVB5JXp6TVB8ZWp2q1TY18JLQLmBV73QFsiQ/g7pcDlwPMnz/fFy5cmHdi69ev50u/eBqYCBifeM0gX3pg+OL7+pJ5LJo3syyVL4fOzk4KzVNSqJ7lUw91hPqpZ4WM2DZB8e3T9u3b+d2D3+cbXTPJ1zbtNaGZzy2ey7teOyvnNJKqkdYTzUsyNdK8lElZfzv94Gd38qUHBsjXNu29Zwufecch7D1pAuDMPWCvqp5FlsTvP2l1Slp9IHl1Slp9IJl1ytbIIfS3wBwzOwjYDCwB3j+aCa1fv55ly5bxmVd08Pk/7r5X4aiXTuWy0+br9FsRKUbZ2qbt27dz7bXXsmNbN58+7iguWjE8y5782pksed0s3d5ARIpVtvZp5cqV/HHNSt4447Xc/XTzsPf23rOZG/95gU65FRnHGjaEuvugmX0YuA1oBq5y9/WlTicTQDs6Ojj11FP5x7Y2Djz/f3e+/+TFby9fpUWk4ZWrbcoE0O7ubt7//vdz8MEH8543HMJ9q+7md//3jdopJiIlK1f7tHLlSu68807mzZvHZxa/g8f/sp3frb6HU4+eybvnHaAdYyLSuCEUwN1/Dvx8tONnB9C2tuhH3ZMXv53Ozk6ePHVhmWoqIuPJWNumXAEUYPqkNtpbmxVARWTUxto+xQPo4sWLaWpqYvaMyXRNmcBFC19TxpqKSD1r5Fu0jEm+ACoiUkv5AqiISK3lCqAiIrmodchBAVREkkgBVESSSgFUREqhFiKLAqiIJJECqIgklQKoiJRKrUSMAqiIJFE6nVYAFZFEUgAVkdFQSxHs2LFDAVREEqm7u1sBVEQSp7e3VwFUREZFrUWwbds2BVARSaTBwUEFUBFJnN7eXgVQERkVc/da1yERzOwvwFMljLIP8GyFqlMu9VBHUD3LqR7qCNWt58vc/SVV+qyKKLF9qpd1oBial2TSvJSH2qbaU51GlrT6QPLqlLT6wNjqVJW2SSF0lMxsjbvPr3U9CqmHOoLqWU71UEeon3rWo0ZatpqXZNK8yGgkcVmrTiNLWn0geXVKWn0gmXXKpnMnREREREREpGoUQkVERERERKRqFEJH7/JaV6AI9VBHUD3LqR7qCPVTz3rUSMtW85JMmhcZjSQua9VpZEmrDySvTkmrDySzTsPomlARERERERGpGh0JFRERERERkapRCC2RmZ1gZo+a2QYzO79Kn/mkmT1gZmvNbE0o29vMbjezx8LfabHhLwj1e9TMjo+VHxmms8HMvm5mFsrbzOyGUL7azA4ssl5XmdkzZvZgrKwq9TKz08NnPGZmp4+inhea2eawTNea2dtqWU8zm2Vmd5rZw2a23szOTeLyLFDPRC3P8cpq0D6NpNbrdoXmqdnM/mBmP6vneTGzqWZ2k5k9Er6f19fxvPxrWL8eNLMfmtmEep2XRlTJtslq+FskT30S1+aF7eE+M7s/1Olzta5TGCdRbakl7Pe2NVAbnZO761HkA2gG/gQcDOwB3A8cUoXPfRLYJ6vsUuD88Px84JLw/JBQrzbgoFDf5vDefcDrAQNuBf4ulP8f4L/D8yXADUXW603Aa4EHq1kvYG/g8fB3Wng+rcR6Xgh8MsewNaknsD/w2vB8MvDHUJdELc8C9UzU8hyPD2rUPhVRr5qt2xWcp48DPwB+Fl7X5bwA1wBnhed7AFPrcV6AmcATQHt4fSNwRj3OSyM+qHDbRI1+ixSoT+LavDD+pPC8FVgNHFPrbYSEtaUk7Pc2DdJG552/an5YvT/CF3hb7PUFwAVV+NxcG8WjwP7h+f7Ao7nqBNwW6r0/8Eis/H3Ad+LDhOctRDe3tSLrdiDDG/6K1ys+THjvO8D7SqznheQOTTWtZ2zYW4C/TeryzFHPRC/P8fCgRu3TKOpZtXW7QvXvAO4AjmPXD6e6mxdgClFws6zyepyXmcAmoh1ULcDPgLfW47w04qMabRM1+C1SQt0S1eYBewK/B46uZZ1IYFtKgn5v00BtdL6HTsctTeYfXUZXKKs0B35pZr8zs7ND2Qx33woQ/u47Qh1nhufZ5cPGcfdB4Hlg+ijrWo16let7+LCZrbPoVJ7M6Qw1r2c4HeIIoj2ViV2eWfWEhC7PcSTxy6cG63YlfBU4D0jHyupxXg4G/gL8Tzgd7gozm1iP8+Lum4H/AjYCW4Hn3f2X9TgvDaoWbVMivvsktXnh1Ne1wDPA7e5e6zp9leS1pUn6vd0wbXQ+CqGlsRxlXoXPXeDurwX+DjjHzN5UYNh8dSxU92rMVznrVY76Xga8HJhH9KPlS2P4zLLV08wmAcuAj7n7C4UGTVg9E7k8x5lEL58ardtlZWbvAJ5x998VO0qOskTMC9Fe79cCl7n7EcB2olO78knsvISdXicSnYJ2ADDRzD5QaJQ89ar5vDSoJC27qn33SWvz3H3I3ecRHYE8yswOrVWdEtyWJun3dsO00fkohJamC5gVe90BbKn0h7r7lvD3GeBm4CjgaTPbHyD8fWaEOnaF59nlw8YxsxZgL+C5UVa3GvUa8/fg7k+HBjkNfJdomda0nmbWSvQP6zp3/3EoTtzyzFXPJC7PcSixy6eG63a5LQAWm9mTwPXAcWb2/Tqdly6gKxwNAbiJ6AdPPc7LW4An3P0v7j4A/Bh4Q53OSyOqRdtU0+8+yW2eu28DOoETalinRLalCfu93UhtdE4KoaX5LTDHzA4ysz2ILuJdXskPNLOJZjY585zoOpcHw+eeHgY7neiaA0L5ktDj1UHAHOC+cMi+18yOCb1inZY1TmZaJwMrPJwgPgrVqNdtwFvNbFrYA/7WUFa0zAYcvJtomdasnmGaVwIPu/uXY28lannmq2fSluc4VfX2qRg1XrfLyt0vcPcOdz+QaPmucPcP1Om8/BnYZGavDEWLgIfqcV6ITsM9xsz2DHVYBDxcp/PSiGrRNtXsu09im2dmLzGzqeF5O9GOm0dqVacktqVJ+73dYG10bl6li08b5QG8jainsz8Bn67C5x1M1NvV/cD6zGcSnbN9B/BY+Lt3bJxPh/o9SugBK5TPJ9qg/gR8k3DxMTAB+BGwgagHrYOLrNsPiU69HCDam3JmteoF/GMo3wD8wyjq+T3gAWAd0Ua4fy3rCbyR6BSIdcDa8Hhb0pZngXomanmO1wdVbp+KrFNN1+0KztdCdnWmUZfzQnT6/Jrw3fyEqNfpep2XzxH9qH4wtEdt9TovjfioZNtEDX+L5KlP4to84DDgD6FODwKfCeU130ZISFtKAn9v00BtdK5HphIiIiIiIiIiFafTcUVERERERKRqFEJFRERERESkahRCRUREREREpGoUQkVERERERKRqFEJFRERERESkahRCZVwws4Vm9rPwfLGZnV9g2Klm9n9G8RkXmtknx1JPERlf1DaJSFKpfZJKUgiVumZmzaWO4+7L3f3iAoNMBUpuSEVEMtQ2iUhSqX2SJFAIlcQyswPN7BEzu8bM1pnZTWa2p5k9aWafMbO7gVPM7K1mtsrMfm9mPzKzSWH8E8L4dwPviU33DDP7Zng+w8xuNrP7w+MNwMXAy81srZl9MQz3KTP7bajH52LT+rSZPWpmvwJeWcXFIyI1orZJRJJK7ZPUi5ZaV0BkBK8EznT3e8zsKnbtZetz9zea2T7Aj4G3uPt2M1sKfNzMLgW+CxwHbABuyDP9rwMr3f3dYc/gJOB84FB3nwdgZm8F5gBHAQYsN7M3AduBJcARRNvS74HflXf2RSSh1DaJSFKpfZLEUwiVpNvk7veE598HPhqeZxrGY4BDgHvMDGAPYBXwKuAJd38MwMy+D5ydY/rHAacBuPsQ8LyZTcsa5q3h8YfwehJRwzoZuNnd/xo+Y/noZ1NE6ozaJhFJKrVPkngKoZJ0nuf19vDXgNvd/X3xgcxsXo5xR8uA/+fu38n6jI+V8TNEpL6obRKRpFL7JImna0Il6V5qZq8Pz98H3J31/r3AAjObDRCue3gF8AhwkJm9PDZuLncAHwrjNpvZFKCXaE9dxm3AP8aul5hpZvsCdwHvNrN2M5sMvHMsMyoidUVtk4gkldonSTyFUEm6h4HTzWwdsDdwWfxNd/8LcAbwwzDMvcCr3L2P6BSS/w0X1z+VZ/rnAsea2QNE1yTMdfduolNUHjSzL7r7L4EfAKvCcDcBk93990SntqwFlgG/LuN8i0iyqW0SkaRS+ySJZ+46Ii7JZGYHAj9z90NrXRcRkQy1TSKSVGqfpF7oSKiIiIiIiIhUjY6EioiIiIiISNXoSKiIiIiIiIhUjUKoiIiIiIiIVI1CqIiIiIiIiFSNQqiIiIiIiIhUjUKoiIiIiIiIVI1CqIiIiIiIiFTN/wcxOWee/2EpmAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6EAAAEzCAYAAADAagVLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABlG0lEQVR4nO3de5gcZZ33//d3DpmMJGFCkAQyQMDgARCjZAMaHw2iwHoIKqAICu7isuuyiuuBw/rsirI8P8BVV9aFFYUFFAVMRPCAiIQJC4ZAYEMgIBIEkkkikGEC0zEzmZn+/v6ou0NNp7une6YP1T2f13X1Nd13V1XfVV11T3/qcJe5OyIiIiIiIiLV0FTrCoiIiIiIiMjEoRAqIiIiIiIiVaMQKiIiIiIiIlWjECoiIiIiIiJVoxAqIiIiIiIiVaMQKiIiIiIiIlUz4UOomd1mZqfXuh6NxszmmJmbWUut6yISZ2ZdZvapWtdDqkftkSSV2iMxs0+a2T21rodItvB/c26lpl+XIdTMUrFH2sy2x16fWsq03P0v3f3aStW1GGb2jJm9u5Z1qHdJb8TN7Cgze8TMtppZj5ndbGazY+93hY39TVnj/SyUL6p2nUthZteY2b/Wuh5JE7bt7WbWF77735nZ35lZYttetUfjp/aottQeFVbO31BhelUJ0tqZVB5J3z7M7HNm9kcze9nMNpnZt+LfeVgHnssqazGz583Ma1Pr4ul/7CsS+0OoEHefknkA64EPxMquzwynhqp8tCyLl2dZPQYc6+4dwD7Ak8AVWcP8ATgtNp0ZwJHAC5WpaXI0+Pr1AXefCuwPXAycC1xV2yrVtwZfX8pK7VHpGn39KvY3lJTOInX527oW8mxrPwfe4u7TgEOBNwGfzRpmK/CXsdfvBXorUcekMbPmWtehbNy9rh/AM8C7w/NFQDfRj7w/AT8ApgO/IPrH2Rued8bG7wI+FZ5/ErgH+Lcw7NPAX5ZQl/OAp4A+on/yH8p6/2+Ax2PvvyXUMQ1sB1LAOTmm+zjw/tjrFmBLGH8y8EOgh2ijfACYWURd5wAOnAlsAjYDX4i9fwGwJEz7ZeBTwO5EP543AxuBfwWaw/DNYbltAf4InBWm35Ln8/cFfhq+lx7gO7HP/WGOerbEvqM/hmX4NHAq8AagHxgOy3BrGHZ34LrwGc8C/xdoik3nXuBbYbn9EXhbKN8APA+cHqtHW5i/9cBzwH8B7fnWu1GWfRvw/wGPZa2H/xKmk1mm/0D0w7AbWJRnWtcAlwO3hXm/F5gF/DvROvx74M2x4d8QPmsrsBZYnDWt/wR+GZbvSuA1sfdfD9wBvAg8AXwklJ8JDAI7Qh1+Ptr2kLX8XwzL40XgjbFh9iLaLl6dY/ltBQ6Nlb06DLsXpW3zF1B4fcu7zpfaPsXKFhBt84cWsW7l3fbVHqk9yrPOLELtkdqjMbRRRAcmMsupB7gJ2CO8l3PbBi4iWtf7w/L+TpGf+xOi9fMl4G7gkNh77cA3iLaTl4h+l7UTre8ePicFvDVrmvuE5b5HrOzNRO1AKzAXWB6muQW4sci6ZtaP/wjj/h44Ous7vCgMsz18Ts71Mww/A7iVqC27H7gQuKfA578d+F1Y7huAT2avO7F63hOeG9H6/Hyo8xqiQJdv+xhtWyxlu94HWEq0zj8NfLZQWz7Ksp8B/Ba4PFbmRO3nT2JlS4AvAz7Kuv6lsCy2EW1LM8N89YXPmR4bfnFYFlvDsnlD1rS+GKb1EnAjMDn2/vuB1WHc3wGHhfKc/2MpvD1cQ9T2/irU+0tE7X5LbJgTgNU55vnIMN3mWNmHgDXh+QJgRajnZuA7wKSsZT13tPWtUJtc8PsdT+OVhAe7htAh4BKifwztYQU+AXgVMDV80T/LajziIXSQ6MdZM/Bpoh9EFt4/D/hFgbqcRLTxNQEfDSvL3rH3NgJ/QdQ4zAX2z56HPNP9F+D62Ov3Ab8Pz/+WaK/Rq0KdDwemFbHc5oSV68fAbsAbiRqMzLK8ICyLD4b5aQd+Bnw3DL8XUeP5t2H4vyNqiPYF9gDuIs+PvlDPh4kayN2I/rm9Pfa5Of8Jh2FfBl4X3tubsKFmbwyh7DrglvC9zyHas39GbPgh4K9Cff6V6B/cfxKtO8cQNUpTwvD/TvRPY48wvZ8D/1++9S7PMt+PaENPh2X7yez1EPgNYcdHWL5vZfQffVvC9z4ZWEbU6J8Wm6+7wrCtwDrgn4BJwLvCPL4uNq0XiRqlFuB64Ibw3m5E//z+Krz3lvC5h8TG/dcStofM8v9MmF470T+5S2Ljn034B5ljvq8GLoq9Pgv4dXheyjZ/AYV/9P2MPOt8qe1TVvl64NNFrFuFtn21R2qP1B6pPSq6PRqtjQI+B9wHdIZ157vAj0fbtsn6cRrKfgGcV+Bz/zosjzai9Xl17L3/DNOcHT7rbWG4Ecsjz3SXAX8Te/114L/C8x8TBZUmYtt5Ecsos378I9F6+1GisLBHbP7XA4eE9Wd3Cq+fNxAF/N2IguFG8oRQou20D/hY+OwZwLxcy52RIfRY4EGgg6iNfwOvrO/XENs+KG5bLHa7bgqf+y9hWgcS7VQ7Nl9bnme+TyFqX53of8GbYu95WG7PhfnrCM8PZfQQeh9R8JxNFNAfItpR0Rbm6yth2NcStRHvCcvnnLCMJsWmdT9Rm7IH0c7ZvwvvvSVM+4iwfE4Pw7dlb3NFbg/XEK1vC3ll3X2M2EEy4GZiO26zpv0U8J7Y658Qts3wnR5JtJ7OCfPxuaxlPWoIZZQ2Oe93Mp7GKwkPdg2hO4jtjcgx/DygN/Z650INC3Rd7L1XhS9g1hjrtho4Pjy/HTh7tHnI8/5cogbhVeH19cC/xFbcnXtZSqjbnDBvr4+VXQpcFZ5fANwde28mMECswSBqFO8Kz5cRNsDw+hjy/+h7K1Gjkuu9Cyj8o28r0T/09qzxdm4M4XVzqO/BsbK/Bbpiwz8Ze++N4XNmxsp6wvpiRI3Ra7Lm4eli17usuu5BdJTiyOz1EPg40T/K1wF/CO+N9qPve7HXnwEez5qvreH5/yHaI9YUe//HwAWxaX0/9t57eSVcfBT4n6zP/i6vNNjXkPWjb5Tt4ZPA+qz3jyBqxDJHh1aRZ08a8G7gj7HX9wKn5Rl2Hvm3+ULrW8F1vsjv+hlyh9D7iH4MjbZu5d32S32g9kjtUe5lr/ZogrRHeerzDK/8hnqckUf49iYKDC0U2LbJEUJLrENHmM/diX5kbycWOnItjwLT+hSwLDy38B2+I7y+DriS2JHoIuv3SWIHJELZ/cAnYvP/tdh7eddPorZgkJFt3f8jfwg9H7g5z3sjljsjQ8G7iHZ0HUlsG8u1fVDctljsdn0Eu25L5wP/HVvH7841P3nm8SCiI8WzYmVO9H/o+0Tt6N8B3wtlPsq6fmrs9VLgiqz5+ll4/s/ATbH3moh2FiyKTevjsfcv5ZWdHVcAF2Z99hPAO7O3udG2h9jyvy5rmHMJO4OJ2vA/E3Yy5JjevwJXh+dTif5/7J9n2M/F1zeKD6EF2+R8j0a87uEFd+/PvDCzVxHt4T6O6LQYgKlm1uzuwznG/1Pmibv/2cwAphTzwWZ2GvB5ooYyM96e4fm+RHsjSubu68zsceADZvZzolME3hze/kGY9g1m1kF0isOX3X2wyMlviD1/lqgxyfXe/kR7gzaHZQLRRpkZZp8c08pnX+BZdx8qso4AuPs2M/so0SkQV5nZvUR7fn6fY/A9ifbCxevxLNHer4znYs+3h8/ILptCdGrVq4AHY/NuRP9MMkasd6PMx4tmdi3wsJnNzloOPyU6DamH6LstRnadc80DhO/I3dOx97OXyZ9iz/8cG3d/4Agz2xp7v6VQHUfZHmDk+oK7rzSzbcA7zWwz0T+UW/NMfhnQbmZHhDrPI9oTOJZtPp/R1vnxmE10lKfgujXKtl+Q2iO1R0XOh9qjyERuj+KfcbOZxb+TYaIAPN5te6dwTdtFREenX010NB6i76ON6EjPmNonotMy/8PM9iEKMA78T3jvHKJAc7+Z9QLfcPeri5zuRg+/rINnidbhjOz2Kd/6+erwvJT2qeRl4e7LzOw7REeV9zOzm4EvuvvLOQYvZlssdrveH9gna96beeU7gBLWWXd/0szWEp2Z8OGst68jOnXeiEJZMUppn3Z+L+6eNrMNFG6fMuvD/sDpZvaZ2PuTGLm+7DTK9vBSeJ69zH4IPG5mU4CPEAXAzbmmD/wI+J2ZfZpoGT7k7s+Gz34t8E1gPtH/lRaiI9mlKrlNzgzQaDzr9ReI9uIe4e5/MrN5wP8SrbRlY2b7E+2JORpY4e7DZrY69jkbgNcUWedcfky017OJ6NqddQDhH8BXga+a2Ryic8afoPiOT/YlOm0NotM+NuWp1waivbB75vmxtjlMK2O/Ap+5gahRbMkxrW1EG0LGrPib7n47cLuZtRPt3fke0V687GW4hWhv4/5Epy1k6rSxQL3y2ULUOB3i7vnGL+Y7jGshOp1qGlEYiSYS7fi4jehU8Hzry1htAvY1s6bYP5v9iPaWjmYDsNzd35Pn/RHzX8T2sMs4wbVER1/+BCzJ90M6/EO4iWibeI7otNS+8HYp23yh9W20dX5MzOwviP6R3UNx61bObX+Uz1B7pPaoFGqPJmh7lGUD8Nfufm+e9/Nt26Wub6cAxxMdQX6G6AhoL9Ey2UJ0felriE6Tjxv1c9x9q5n9huiH+RuITif28N6fiC63wszeDvzWzO4upk0FZpuZxYLofozcKZHdPuVcP0PgGGLXti6fDUSnpOcyWvt0GXCZme1FdPrvl4iO8GUvx/Fsi7nq+7S7H1RgmLG0T7nan/8hOlrvRP9Py9lGbSK2E9SiPT/7UlybvYHo9PyL8ryfPf+Ftoec47j7RjNbQXR95yfYtWO5+LCPmdmzRB05nUIUSjOuIGqPPubufWb2OeDEPJMarX0q1CbnNBF68JpK9A97q5ntQXQ6RCXsxivnrmNmf0V0fnrG94Evmtnhofe0ueEfI0T/tA4cZfo3EJ1S9mliK5BFXe2/MTRsLxP90Cll7+o/m9mrzOwQonO5b8w1UNjD8hvgG2Y2zcyazOw1ZvbOMMhNwGfNrNPMphNdr5bP/UQ/Ei82s93MbLKZLQzvrQbeYWb7mdnuRKdxZOZ1ppktNrPdiP4Zp2Lz+hzQaWaTQn2HQ50uMrOpYVl/nmjvUUlCo/w94FuhMcfMZpvZscVOw8w+bGavC8vt1UR7nv7X3V/MMfg/EZ228UypdR3FSqJG5Bwza7XoNgsfIFq3RvML4LVm9okwbquZ/YWZvSG8n70Oj7Y95PMDokb140R7OQv5EdEpIKcyslEtZZtfTZ71rYh1viRhGu8nWt4/dPdHily3cm77o1B7pPYoL7VHao/y+C+idXR/ADN7tZkdH54X2raLaTPiphJtMz1EP2r/X+aNsH5fDXzTzPYxs2Yze6uZtRF9f+kiPutHRNcrnsDI9ukkM+sML3uJ1oli26e9iNqUVjM7iSjg/irPsHnXz9AW/BS4ILR1BxNdM5jP9cC7zewjFt2GZIZFOzIgWl8+HKYzFzgjNq9/YWZHmFkr0XaW6SwNdv2+xrMtZrsfeNnMzjWz9vD9HWrRzteimNmnYm3bwUTbwZ3Zw4UdAh8g6kSp1GA7mpuA95nZ0WEZfoFonf1dEeN+D/i7sPwt/F95n5lNDe9nL/+828MoriM6uv9GwpkXBfyIqIfhdxBdExr/7JeBlJm9nuh/ej6rybO+MXqbnNNECKH/TtTJwBai67B+PdYJmdk/WbRXeBfu/hjRaUsriFawNxJdF5J5/ydEh9t/RHQ91c+IzuOG6HSC/2vRPdu+mGf6m8O038bIH2aziE4/eZnoeo7lhB82ZvZfZvZfo8zWcqKLre8E/s3df1Ng2NOITil4jKgBX0K0Fwqije52oj2XDxE1sjmFRvgDRKc3rSe6xuij4b07wvytITol4BexUZuIGoJNRHvr3wn8fXhvGVEvZn8ysy2h7DNEDesfifaS/Yjon9tYnEu0nO4zs5eJelF7XQnjzyZa9/qAR4j+kX4o14Duvsnd7xljPfNy9x1Ep07+JdH2cDnRdUu5Th/MHrePKHScTLT8/8QrHZ9AtDf84LAO/2y07aHA53QTrT/xU6jyDZv5x7kPUe92Gf9Okdv8KOsbFF7ni/VzM+sj2lP4ZaIf/H8Ve7/gupVv21d7pPYItUdqj0pvjwr5NtHRvd+ENus+omv8oMC2HcY70cx6zewyADO7zcz+Kc/nXEd0quPGMC/3Zb3/RaL18gGibesSousV/0zohTZ8t0fmmf6tRKfiPufu8aOpfwGsNLNUGOZsd3861HetFb5H6sowzS2hDie6e0+uAYtYP/+B6LTPPxFd7/ff+T7U3dcTXQ/9BaJlsZroliUQnea9g2idvpYosGZMI2oHe4mWdQ9Rj9qw6/Yx5m0xR30z7ek8os6LthDt9Ny9hMksBB6x6HT4X4VHznXJ3de6+9pS6zkad3+CaOfTfxDNwweIbmW0o4hxVxEdcf8O0fJfR3T9ZEb2/9jRtod8biacQu/u20YZ9sdE/QUsc/ctsfIvEh0d7SNaX3Lu+A3yrm9FrPM5ZXp9lQnGotNpngZaK3hqj0jJzOxqYJO7/99a10WqQ+2RJJXaIzGzTxJ1yPL2WtdFJM7MniLqIfu3ta7LWDTiNaEiUqdCGPkwRXa+IyJSKWqPRCSpzOwEorM0ltW6LmM1EU7HFZE6YGYXAo8CX8+cIiUiUgtqj0Qkqcysi6hTobN8ZK/GdUWn44qIiIiIiEjV6EioiIiIiIiIVI1CqIiIiIiIiFSNOiYK9txzT58zZ07Rw2/bto3ddtutchUqg3qoI6ie5VQPdYTK13P79u1s3bqV1tZWnn322S3u/uqKfVgVlNI+1cs6UCrNV/1oxHmC8sxXOp2mp6eHoaEhNm3apLapxlSn0SWtPpC8OiWtPjC2OvX19dHX18fmzZur0za5ux7uHH744V6Ku+66q6Tha6Ee6uiuepZTPdTRvbL1fPTRR/2rX/2qX3XVVd7f3+/AKk9AGzOeRyntU72sA6XSfNWPRpwn9/HPVyqV8ssvv9wvvPBCf+qpp9Q2JYDqNLqk1cc9eXVKWn3cS69TV1eXf+UrX/Gbb765am2TTscVkYaxdu1ali5dSmdnJ6eeeiptbQXvkywiUhXbtm3juuuuo6enh1NOOYUDDzyw1lUSEQFg+fLl3HXXXcybN4/FixdX7XMVQkWkISiAikgSKYCKSFJlB9CmpupFQ4VQEal7CqAikkQKoCKSVLUMoKAQKiJ1TgFURJJIAVREkqrWARQUQkWkjimAikgSKYCKSFIlIYCCQqiI1CkFUBFJIgVQEUmqpARQUAituJ7UAA9v2EpPaqDWVRFpGAqgIpJECqDJpN9iIskKoAAtNf30BnfL6o2cu3QNrU1NDKbTXHrCYSyeN7vW1RKpawqgIpJECqDJpN9iIskLoKAjoRXTkxrg3KVr6B9M0zcwRP9gmnOWrtFeOJFxUAAVkSRSAE0m/RYTSWYABYXQiunu3U5r1pfc2tREd+/2GtVIpL4pgIpIEimAJpd+i8lEl9QACgqhFdM5vZ3BdHpE2WA6Tef09hrVSKR+KYCKSBJVM4CaWYeZLTGz35vZ42b2VjPbw8zuMLMnw9/pseHPN7N1ZvaEmR0bKz/czB4J711mZhbK28zsxlC+0szmVGxmqkS/xWQiS3IABYXQipkxpY1LTziMya1NTG1rYXJrE5eecBgzpujHs0gpFEBFJIlqcAT028Cv3f31wJuAx4HzgDvd/SDgzvAaMzsYOBk4BDgOuNzMmsN0rgDOBA4Kj+NC+RlAr7vPBb4FXFLpGao0/RaTiSqVSiU6gII6JqqoxfNms3DunnT3bqdzersaPZESKYCKSBJVO4Ca2TTgHcAnAdx9B7DDzI4HFoXBrgW6gHOB44Eb3H0AeNrM1gELzOwZYJq7rwjTvQ74IHBbGOeCMK0lwHfMzNzdKzpzFabfYjLRLF++nL6+vkQHUFAIrbgZU9rU4ImMgQKoiCRRja4BPRB4AfhvM3sT8CBwNjDT3TcDuPtmM9srDD8buC82fncoGwzPs8sz42wI0xoys5eAGcCWeEXM7EyiI6nMnDmTrq6uomYglUoVPWyl9Ga9TkKdsiWtTkmrDySvTkmqTyqVoq+vj/b2djo6Orj77rtrXaW8FEJFJHFqGUDN7B+BTwEOPAL8FfAq4EZgDvAM8BF37w3Dn090Gtsw8Fl3vz2UHw5cA7QDvwLOdnc3szbgOuBwoAf4qLs/U525E5HxqGEnRC3AW4DPuPtKM/s24dTbPCxHmRcoLzTOyAL3K4ErAebPn++LFi0qUI1XdHV1Ueyw1aI6jS5p9YHk1Skp9Vm+fDmrVq1i3rx5dHR0JKJOhSTz+KyITFg1DqCzgc8C8939UKCZ6LoqXXclMsGl0+la9oLbDXS7+8rweglRKH3OzPYGCH+fjw2/b2z8TmBTKO/MUT5iHDNrAXYHXiz7nIhI2WV3QlQPFEJFJDEScgpuC9AefoS9iugH2vFE11sR/n4wPN953ZW7Pw1krrvam3DdVbie6rqscTLTWgIcnemdUkSSadu2bfT09NTsNizu/idgg5m9LhQdDTwG3AqcHspOB24Jz28FTg493h5AtCPs/nDqbp+ZHRnandOyxslM60RgWb1fDyoyESS9F9x8dDquiCRCEgKou280s38D1gPbgd+4+2/MrOrXXYlIMmROwe3o6Kj1fUA/A1xvZpOAPxJdKtAE3GRmZxC1WycBuPtaM7uJKKgOAWe5+3CYzqd55VKB28ID4CrgB6EToxeJzvIQkQSr1wAKCqEikgBJCKAA4R57xwMHAFuBn5jZxwuNkqOsLNdd1XPnH5Wg+aofjTRP6XSanp4eOjo62G233Vi/fj3r16+vSV3cfTUwP8dbR+cZ/iLgohzlq4BDc5T3E0KsiCRfPQdQUAgVkRpLSgAN3g087e4vAJjZT4G3Ea67CkdBy3XdVXeh664aqfOPctB81Y9GmafsTojWr1/fEPMlIvWv3gMo6JpQEamhhAVQiE5nO9LMXhWulzqa6Ibwuu5KZAKpYS+4IiIFNUIAhQqGUDPb18zuMrPHzWytmZ0dyi8ws41mtjo83hsb53wzW2dmT5jZsbHyw83skfDeZZlOPMIPvxtD+UozmxMb53QzezI8TkdEEiWBAZTQ8+QS4CGi27M0ER2NvBh4j5k9CbwnvMbd1wKZ665+za7XXX2fqLOipxh53dWMcN3V5yl8mwURqTIFUBFJqkYJoFDZ03GHgC+4+0NmNhV40MzuCO99y93/LT5w1q0O9gF+a2avDT/oMrc6uI/ofnvHEf2g23mrAzM7mehWBx81sz2ArxBdO+Hhs2/N3NdPRGqrv78/cQE0w92/QtR+xA2g665EGp4CqIgkVSMFUKjgkVB33+zuD4XnfUSntM0uMEo5b3VwLHCHu78YgucdvHKPvkToSQ3w8Iat9KQGal0Vkapau3Ytvb29iQygIjJxKYCKSFI1WgCFKnVMFE6TfTOwElgI/IOZnQasIjpa2kt5b3WwszzHOPF6jan3SRhf738vbR+ku3c7RnSYtnN6O7u3t45pWoXUSw+Fqmf5JL2O/f399Pb20t7ezqxZs1ixYkWtqyQiogAqIonViAEUqhBCzWwKsBT4nLu/bGZXABcS5a8LgW8Af015b3VQ1C0Qxtr7JIy997+e1AALL1lG/2DzzrLJrUPce+47mDGlvEeE6qWHQtWzfJJcx/g1oLNmzeKoo46qdZVERBRARSSxGjWAQoV7xzWzVqIAer27/xTA3Z9z92F3TwPfAxaEwcdzqwOybnWQb1o11927ndasFai1qYnu3u01qpFI5WV3QhT6FhMRqSkFUBFJqkYOoFDZ3nGNqBfIx939m7HyvWODfQh4NDwv560ObgeOMbPp4ebzx4Symuuc3s5gOj2ibDCdpnN6e41qJFJZSewFV0REAVREkqrRAyhU9nTchcAngEfMbHUo+yfgY2Y2j+j02GeAv4XoVgdmlrnVwRC73urgGqCdqFfc+K0OfhBudfAiUe+6uPuLZnYh8EAY7mvuvsvN4GthxpQ2Lj3hMM5ZuobWpiYG02kuPeGwsp+KK5IECqAikkQKoCKSVBMhgEIFQ6i730PuazN/VWCcst3qwN2vBq4utr7VtHjebBbO3ZPu3u10Tm9XAJWGpAAqIkmkACoiSTVRAihUqXdc2dWMKW0Kn9KwFEBFJIkUQEUkqSZSAIUKd0wkIhOPAqiIJJECqIgk1UQLoKAQKiJlpAAqIkmkACoiSTURAygohIpImSiAikgSKYCKSFJN1AAKCqEiUgYKoCKSRAqgIpJUEzmAgkKoiIyTAqiIJJECqIgk1UQPoKAQKiLjoAAqIkmkACoiSaUAGpmYcy0i46YAKiJJpAAqcT2pAR7esJWe1ECtqyKiABqj+4SKSMkUQEUkiRRAJe6W1Rs5d+kaWpuaGEynufSEw1g8b3atqyUTlALoSBN77kWkZAqgIpJECqAS15Ma4Nyla+gfTNM3MET/YJpzlq7REVGpCQXQXWkJiEjRFEBFJIkUQCVbd+92WrN+6Lc2NdHdu71GNZKJSgE0Ny0FESmKAqiIJJECqOTSOb2dwXR6RNlgOk3n9PYa1UgmIgXQ/LQkRGRUCqAikkQKoJLPjCltXHrCYUxubWJqWwuTW5u49ITDmDFF/7+kOhRAC1PHRCJSkAKoiCSRAqiMZvG82SycuyfdvdvpnN6uACpVowA6OoVQEclLAVREkkgBVIo1Y0qbwqdUlQJocbRURCQnBVARSSIFUBFJKgXQ4mnJiMguFEBFJIkUQEUkqRRAS6OlIyIjKICKSBJN9ABqZs+Y2SNmttrMVoWyPczsDjN7MvydHhv+fDNbZ2ZPmNmxsfLDw3TWmdllZmahvM3MbgzlK81sTtVnUqROKYCWTktIRHZSABWRJJroATTmKHef5+7zw+vzgDvd/SDgzvAaMzsYOBk4BDgOuNzMmsM4VwBnAgeFx3Gh/Ayg193nAt8CLqnC/IjUvVQqpQA6BlpKIgIogIpIMimAFnQ8cG14fi3wwVj5De4+4O5PA+uABWa2NzDN3Ve4uwPXZY2TmdYS4OjMUVIRyW358uX09fUpgI6BescVEQVQEUkkBdARHPiNmTnwXXe/Epjp7psB3H2zme0Vhp0N3BcbtzuUDYbn2eWZcTaEaQ2Z2UvADGBLvBJmdibRkVRmzpxJV1dXUZVPpVJFD1stqtPoklYfSE6dUqkUfX19tLe309HRwd13313rKu2UlGVUiEKoyASnACoiSaQAuouF7r4pBM07zOz3BYbNdQTTC5QXGmdkQRR+rwSYP3++L1q0qGClM7q6uih22GpRnUaXtPpAMuq0fPlyVq1axbx58+jo6Kh5fbIlYRmNRseMRSYwBVARSSIF0F25+6bw93ngZmAB8Fw4xZbw9/kweDewb2z0TmBTKO/MUT5iHDNrAXYHXqzEvIjUs+xOiGRsFEJFJigFUBFJIgXQXZnZbmY2NfMcOAZ4FLgVOD0MdjpwS3h+K3By6PH2AKIOiO4Pp+72mdmR4XrP07LGyUzrRGBZuG5URAL1gls+Oh1XZAJSABWRJFIAzWsmcHPoJ6gF+JG7/9rMHgBuMrMzgPXASQDuvtbMbgIeA4aAs9x9OEzr08A1QDtwW3gAXAX8wMzWER0BPbkaMyZSLxRAy0shVGSCUQAVkSRSAM3P3f8IvClHeQ9wdJ5xLgIuylG+Cjg0R3k/IcSKyEgKoOWnJSgygSiAikgSKYCKSFIpgFaGlqLIBKEAKiJJpAAqIkmlAFo5WpIiE4ACqIgkkQKoiCSVAmhlaWmKNDgFUBFJIgVQEUkqBdDK0xIVaWAKoCKSRAqgIpJUCqDVoaUq0qAUQEUkiRRARSSpFECrp2JL1sz2NbO7zOxxM1trZmeH8j3M7A4zezL8nR4b53wzW2dmT5jZsbHyw83skfDeZeEGy4SbMN8Yylea2ZzYOKeHz3jSzE5HZAJRABWRJFIAFZGkUgCtrkou3SHgC+7+BuBI4CwzOxg4D7jT3Q8C7gyvCe+dDBwCHAdcbmbNYVpXAGcCB4XHcaH8DKDX3ecC3wIuCdPaA/gKcASwAPhKPOyKNDIFUBFJIgVQEUkqBdDqq9gSdvfN7v5QeN4HPA7MBo4Hrg2DXQt8MDw/HrjB3Qfc/WlgHbDAzPYGprn7Cnd34LqscTLTWgIcHY6SHgvc4e4vunsvcAevBFeRhtXf368AKiKJowAqIkmlAFobVVnK4TTZNwMrgZnuvhmioArsFQabDWyIjdYdymaH59nlI8Zx9yHgJWBGgWmJNKy1a9fS29urACoiiaIAKiJJpQBaOy2V/gAzmwIsBT7n7i+HyzlzDpqjzAuUj3WceN3OJDrNl5kzZ9LV1ZWvbrtIpVIlDV8L9VBHUD3Lob+/n97eXtrb25k1axYrVqyodZUKSvKyFJHyUQAVkaRSAK2tioZQM2slCqDXu/tPQ/FzZra3u28Op9o+H8q7gX1jo3cCm0J5Z47y+DjdZtYC7A68GMoXZY3TlV0/d78SuBJg/vz5vmjRouxB8urq6qKU4WuhHuoIqud4xa8BnTVrFkcddVStqzSqpC5LESkfBVARSSoF0NqrZO+4BlwFPO7u34y9dSuQ6a32dOCWWPnJocfbA4g6ILo/nLLbZ2ZHhmmeljVOZlonAsvCdaO3A8eY2fTQIdExoUykoWR3QlTgTAMpkpl1mNkSM/t96N37rdXq1VukUSiAikhSKYAmQyWX+kLgE8C7zGx1eLwXuBh4j5k9CbwnvMbd1wI3AY8BvwbOcvfhMK1PA98n6qzoKeC2UH4VMMPM1gGfJ/S06+4vAhcCD4TH10JZ1fWkBnh4w1Z6UgO1+HhpYOoFt2K+Dfza3V8PvImoU7WK9+ot0ijS6bQCqIgkkgJoclTsdFx3v4fc12YCHJ1nnIuAi3KUrwIOzVHeD5yUZ1pXA1cXW99KuGX1Rs5duobWpiYG02kuPeEwFs9T/0gyfgqglWFm04B3AJ8EcPcdwA4zO55XTvG/luj0/nOJ9eoNPB12iC0ws2cIvXqH6WZ69b4tjHNBmNYS4DtmZuEsDpG6tm3bNnp6ehRARSRxFECTpeIdE01UPakBzl26hv7BNP2kAThn6RoWzt2TGVMUGGTsFEAr6kDgBeC/zexNwIPA2WT16m1m8V6974uNn+mJe5Aie/U2s0yv3lviFRlrx2mN2umT5iv50uk0PT09NDc3s2DBAtavX8/69etrXa2yaaTvSmSiUQBNHoXQCunu3U5rU9POAArQ2tREd+92hVAZMwXQimsB3gJ8xt1Xmtm3Cafe5lHOXr1HFoyx47RG7fRJ85Vs8WtAFyxYwDHHHFPrKpVdo3xXIhONAmgy6VuokM7p7Qym0yPKBtNpOqe316hGUu8UQKuiG+h295Xh9RKiUPpc6M2bMvbqTVav3iJ1KbsTokmTJtW6SiIigAJokumbqJAZU9q49ITDmNzaxNS2Fia3NnHpCYfpKKiMiQJodbj7n4ANZva6UHQ0UWdp1ejVW6TuqBdcEUkqBdBk0+m4FbR43mwWzt2T7t7tdE5vVwCVMVEArbrPANeb2STgj8BfEe2wu8nMzgDWEzpEc/e1Zpbp1XuIXXv1vgZoJ+qQKN6r9w9CJ0YvEvWuK1J3FEBFJKkUQJNPIbTCZkxpU/iUMVMArT53Xw3Mz/FWxXv1FqkXCqAiklQKoPVB34pIQimAikgSKYCKSFIpgNYPfTMiCaQAKiJJpAAqIkmlAFpf9O2IJIwCqIgkkQKoiCSVAmj90TckkiAKoCKSRAqgIpJUCqD1Sd+SSEIogIpIEimAikhSKYDWL31TIgmgACoiSaQAKiJJpQBa3/RtidSYAqiIJJECaPKYWbOZ/a+Z/SK83sPM7jCzJ8Pf6bFhzzezdWb2hJkdGys/3MweCe9dZmYWytvM7MZQvtLM5lR9BkWKpABa//SNidSQAqiIJJECaGKdDTwee30ecKe7HwTcGV5jZgcDJwOHAMcBl5tZcxjnCuBM4KDwOC6UnwH0uvtc4FvAJZWdFZGxSaVSCqANQN+aSI0ogIpIEimAJpOZdQLvA74fKz4euDY8vxb4YKz8BncfcPengXXAAjPbG5jm7ivc3YHrssbJTGsJcHTmKKlIUixfvpy+vj4F0AbQUusKiExECqAikkQKoIn278A5wNRY2Ux33wzg7pvNbK9QPhu4LzZcdygbDM+zyzPjbAjTGjKzl4AZwJZ4JczsTKIjqcycOZOurq6iKp9KpYoetlpUp9ElqT6pVIq+vj7a29vp6Ojg7rvvrnWVgGQto4wk1imbQqhIlSmAikgSKYAml5m9H3je3R80s0XFjJKjzAuUFxpnZIH7lcCVAPPnz/dFi4qpDnR1dVHssNWiOo0uKfVZvnw5q1atYt68eXR0dCSiThlJWUZxSaxTNh3DFqkiBVARSSIF0MRbCCw2s2eAG4B3mdkPgefCKbaEv8+H4buBfWPjdwKbQnlnjvIR45hZC7A78GIlZkakFNmdEEljUAgVqRIFUBFJIgXQ5HP38929093nEHU4tMzdPw7cCpweBjsduCU8vxU4OfR4ewBRB0T3h1N3+8zsyHC952lZ42SmdWL4jF2OhIpUk3rBbVw6HVekChRARSSJFEDr3sXATWZ2BrAeOAnA3dea2U3AY8AQcJa7D4dxPg1cA7QDt4UHwFXAD8xsHdER0JOrNRMiuSiANjaFUJEKUwAVkSRSAK1P7t4FdIXnPcDReYa7CLgoR/kq4NAc5f2EECtSawqgjU/fqEgFKYCKSBIpgIpIUimATgz6VkUqRAFURJJIAVREkkoBdOLQNytSAQqgMlH0pAZ4eMNWelIDta6KFEEBVESSSgF0YtE1oSJlpgAqE8Utqzdy7tI1tDY1MZhOc+kJh7F43uzRR5SaUAAVkaRSAJ149A2LlJECqEwUPakBzl26hv7BNH0DQ/QPpjln6RodEU0oBVARSSoF0IlJ37JImSiAykTS3bud1qwfCq1NTXT3bq9RjSQfBVARSSoF0IlL37RIGSiAykTTOb2dwXR6RNlgOk3n9PYa1UhyUQAVkaRSAJ3Y9G2LjJMCqExEM6a0cekJhzG5tYmpbS1Mbm3i0hMOY8YUrf9JoQAqIkmlACrqmEhkHBRAZSJbPG82C+fuSXfvdjqntyuAJogCqIgklQKogEKoyJgpgIpER0QVPpNFAVREkkoBVDL0zYuMgQKoiCSRAqiIJJUCqMTp2xcpkQKoiCSRAqiIJJUCqGSr2BpgZleb2fNm9mis7AIz22hmq8PjvbH3zjezdWb2hJkdGys/3MweCe9dZmYWytvM7MZQvtLM5sTGOd3MngyP0ys1jzLxKICKSBIpgIpIUimASi6VXAuuAY7LUf4td58XHr8CMLODgZOBQ8I4l5tZcxj+CuBM4KDwyEzzDKDX3ecC3wIuCdPaA/gKcASwAPiKmU0v/+zJRNPf368AKiKJowAqIkmlACr5VGxNcPe7gReLHPx44AZ3H3D3p4F1wAIz2xuY5u4r3N2B64APxsa5NjxfAhwdjpIeC9zh7i+6ey9wB7nDsEjR1q5dS29vrwKoiCSKAqiIJJUCqBRSi7XhH8xsTThdN3OEcjawITZMdyibHZ5nl48Yx92HgJeAGQWmJTImmVNwJ02apAAqIomhACoiSaUAKqOp9i1argAuBDz8/Qbw14DlGNYLlDPGcUYwszOJTvVl5syZdHV1Faj6SKlUqqTha6Ee6gjJrmd/fz+9vb0ccsghTJo0iRUrVtS6SgUleVnG1Us9RZJKAVREkkoBVIpRMISaWR+5A5wB7u7TSvkwd38uNu3vAb8IL7uBfWODdgKbQnlnjvL4ON1m1gLsTnT6bzewKGucrjz1uRK4EmD+/Pm+aNGiXIPl1NXVRSnD10I91BGSW894J0Qf/vCHWbFiRSLrGZfUZZmtkvWcOnUqof+yjDeb2cuMsd0SSRoF0PqktkkmAgVQKVbBEOruU8v5YWa2t7tvDi8/BGR6zr0V+JGZfRPYh6gDovvdfdjM+szsSGAlcBrwH7FxTgdWACcCy9zdzex24P/FTvU9Bji/nPMhjU+94Navvr6+Ea/N7H/dfX6NqiNSVgqg9UttkzQ6BVApRUmn45rZXsDkzGt3X19g2B8THZHc08y6iXqsXWRm84iOrj4D/G2Yzlozuwl4DBgCznL34TCpTxP1tNsO3BYeAFcBPzCzdURHQE8O03rRzC4EHgjDfc3di+0gSUQBtPG0mNl+mReF2i2RJFMAbThqm6RhKIBKqYoKoWa2mOj6zX2A54H9gceJbqmSk7t/LEfxVQWGvwi4KEf5KuDQHOX9wEl5pnU1cHW+zxLJRwG0cdx666184QtfAHgjsJwi2i2RpFIAbRxqm6TRKIDKWBS7llwIHAn8wd0PAI4G7q1YrURqQAG0sfzzP/8z9913H8CA2i2pZwqgjUVtkzQSBVAZq2LXlEF37wGazKzJ3e8C5lWuWiLVpQDaeFpbW5kxYwYAarekXimANh61TdIoFEBlPIq9JnSrmU0B7gauN7Pnia7dFKl7CqCNqaOjg1QqBdCH2i2pQwqgjUltkzQCBVAZr2LXmOOB7cA/Ar8GngI+UKlK1Zue1AAPb9hKT2qg1lWREimANq5bbrmF9vZ2gA2o3ZI6owDauNQ2Sb1TAJVyKOpIqLtvi728tkJ1qUu3rN7IuUvX0NrUxGA6zaUnHMbiebNrXS0pggJoY9ttt912Pnd3tVtSNxRAG5vaJqlnCqBSLkWtOeFenS+HR7+ZDYcbLE9oPakBzl26hv7BNH0DQ/QPpjln6RodEa0DCqCNb+rUqUybNg2iG8Kr3ZK6oADa+NQ2Sb1SAJVyKvZI6NT4azP7ILCgEhWqJ92922ltaqKf9M6y1qYmunu3M2OKQk1SKYBODJkbw2duCK92S5JOAXRiUNsk9UgBVMptTGuQu/8MeFd5q1J/Oqe3M5hOjygbTKfpnN5eoxrJaBRAJy61W5JkCqATVzFtk5lNNrP7zexhM1trZl8N5XuY2R1m9mT4Oz02zvlmts7MnjCzY2Plh5vZI+G9y8zMQnmbmd0Yylea2ZyKzLDUHQVQqYSijoSa2YdjL5uA+YBXpEZ1ZMaUNi494TDOybomVEdBk0kBdGL56U9/mnnaYWYnonZLEkoBdGIZY9s0ALzL3VNm1grcY2a3AR8G7nT3i83sPOA84FwzOxg4GTgE2Af4rZm91t2HgSuAM4H7gF8BxwG3AWcAve4+18xOBi4BPlq2GZe6lEqlWLVqlQKolF2xt2iJ99o2BDxD1GPuhLd43mwWzt2T7t7tdE5vVwBNKAXQiefnP/955mkHcCxFtltm1gysAja6+/vNbA/gRmBOmMZH3L03DHs+0Q+3YeCz7n57KD8cuAZoJ/qRd7a7u5m1AdcBhwM9wEfd/ZnxzqvUr3Q6rQDaIHpSA0X9FhhL2+TuDqTCy9bw8DDeolB+LdAFnBvKb3D3AeBpM1sHLDCzZ4Bp7r4CwMyuAz5IFEKPBy4I01oCfMfMLHy2TEDLly+nr69PAVQqotgQ+n13vzdeYGYLgefLX6X6M2NKm8JngimATkyf+tSnWLhwIddcc80z7v43UHS7dTbwODAtvD4PHWmQCti2bRs9PT0KoA2glJ7yx9o2hR1kDwJzgf9095VmNtPdNwO4+2Yz2ysMPpuo/cnoDmWD4Xl2eWacDWFaQ2b2EjAD2JJVjzOJ2jdmzpxJV1dXoWrvlEqlih62WlSnwvXo6+ujvb2djo4O7r777lpXaaekLKOMpNUHklmnbMWG0P8A3lJEmUiiKIBOXJ/5zGd46KGHsosLtltm1gm8D7gI+Hwo1pEGKbvMKbgdHR0KoHUu3lN+pqPCc5auYeHcPXPuoB5L2wQQdnDNM7MO4GYzO7TA4JZrEgXKC42TXY8rgSsB5s+f74sWLSpQjVd0dXVR7LDVojrltnz58p2n4HZ0dNS8PtmSsIziklYfSGadshUMoWb2VuBtwKvN7POxt6YBzZWsWCMq9lQdKQ8F0IlpxYoV/O53v+OFF17gm9/8JsDM0H4V0279O3AOEO8RvOpHGqCxjjaUQyPNVzqdpqenh46ODnbbbTfWr1/P+vXra12tsmmk7you33xtHxzms28YZDi2L6nZjPtX3EN76ytNztq1a1m7di3d3d38/d//PZTWNu3k7lvNrIvoDIvnzGzv0DbtzStHU7uBfWOjdQKbQnlnjvL4ON1m1gLsDrxYbL2kMWR3QpSkI6DSWEY7EjoJmBKGi/8oexk4sVKVakSlnKoj46cAOnHt2LGDVCrF0NBQ5lYITUTtV8F2y8zeDzzv7g+a2aIiPqpiRxqgsY42lEOjzFd2J0Tr169viPmKa5TvKlu++epJDfCPlyyjf/CV3vIntzZx7+K3j9jhbGZs2bKF5uZmZs6cCUW2TWHcVwODIYC2A+8mOp3/VuB04OLw95Ywyq3Aj8zsm0SXCxwE3O/uw+He70cCK4HTiI7CEpvWilCfZTpLY2JRL7hSTQVDqLsvB5ab2TXu/myV6tRwSj1VR8ZHAXRie+c738k73/lOPvnJT7L//vtzwQUXbHb3rxYx6kJgsZm9F5gMTDOzH6IjDVImuXrBbaQjoBNVsT3lj6NtAtgbuDZcF9oE3OTuvzCzFcBNZnYGsB44CcDd15rZTcBjRB1KnhVO5wX4NK90nHZbeABcBfwgXFrwItE17zJBKIBKtRXdMZGZneTuWwHCfahucPdjC48mAN2922ltatoZQAFam5ro7t2uEFpmCqCS8alPfYqf/OQnO1+P1m65+/nA+WHYRcAX3f3jZvZ1dKRBxkm3YWlspfSUX2rbBODua4A35yjvAY7OM85FRNe3Z5evAna5ntTd+wkhViYWBVCphWJD6J6ZAArg7r2x66JkFJ3T2xlMp0eUDabTdE5vr1GNGpMCqMRt2bKFjo6Ona/H0W5djI40yDgogE4MxfaUX8a2SWTcFEClVooNoWkz28/d1wOY2Rx00/eiFXuqjoydAqhka2pqGnGqYyntlrt3EfWCqyMNMi4KoJJtPG2TSDkpgEotFRtCvwzcY2bLw+t3EHptlOKUcqqOlEYBVHK56KKLePvb3w5wgJn9ALVbUmUKoJKL2iZJAgVQqbWiQqi7/9rM5hM1kquJronaXsF61bV8t2Ip9lQdKZ4CqORz3HHHsWrVKmbOnNkP3IjaLakiBVDJR22T1JoCqCRBUSHUzD4FnE3Uy+Nq4EiijjXeVbGa1SndiqV6FEClkO9///t8+9vfBpgJfAG1W1IlCqBSiNomqSUFUEmKYte8s4G/AJ5196OIemh7oWK1qlPxW7H0DQzRP5jmnKVr6EkN1LpqDUcBVEbz7W9/mwceeABgh9otqRYFUBmN2iapFQVQSZJi177+0KEGZtbm7r8HXle5atWnzK1Y4jK3YpHyUQCVYkyePJnJkycDarekOhRApRhqm6QWFEAlaYrtmKjbzDqAnwF3mFkvr9x8XQLdiqXyFEClWJ2dnWzduhVgK2q38sp3DbuURgFUiqW2SapNAVSSqNiOiT4Unl5gZncBuwO/rlit6pRuxVJZCqBSiptvvjnzdBPwz6jd2oWuYS8PBVAphdomqSYFUEmqYo+E7uTuy0cfauLSrVgqQwFUxkPt1q7i17D3E53Bcc7SNSycu6farRIogMp4qG2SSlIAlSQrOYTK6HQrlvJSABUpv8w17JkACq9cw672qzgKoCKSVAqgknRaIyXRFEBFKkPXsI+PAqiIJJUCqNQDrZWSWAqgIpWTuYZ9cmsTU9tamNzapGvYi6QAKiJJpQAq9UKn40oiKYCKVJ6uYS+dAqiIJJUCqNQThVBJHAVQkerRNezFUwAVkaRSAJV6ozVUEkUBVESSSAFURJJKAVTqkdZSSQwFUBFJIgVQEUkqBVCpVxVbU83sajN73swejZXtYWZ3mNmT4e/02Hvnm9k6M3vCzI6NlR9uZo+E9y4zMwvlbWZ2YyhfaWZzYuOcHj7jSTM7vVLzKOWjACoiSaQAKiJJpQAq9aySa+s1wHFZZecBd7r7QcCd4TVmdjBwMnBIGOdyM2sO41wBnAkcFB6ZaZ4B9Lr7XOBbwCVhWnsAXwGOABYAX4mHXUme/v5+BVARSRwFUBFJKgVQqXcVW2Pd/W7gxazi44Frw/NrgQ/Gym9w9wF3fxpYBywws72Bae6+wt0duC5rnMy0lgBHh6OkxwJ3uPuL7t4L3MGuYVgSYu3atfT29iqAikiiKICKSFIpgEojqHbvuDPdfTOAu282s71C+Wzgvthw3aFsMDzPLs+MsyFMa8jMXgJmxMtzjDOCmZ1JdJSVmTNn0tXVVfSMpFKpkoavhaTXsb+/n97eXtrb25k1axYrVqyodZUKSvryhPqoI9RPPWViUgAVkaRSAJVGkZRbtFiOMi9QPtZxRha6XwlcCTB//nxftGjRqBXN6OrqopThayHJdYxfAzpr1iyOOuqoWldpVElenhn1UEeon3rKxKMAKiJJpQAqjaTaa+9z4RRbwt/nQ3k3sG9suE5gUyjvzFE+YhwzawF2Jzr9N9+0JCGyOyEKfU2JiNSUAqiIJJUCqDSaaq/BtwKZ3mpPB26JlZ8cerw9gKgDovvDqbt9ZnZkuN7ztKxxMtM6EVgWrhu9HTjGzKaHDomOCWWSAOoFV0SSSAFURJJKAVQaUcVOxzWzHwOLgD3NrJuox9qLgZvM7AxgPXASgLuvNbObgMeAIeAsdx8Ok/o0UU+77cBt4QFwFfADM1tHdAT05DCtF83sQuCBMNzX3D27gySpAQVQEUkiBVARSSoFUGlUFQuh7v6xPG8dnWf4i4CLcpSvAg7NUd5PCLE53rsauLroykrFKYCKSBIpgIpIUimASiPT2iwVpwAqIkmkACoiSaUAKo1Oa7RUlAKoiCSRAqjUEzPb18zuMrPHzWytmZ0dyvcwszvM7Mnwd3psnPPNbJ2ZPWFmx8bKDzezR8J7l4U+Nwj9ctwYylea2Zyqz6gACqAyMWitlopRABWRJFIAlTo0BHzB3d8AHAmcZWYHA+cBd7r7QcCd4TXhvZOBQ4DjgMvNrDlM6wqie6QfFB7HhfIzgF53nwt8C7ikGjMmI6VSKQVQmRC0ZktFKICKSBIpgEo9cvfN7v5QeN4HPA7MBo4Hrg2DXQt8MDw/HrjB3Qfc/WlgHbAg3B5vmruvCHcUuC5rnMy0lgBHZ46SSnUsX76cvr4+BVCZELR2S9kpgIpIEimASiMIp8m+GVgJzAy3syP83SsMNhvYEButO5TNDs+zy0eM4+5DwEvAjIrMhOwicwpue3u7AqhMCBXrHXei6kkN0N27nc7p7cyYMvHClwKoiCSRAqg0AjObAiwFPufuLxc4UJnrDS9QXmic7DqcSXQ6LzNnzqSrq2uUWkdSqVTRw1ZLUuqUSqV2HgFtaWnh7rvvrnWVdkrKMopLWp2SVh9IZp2yKYSW0S2rN3Lu0jW0NjUxmE5z6QmHsXje7NFHbBAKoCKSRAqg0gjMrJUogF7v7j8Nxc+Z2d7uvjmcavt8KO8G9o2N3glsCuWdOcrj43SbWQuwO9F92Edw9yuBKwHmz5/vixYtKqr+XV1dFDtsMcqx07/cdRqL5cuXs2rVqp2n4N599901r1NcEpZRtqTVKWn1gWTWKZuO9ZfJuuf6+NKSNfQPpukbGKJ/MM05S9fQkxqoddWqQgFURJJIAVQaQbg28yrgcXf/ZuytW4HTw/PTgVti5SeHHm8PIOqA6P5wym6fmR0Zpnla1jiZaZ0ILAvXjSbOLas3svCSZXz8+ytZeMkybl29sdZVGhP1gisTmY6ElsEtqzfypZ88zI7hkW11a1MT3b3bG/60XAVQEUkiBVBpIAuBTwCPmNnqUPZPwMXATWZ2BrAeOAnA3dea2U3AY0Q9657l7sNhvE8D1wDtwG3hAVHI/YGZrSM6AnpyhedpTHpSA5y7NNrp308agHOWrmHh3D3r6veWAqhMdAqh45RpDLMDKMBgOk3n9PYa1Kp6FEBFJIkUQKWRuPs95L5mE+DoPONcBFyUo3wVcGiO8n5CiE2y7t7ttDY17QygUH87/RVARXQ67rhlGsNsk1qauPSEw+qmQRyLagfQntQAD2/YOmFOcRaRsVEAFWlcndPbGUynR5TV005/BVCRiI6EjlOuxnBSs/Grz7yduTOn1qhWlVftADrRO30SkeIogIo0thlT2rj0hMM4J+s3QT3s9FcAFXmFQug45WsMFUDLp1Gu/xCRylIAFZkYFs+bzcK5e9bVLfEUQEVGUggtg3psDMeqFteANsL1HyJSWQqgIo0p361YZkxpq5vfAAqgIrtSCC2TemoMx6pWnRDV+/UfIlJZCqAijSlzKU5Lk7Fj2PnKBw7m1CP2r3W1SqIAKpKbtgQpSi17wc2c8jy5tYmpbS1Mbm38Tp9EpDgKoCKNKX4pTmpgmB1Dab5886Ncf9+zta5a0RRARfLTkVAZVRJuwzKRTnkWkeIogIo0ru7e7bQ07XpXmq/+fC3HHTor8b8DFEBFClMIlYKSEEAzJsIpzyJSHAVQkcbWOb095z3YW5uT3yeEAqjI6LRVSF5JCqAiIhkKoCKNb8aUNr7ygYN3KR92T3SfEAqgIsXRkVDJSQFURJJIAVRk4jj1iP3Bo1NwW5ubGHZPdJ8QCqAixVMIlV0ogMpEZWb7AtcBs4A0cKW7f9vM9gBuBOYAzwAfcffeMM75wBnAMPBZd789lB8OXAO0A78CznZ3N7O28BmHAz3AR939mSrNYl1TABWZeE49cn+OO3RW4vuEUAAVKY22EBlBAVQmuCHgC+7+BuBI4CwzOxg4D7jT3Q8C7gyvCe+dDBwCHAdcbmbNYVpXAGcCB4XHcaH8DKDX3ecC3wIuqcaM1bt0Oq0AKjIB5btPaJIogIqUTkdCZScFUJno3H0zsDk87zOzx4HZwPHAojDYtUAXcG4ov8HdB4CnzWwdsMDMngGmufsKADO7DvggcFsY54IwrSXAd8zM3H3XHjgEiI6A9vT0KICKTDCZ+4S2NjUxmE5z6QmHsXje7FpXawQFUJGx0ZZSJj2pAR7esJWe1ECtqzImCqAiI5nZHODNwEpgZgiomaC6VxhsNrAhNlp3KJsdnmeXjxjH3YeAl4AZFZmJPOqpvcqcgjs0NKQAKjKBxO8T2jcwRP9gmnOWrklUu6UAKjJ2OhJaBvWwp64QBVCRkcxsCrAU+Jy7v2y2673qMoPmKPMC5YXGya7DmUSn8zJz5ky6urpGqXUklUoVHPal7YN0927Hwod2Tm9n9/bWoqZdbel0mp6eHjo6Othtt91Yv34969evr3W1ymq076seNeI8QePOV1J1926ntamJftI7y1qbknN7FgVQkfFRCB2nntQA5yx5mIEh39lQnrN0DQvn7pmIRnI0CqAiI5lZK1EAvd7dfxqKnzOzvd19s5ntDTwfyruBfWOjdwKbQnlnjvL4ON1m1gLsDryYXQ93vxK4EmD+/Pm+aNGiourf1dVFvmF7UgMsvGQZ/YPNO8smtw5x77nvSFx7ld0J0fr16/POVz0r9H3Vq0acJ2jc+UqqzuntDKbTI8oG0+lE3J5FAVRk/LTVjNP1K9czMDTyIEZmT13SKYCKjGTRIc+rgMfd/Zuxt24FTg/PTwduiZWfbGZtZnYAUQdE94dTdvvM7MgwzdOyxslM60RgWbWuB80cWYhLYnulXnBFZMaUNi494TAmtzYxta2Fya1NY7o9S7kvP1AAFSkPHQkdh57UAP9517pdyncMDydiT10hCqAiOS0EPgE8YmarQ9k/ARcDN5nZGcB64CQAd19rZjcBjxH1rHuWuw+H8T7NK7douS08IAq5PwidGL1I1LtuVST5yEKGAqiIZCyeN5uFc/ccc++45b5cSgFUpHwUQsegJzXA9sFh1m56iUnNTQwMjfxR99dvPyBxp7bFKYCK5Obu95D7mk2Ao/OMcxFwUY7yVcChOcr7CSG22jJHFs7J+lGWlPZKAVREss2Y0jamNiresVE5LpdSABUpL4XQEmX2qn32DYN8e/kq0jlOorv6nqd5w6xpieycSAFUZGIb75GFSlEAFZFyKmfHRgqgIuWnragE8b1qw+4MDDnDOVLowJAnrhtxUAAVkciMKW28ad8OBVARaVjluvxAAVSkMrQllSBXpx65joRC8jr7UAAVkSRSABWRSihHx0YKoCKVo9NxS5Brr1o+SersQwFURJJIAVREculJDRR9yUChYcdz+YECqEhl1SSEmtkzQB8wDAy5+3wz2wO4EZgDPAN8xN17w/DnA2eE4T/r7reH8sN5pffJXwFnu7ubWRtwHXA40AN81N2fGW+94516NJvR1tLEcDpNVr9ENBmJ6exDAVREkkgBVERyydejba6wWUzvt2Pp2EgBVKTyarlVHeXu89x9fnh9HnCnux8E3BleY2YHE93C4BDgOOByM8vcaf0K4Eyie/MdFN6HKLD2uvtc4FvAJeWq9OJ5s7n33HdxwKt343fnvYtzjnv9LsOkHQ7ee1q5PnLM+vv7FUBFJHEUQEUkl3XP9fGlJVHfG30DQ/QPpjln6Rquv+9ZFl6yjI9/fyULL1nGras3juinIz7sePvjUAAVqY4kbVnHA9eG59cCH4yV3+DuA+7+NLAOWGBmewPT3H1FuNH7dVnjZKa1BDg63DC+LGZMaaO9tZkZU9rY41WTcg6zesPWcn3cmKxdu5be3l4FUBFJFAVQEcnlltUbee9l/8OOrNPLmoCv/uKxXcLm2k0v7dJPx3j741AAFameWl0T6sBvzMyB77r7lcBMd98M4O6bzWyvMOxs4L7YuN2hbDA8zy7PjLMhTGvIzF4CZgBb4pUwszOJjqQyc+ZMurq6ip6BVCpFV1cXU4fSfOGNQ7u8P3Xrk3R1PVX09Mqpv7+f3t5e2tvbmTVrFitWrKhJPYqVWZZJVw/1rIc6Qv3UU8pLAVREcskc1dwxvGtvj38eTNPWsmvYBCtL77cZCqAi1VWrELrQ3TeFoHmHmf2+wLC5jmB6gfJC44wsiMLvlQDz58/3RYsWFax0XFdXF5nh773lEa5bsX7ne6e9dT8+8+43Fj2t8ci+RiJ+DeisWbM46qijqlKP8YgvyySrh3rWQx2hfuop5aMAKiL55LqnZ9zA0K5h85B9pu3spyN+TehY+uNQABWpvpqEUHffFP4+b2Y3AwuA58xs73AUdG/g+TB4N7BvbPROYFMo78xRHh+n28xagN2BFys1P187/o2cduQcVm/Yyrx9O5g7c2qlPmqE7AvyP3vEHmx56Padp+Am/QioiFRfvp4kS+mNslQKoCLjZ2ZXA+8Hnnf3Q0NZ4jt1LEYxdx+Y1NxEW8vIsDme3m8zFEBFaqPqIdTMdgOa3L0vPD8G+BpwK3A6cHH4e0sY5VbgR2b2TWAfog6I7nf3YTPrM7MjgZXAacB/xMY5HVgBnAgsC9eNVszcmVOrFj6BERfkZ/YcfuOe5/ncgfty6qmn6BpQEdlFfMfVjuE0/3DUXE45Yj/uWbdl1B4mx0oBVKRsrgG+QxQUMzKdOl5sZueF1+dmdeq4D/BbM3utuw/zSqeO9xGF0OOA24h16mhmJxN16vjRasxY5u4DX/zJwzlPyQU4++i5vLFzdw7ZZ/cRYXMsvd9mpFIpVq1apQAqUgO1OBI6E7g59BPUAvzI3X9tZg8AN5nZGcB64CQAd19rZjcBjwFDwFmhEQX4NK/szbstPACuAn5gZuuIjoCeXI0Zy6jkEYWMXKeutDTBke9+nwKoiOwi546rO/7Afyz7A44xOOw7y89ZuoaFc/ccd/ulACpSPu5+t5nNySo+HlgUnl8LdAHnEuvUEXg6/B5aEG6RN83dVwCYWaZTx9vCOBeEaS0BvmNmVumd+BmL583m4L2n8d7L7mHH8K5HRS/veoph97LtJFu+fDl9fX0KoCI1UvUQ6u5/BN6Uo7wHODrPOBcBF+UoXwUcmqO8nxBiq62Ye1aVQ65TV6yphQP32r3snyUi9S/fNVc7hiH7kvlMD5PjCaEKoCJVUTedOhbbId3X397Cht7t7Jp9o04gNzz2IHe++Aeam8Z+04NUKkVfXx/t7e10dHRw9913j3la5Za0jvuSVh9IXp2SVh9IZp2y1apjooaU60hDuY4oZJsxpY3PHrEH37jneVqaogB66YljuyBfRBpfMddcZYynh0lQABVJgMR16lhKh3TrnuvjnnVb2DYwxOVdT7Ftx/DO96a2tfDD//Nm3rRvR1HTyrZ8+fKdp+B2dHQkrpO8pHXcl7T6QPLqlLT6QDLrlE0hdJzip97mOtJQjiMKuaxdu5YtD93O5w7clyPf/T4O3Gt3BVARyStzzdWXlqzZpafJliZobmpiUvP4epgEBVCRKqvbTh3zuWX1Rs5Z8jDN1sRQOk0664hoOW/DkqQjoCITjULoOGSfevvP7zu4rPesyid+GxZ1QiQixcr0JPmjlev5zl1PMqm5eWfoHG8Pk6AAKlIDdd2pY7ae1ABfuGk10X6y6Ohnk0Fbi41or9QLrkj9Uwgdo+G073Lq7YW/fIx/fv/BXPiLx8Z9z6p8RgbQUxVARaQkM6a08ZmjD+KUI/bbJXTqGlCR5DKzHxN1QrSnmXUDXyEKnw3RqSPAiqd6yDpRg7TDN056E/vusZtuwyLSQBRCx2jHcBpPj9xBmB5Oc+g+u3Pvue+qSO+4CqAiUi7jua1BNgVQkcpz94/leavuO3WE6OyyL9y0Oud709pbx3UNqAKoSPIohI5RkxkDWfey2pGGlX/s4U3vfE1FrgFVABWRcslcz77bpGa27Rge804zBVARGa+e1AD/eONq0jlO/m1tNg7ZZ2w9/yuAiiSXQugYvbR9MGf5Jb/+PScc3qkjoCKSWJnr2QH6B9O0NRvWZCXfUkoBVETKYcVTW3IGUICPLdi3pN9UmR1s6x9fzYO/61IAFUkobZFj0JMa4IW+gZzvDTt8/3/+WLbPUgAVkXIacSupwejiq4Fhp38wzTlL19CTyt22ZVMAFZFy2ZLakfe9m1Z1F90u3bJ6IwsvWcbJ372Xzy17meHONyuAiiSUtsox6O7dnvNmWhlX3fNM0Q1mIQqgIlJumVtJ5ZK5pdRoFEBFpJzePnfPvO81mbF200ujTiO+g237EAzTzE+enUTvn3OfuSYitaUQOgad09t3vXtzTEszRf2QK0QBVEQqoXN6+y63ksoo5pZSCqAiUm5zZ07l/8ydkfO9P+8Y5lPXPsCtqzcWnEZ373bMR7Ztxe5YE5HqUwgdgxlT2uic3s7k1iZacyzBP+9I82gRe+3yUQAVkUqZMaWNS084jMmtTUwODVhbszG5tWnUW0opgIpIJfSkBnjg2d687+8Yhs/ftLrgWWbrH1/NjqHhEWWVuFe7iJSHOiYao93bW/n8uw/k4tt+n/P9r/38MY47ZFbJHRQpgIpIJWQ66+ic3s7iebNZOHfPknrHVQAVkUrp7t1OS1OhC51gKA1rN73MO1776l3eW758OQ/+rotT5r6ZnzzbVLF7tYtI+SiEjtGL23bw//4ndwAFaG4yunu3l9T4KYCKSCVkesNtbWpix3CafzhqLqccsV/R991TABWRSnp040ukBoZHHzDHxVAjb8PyAT7358GK3KtdRMpLp+OOQU9qgE0v9RccZjjtJZ0CogAqIpXQkxrgnCVRZx19A0MMDKX5xh1/4G0X3znqNVagACoildWTGuDCXz426nAtTcY+u4/8XZXrPqAzprTxpn07FEBFEk4hdAxG6x23tdn4+onFnwKiACoilXL9yvUMDO3aEdHAkI96SxYFUBGptEI9dsc1G7z/O/fs3HmWK4CKSP3Q6bhj0Dm9Hff8/eN+7uiDOHjvaUVNSwFURCqlJzXAf971ZN73m834+cObOPDVUzhkn2kjdpwpgIpINew2qZk/Dw6NOtzAsMNwtPPMnn+SB3/XpQAqUscUQsdgxpQ29pzaBuS+fuHrv/kDX//NHzjtrfvxtePfmHc6CqAiUkndvduZ1NzMwFDuH3jbdgxzwc+j0+BamuCbH5nH4nmzFUBFpCpuWb2RL/7kYYZz3zUqJ/M0t9/zAO9+iwKoSD3TljtGr57SRnPhjty4bsV61j3Xl/M9BVARqbRC9wTNNpSGLy15mA3P9yqAikjFZa5XHxwudOf1Xe0YGubINx6kACpS57T1VtjqDVt3KVMAFZFqmDGljY8c3ln08E1mfO9HP1UAFZGK6+7dTvMot2UBeN+hs5jc2kR7CzQzzClznVNOUAAVqXc6HXcMelIDvNw/RLqInXfzsm6BoAAqItXSkxrgxw9sKHr4HYNDDPe9wCmnKoCKSGV1Tm9naJTzcA342gcP5bjfreD2ex7gyMMPUgAVaRDaikt0y+qNLLxkGRt7/5zjblUjnfbW/Zg7c+rO1wqgIlJNaze9VPSpbkaad7Q9yxmnfkQBVEQqbsaUNo45eGbBYQz43e9W8ODvunj3WxRARRqJjoSWoCc1wLlLo/vtFfpZ99H5nfzN/zlQAVREaupXazYXOWSaJuBtCxcqgIpIVVx/37P84pE/FRwmDSy5+2E+NF+dEIk0Gm3NJSj2XlYnHd6pACoiNdWTGuAnD3UXOXQTwzTxjf/5U8H7hoqIjEdPaoCHN2zlyuVP8eWfPVrEGM7dQ6/B9p+vACrSYHQktATF9jTZ2tJMT2qA7t7tbHt+Pb/95c8UQEWkqq5fub6k2x4AtDY10d27fcT9QkVEyuGl7YO87eJlmEH/YLGNk+HAOUvX8PaDXq22SaSBKISWYMaUNi494TD+8aaHCw53Rdc6uv7wAk04A4PDHD/rNZx76om0tbXtDKed09vVmIpIRfSkBrjst38oebwdw8N0Tm+vQI1EZCLrSQ2woXc7A0PNY5uAG2s3vcw7Xvvq8lZMRGpG5zaUaPG82czff/eCw/x67XP0D6b586AzTBO/2rIHqcFXOjX6+PdXsvCSZdy6emOVai0iE8k5Sx5maNT+iHYdIO1w77otFamTiExcaze9hHtp9wONGxhO8zfXrdLvJpEGohBaop7UAPc/vbWkcVqbm1i76eWdnRr1DQzRP5jmnKVrdP2ViJTVltQAd/7+hSKG3PX+fIPDrnZJRMru5e1D457GwJB+N4k0EoXQEnX3bh/11izZRxii60h9l06NMtdfiYiUQ09qgD+91D+uaahdEpFym9Zenqu/1D6JNA5dE1qiXz5czKkg0RGG3SY1M+zOpSccxiH77L5Lp0aD6bSuvxKRslm76aUidpIVpnZJRMptw4vlCY5qn0Qah46ElqAnNcD37n2mqGHbW5v56uJDuPfcd7F43uydnRpNbm1ialsLk1ubuPSEw9Q5kYiUzVd//ljJ4xjQ2mxql0SkInpSA1z4y9LbprhXtTarfRJpMDoSWoLowvriht0+OMzAUHpEY7l43mwWzt1TveOKSNmterqHp17YBrOKH+dLx7yWkxfsB6B2SUQqort3ewm3ZNlVW0sT//WJwzlkn2lqn0QaiEJoCTaWeB3Chb98jOMOnTWi0ZwxpU2NqIiU3e2PPVfyOG/s3H1ne6R2SUQqYUvf2K9Tb2kyvn7iYbo1i0gDaujTcc3sODN7wszWmdl5453eL9dsLml4XUAvIrmUu20C+NlD3SUN39xkHLJP4dtNicjEU+726bZHS/vttLMewNWf/AsWz5s93iqISAI1bAg1s2bgP4G/BA4GPmZmB49nmvc81VPS8LqAXkSyVaJtWvdcHy9sGyxpnK8df4iOforICJVon5Y8tGlM401qaeKQfaaN56NFJMEaNoQCC4B17v5Hd98B3AAcX40Pbms2XUAvIvmUvW1697fuLmn4f3rv6zn1iP3H85Ei0pjK2j7d+difxjRea3N0Gq5+Q4k0rka+JnQ2sCH2uhs4otIf+uX3vp4FB8xQBx8ikk9N2qaMjx+xH2e+4zXV+jgRqS9lbZ+uv399yeNc/KFDec8hs/QbSqTBmRfb3WudMbOTgGPd/VPh9SeABe7+mdgwZwJnAsycOfPwG264oeA0H9n40s7nM9vhuRyXex689zSam6wMczB+qVSKKVOm1Loao1I9y6ce6gjVredRRx31oLvPr8qHFaGYtimUF90+FdM2QdTL5GtnTh3nHNRGvazbpWrE+WrEeYLyz1fS2iYo/2+nDS/+ma3bo0sFCrVNGTOmTGKf3at3GVMS19Wk1Slp9YHk1Slp9YHx1alabVMjHwntBvaNve4ERlyY4O5XAlcCzJ8/3xctWpR3YmvXruUbv34O2A0wvvDGIb7xyMjFd9nJ8zg6QRfQd3V1UWiekkL1LJ96qCPUTz0rZNS2CYpvn7Zt28aDj/6Q/+ieTb626bDZUzn76Ndy9MEl3L8lYRp1nWnE+WrEeYLGna8sZf3tdOXNy/jGI2nytU17vKqFz7/7tUye1MK8fTuYW+WdZEn8TpNWp6TVB5JXp6TVB5JZp2yNHEIfAA4yswOAjcDJwCljmdDatWtZunQp//LaTr72h133Kix+4yy+cvyhOnVERIpRtrZp27ZtXHfddWzf2sOX37WAi5aNzLLf+dibeetrZqhtEpFila19Wr58OZsevpvXTjucP7w88gyx/aZP5upPLqh66BSR5GjYEOruQ2b2D8DtQDNwtbuvLXU6mQDa2dnJqaeeyl+3tTHnvF/ufP+Zi99XvkqLSMMrV9uUCaA9PT2ccsopHHjggXz4bQdz/4p7ePD/vl3BU0RKVq72afny5dx1113MmzePf1n8Ph56tpc/PHw/Zy2aw4fe3KnwKSKNG0IB3P1XwK/GOn52AG1ri37UPXPx++jq6uKZUxeVqaYiMpGMt23KFUABZkxpo721WQFURMZsvO1TPIAuXryYpqYm5h8wg9Sz7Zyy6A1lrKmI1LNGvkXLuOQLoCIitZQvgIqI1FquACoikotahxwUQEUkiRRARSSpFEBFpBRqIbIogIpIEimAikhSKYCKSKnUSsQogIpIEqXTaQVQEUkkBVARGQu1FMH27dsVQEUkkXp6ehRARSRx+vr6FEBFZEzUWgRbt25VABWRRBoaGlIAFZHE6evrUwAVkTExd691HRLBzF4Ani1hlD2BLRWqTrnUQx1B9SyneqgjVLee+7v7q6v0WRVRYvtUL+tAqTRf9aMR5wnKP19qm2pPdRpd0uoDyatT0uoD46tTVdomhdAxMrNV7j6/1vUopB7qCKpnOdVDHaF+6lmPGnXZar7qRyPOEzTufFVLEpef6jS6pNUHklenpNUHklmnbDp3QkRERERERKpGIVRERERERESqRiF07K6sdQWKUA91BNWznOqhjlA/9axHjbpsNV/1oxHnCRp3vqolictPdRpd0uoDyatT0uoDyazTCLomVERERERERKpGR0JFRERERESkahRCS2Rmx5nZE2a2zszOq9JnPmNmj5jZajNbFcr2MLM7zOzJ8Hd6bPjzQ/2eMLNjY+WHh+msM7PLzMxCeZuZ3RjKV5rZnCLrdbWZPW9mj8bKqlIvMzs9fMaTZnb6GOp5gZltDMt0tZm9t5b1NLN9zewuM3vczNaa2dlJXJ4F6pmo5TlRWQ3ap1LUej2v8Lw1m9n/mtkvGmieOsxsiZn9Pnxnb22Q+frHsP49amY/NrPJjTBfSVbJtslq+FskT30S186Fdfx+M3s41Omrta5TGCdR7aYl7Pe2NWgbvJO761HkA2gGngIOBCYBDwMHV+FznwH2zCq7FDgvPD8PuCQ8PzjUqw04INS3Obx3P/BWwIDbgL8M5X8P/Fd4fjJwY5H1egfwFuDRatYL2AP4Y/g7PTyfXmI9LwC+mGPYmtQT2Bt4S3g+FfhDqEuilmeBeiZqeU7EBzVqn0qsY83W8yrM2+eBHwG/CK8bYZ6uBT4Vnk8COup9voDZwNNAe3h9E/DJep+vJD+ocNtEjX6LFKhP4tq5MP6U8LwVWAkcWev1noS1myTs9zYN2AaPmL9qfli9P8IXeHvs9fnA+VX43FwbxRPA3uH53sATueoE3B7qvTfw+1j5x4DvxocJz1uIbm5rRdZtDiMb/orXKz5MeO+7wMdKrOcF5A5NNa1nbNhbgPckdXnmqGeil+dEeFCj9mmcda7ael7h+egE7gTexSs/pup9nqYRhTXLKq/3+ZoNbCDamdUC/AI4pt7nK8mParRN1OC3SAl1S1Q7B7wKeAg4opZ1IoHtJgn6vU2DtsHxh07HLU3mn1dGdyirNAd+Y2YPmtmZoWymu28GCH/3GqWOs8Pz7PIR47j7EPASMGOMda1Gvcr1PfyDma2x6FSezOkMNa9nOB3izUR7KhO7PLPqCQldnhNIXS2fGqznlfTvwDlAOlZW7/N0IPAC8N/hdLnvm9lu1Pl8uftG4N+A9cBm4CV3/w11Pl8JV4u2KRHfZ5LauXDq62rgeeAOd691nf6d5LWbSfq93ZBtcJxCaGksR5lX4XMXuvtbgL8EzjKzdxQYNl8dC9W9GvNVznqVo75XAK8B5hH9EPnGOD6zbPU0synAUuBz7v5yoUETVs9ELs8Jpm6WT43W84ows/cDz7v7g8WOkqMsUfMUtBCd4niFu78Z2EZ06lc+dTFfYQfZ8USnq+0D7GZmHy80So6yxM1XwiVpeVTt+0xaO+fuw+4+j+gI5AIzO7RWdUpwu5mk39sN2QbHKYSWphvYN/a6E9hU6Q91903h7/PAzcAC4Dkz2xsg/H1+lDp2h+fZ5SPGMbMWYHfgxTFWtxr1Gvf34O7PhQY5DXyPaJnWtJ5m1kr0D+t6d/9pKE7c8sxVzyQuzwmoLpZPDdfzSlkILDazZ4AbgHeZ2Q+p73nKfGZ3OFoCsIToB1G9z9e7gafd/QV3HwR+CryN+p+vJKtF21TT7zPJ7Zy7bwW6gONqWKdEtpsJ+73dqG3wTgqhpXkAOMjMDjCzSUQX8d5ayQ80s93MbGrmOdG1K4+Gzz09DHY60TUHhPKTQ49XBwAHAfeHQ/Z9ZnZk6BXrtKxxMtM6EVjm4QTxMahGvW4HjjGz6WGv9jGhrGiZDTj4ENEyrVk9wzSvAh5392/G3krU8sxXz6Qtzwmq6u1TqWq8nleEu5/v7p3uPodomS9z94/X8zyF+foTsMHMXheKjgYeq/f5IjoN90gze1Woz9HA4w0wX0lWi7apZt9nEts5M3u1mXWE5+1EO2N+X6s6JbHdTNrv7QZug1/hVbr4tFEewHuJejp7CvhyFT7vQKLerh4G1mY+k+ic7TuBJ8PfPWLjfDnU7wlCD1ihfD7RBvUU8B3CxcfAZOAnwDqiHrQOLLJuPyY69XKQaG/KGdWqF/DXoXwd8FdjqOcPgEeANUQb4d61rCfwdqJTINYAq8PjvUlbngXqmajlOVEfVLl9GkP9arqeV2H+FvFKBxt1P09Ep9evCt/Xz4h6pW6E+foq0Q/wR0Pb1dYI85XkRyXbJmr4WyRPfRLXzgGHAf8b6vQo8C+hvObrPQlpN0ng720atA3OPDKVEBEREREREak4nY4rIiIiIiIiVaMQKiIiIiIiIlWjECoiIiIiIiJVoxAqIiIiIiIiVaMQKiIiIiIiIlWjECoTgpktMrNfhOeLzey8AsN2mNnfj+EzLjCzL46nniIysahtEpGkUvsklaQQKnXNzJpLHcfdb3X3iwsM0gGU3JCKiGSobRKRpFL7JEmgECqJZWZzzOz3Znatma0xsyVm9ioze8bM/sXM7gFOMrNjzGyFmT1kZj8xsylh/OPC+PcAH45N95Nm9p3wfKaZ3WxmD4fH24CLgdeY2Woz+3oY7ktm9kCox1dj0/qymT1hZr8FXlfFxSMiNaK2SUSSSu2T1IuWWldAZBSvA85w93vN7Gpe2cvW7+5vN7M9gZ8C73b3bWZ2LvB5M7sU+B7wLmAdcGOe6V8GLHf3D4U9g1OA84BD3X0egJkdAxwELAAMuNXM3gFsA04G3ky0LT0EPFje2ReRhFLbJCJJpfZJEk8hVJJug7vfG57/EPhseJ5pGI8EDgbuNTOAScAK4PXA0+7+JICZ/RA4M8f03wWcBuDuw8BLZjY9a5hjwuN/w+spRA3rVOBmd/9z+Ixbxz6bIlJn1DaJSFKpfZLEUwiVpPM8r7eFvwbc4e4fiw9kZvNyjDtWBvx/7v7drM/4XBk/Q0Tqi9omEUkqtU+SeLomVJJuPzN7a3j+MeCerPfvAxaa2VyAcN3Da4HfAweY2Wti4+ZyJ/DpMG6zmU0D+oj21GXcDvx17HqJ2Wa2F3A38CEzazezqcAHxjOjIlJX1DaJSFKpfZLEUwiVpHscON3M1gB7AFfE33T3F4BPAj8Ow9wHvN7d+4lOIflluLj+2TzTPxs4ysweIbom4RB37yE6ReVRM/u6u/8G+BGwIgy3BJjq7g8RndqyGlgK/E8Z51tEkk1tk4gkldonSTxz1xFxSSYzmwP8wt0PrXVdREQy1DaJSFKpfZJ6oSOhIiIiIiIiUjU6EioiIiIiIiJVoyOhIiIiIiIiUjUKoSIiIiIiIlI1CqEiIiIiIiJSNQqhIiIiIiIiUjUKoSIiIiIiIlI1CqEiIiIiIiJSNf8/+GAKUcr/yGoAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 1080x1080 with 3 Axes>"
       ]
@@ -1533,7 +1580,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ccdf7257",
+   "id": "7fee4fe8",
    "metadata": {},
    "source": [
     "You have trained a model better than your baseline. As indicated in the charts above, there is still additional feature engineering and data cleaning opportunities to improve your model's performance on customers with CLV. Some options include handling these customers as a separate prediction task, applying a log transformation to your target, clipping their value or dropping these customers all together to improve model performance.\n",
@@ -1543,7 +1590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6a01347c",
+   "id": "797aee1c",
    "metadata": {},
    "source": [
     "## Create a managed Tabular dataset from your BigQuery data source"
@@ -1551,7 +1598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "994e967c",
+   "id": "bf9634f9",
    "metadata": {},
    "source": [
     "[**Vertex AI managed datasets**](https://cloud.google.com/vertex-ai/docs/datasets/prepare-tabular) can be used to train AutoML models or custom-trained models.\n",
@@ -1563,17 +1610,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
-   "id": "a0cb2758",
+   "execution_count": 38,
+   "id": "c8b8c5bd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.datasets.dataset:Creating TabularDataset\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:Create TabularDataset backing LRO: projects/654544512569/locations/us-central1/datasets/8102160447592988672/operations/4313443764271054848\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:TabularDataset created. Resource name: projects/654544512569/locations/us-central1/datasets/8102160447592988672\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:To use this TabularDataset in another session:\n",
+      "INFO:google.cloud.aiplatform.datasets.dataset:ds = aiplatform.TabularDataset('projects/654544512569/locations/us-central1/datasets/8102160447592988672')\n"
+     ]
+    }
+   ],
    "source": [
-    "ds = aiplatform.TabularDataset.create(display_name=\"online-retail-clv\", bq_source=f\"{BQ_URI}\")"
+    "BQ_URI=f\"bq://{PROJECT_ID}.{BQ_DATASET_NAME}.{BQ_ML_TABLE_NAME}\"\n",
+    "ds = aiplatform.TabularDataset.create(display_name=\"online-retail-clv\", bq_source=BQ_URI)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1bcf11b8",
+   "id": "3cd88f1e",
    "metadata": {},
    "source": [
     "## Vertex AI custom training workflow: containerize your model training code"
@@ -1581,7 +1641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "914ad863",
+   "id": "c3c90a23",
    "metadata": {},
    "source": [
     "There are two ways you can train a custom model on Vertex AI:\n",
@@ -1595,7 +1655,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8949d9e2",
+   "id": "087ec287",
    "metadata": {},
    "source": [
     "In the next 5 steps, you will proceed with **2. Use your own custom container image** that also leverages a Vertex AI prebuilt container that already contains pre-built and tested versions of model code dependencies such as `tensorflow` and the `google-cloud-bigquery` SDK. This enables you to manage and share your model container image with others for reuse and reproducibility while also enabling you to incorporate additional packages for your ML application. You will walk through creating the following project structure for your ML mode code:\n",
@@ -1615,7 +1675,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8cf752c",
+   "id": "67abfce6",
    "metadata": {},
    "source": [
     "### 1. Write a `model.py` training script"
@@ -1623,7 +1683,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db8e2161",
+   "id": "ce37eef9",
    "metadata": {},
    "source": [
     "First, you will take tidy up your local TensorFlow model training code from above into a training script.\n",
@@ -1633,8 +1693,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1417,
-   "id": "2c3a7ae1",
+   "execution_count": 41,
+   "id": "88c72de0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1644,8 +1704,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1436,
-   "id": "148f2991",
+   "execution_count": 42,
+   "id": "75ff10ed",
    "metadata": {},
    "outputs": [
     {
@@ -1811,7 +1871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6daee005",
+   "id": "46380198",
    "metadata": {},
    "source": [
     "### 2. Write a `task.py` file as an entrypoint to your custom ML model container"
@@ -1819,8 +1879,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1419,
-   "id": "11f10ab5",
+   "execution_count": 43,
+   "id": "26d96aeb",
    "metadata": {},
    "outputs": [
     {
@@ -1871,72 +1931,15 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86d72c0a",
+   "id": "57880628",
    "metadata": {},
    "source": [
-    "### 3. Write a `Dockerfile` for your custom ML model container"
+    "### 4. specify additional ML code dependencies"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "75e8f8af",
-   "metadata": {},
-   "source": [
-    "Third, you will write a `Dockerfile` that contains your model code as well as specifies your model code's dependencies.\n",
-    "\n",
-    "Notice the base image below is a Vertex AI [pre-built container](https://cloud.google.com/vertex-ai/docs/training/pre-built-containers). This image includes dependencies you need for your training code such TensorFlow and BigQuery SDK which are already tested and built to save you time when building your custom container."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1456,
-   "id": "6aa86895",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Overwriting online-retail-clv-3M/Dockerfile\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%writefile {MODEL_NAME}/Dockerfile\n",
-    "# Specifies base image and tag.\n",
-    "# https://cloud.google.com/vertex-ai/docs/training/pre-built-containers\n",
-    "# us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-3:latest\n",
-    "FROM gcr.io/deeplearning-platform-release/tf2-cpu.2-3\n",
-    "\n",
-    "# Sets the container working directory.\n",
-    "WORKDIR /root\n",
-    "\n",
-    "# Copies the requirements.txt into the container to reduce network calls.\n",
-    "COPY requirements.txt .\n",
-    "# Installs additional packages.\n",
-    "RUN pip3 install -U -r requirements.txt\n",
-    "\n",
-    "# Copies the trainer code to the docker image.\n",
-    "COPY . /trainer\n",
-    "\n",
-    "# Sets the container working directory.\n",
-    "WORKDIR /trainer\n",
-    "\n",
-    "# Sets up the entry point to invoke the trainer.\n",
-    "ENTRYPOINT [\"python\", \"-m\", \"trainer.task\"]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "90d9fecd",
-   "metadata": {},
-   "source": [
-    "### 4. Write a `requirements.txt` file to specify additional ML code dependencies"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "279d289c",
+   "id": "7e870ebc",
    "metadata": {},
    "source": [
     "These are additional dependencies for your model code outside the pre-built containers needed for prediction explainability and the BigQuery TensorFlow IO reader."
@@ -1944,143 +1947,101 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1421,
-   "id": "b65f5d2d",
+   "execution_count": 55,
+   "id": "60a5d37f",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Overwriting online-retail-clv-3M/requirements.txt\n"
+      "Overwriting online-retail-clv-3M/setup.py\n"
      ]
     }
    ],
    "source": [
-    "%%writefile {MODEL_NAME}/requirements.txt\n",
-    "explainable-ai-sdk==1.3.0\n",
-    "tensorflow-io==0.16.0\n",
-    "pyarrow"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b7f29c38",
-   "metadata": {},
-   "source": [
-    "### 5. Use Cloud Build to build and submit your container to Google Cloud Artifact Registry"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3fbaa905",
-   "metadata": {},
-   "source": [
-    "Next, you will use [Cloud Build](https://cloud.google.com/build) to build and upload your custom TensorFlow model container to [Google Cloud Artifact Registry](https://cloud.google.com/artifact-registry).\n",
+    "%%writefile {MODEL_NAME}/setup.py\n",
+    "from setuptools import find_packages, setup\n",
     "\n",
-    "Cloud Build brings reusability and automation to your ML experimentation by enabling you to reliably build, test, and deploy your ML model code as part of a CI/CD workflow. Artifact Registry provides a centralized repository for you to store, manage, and secure your ML container images. This will allow you to securely share your ML work with others and reproduce experiment results.\n",
+    "PACKAGE_NAME = \"clv_prebuilt\"\n",
+    "VERSION = \"0.1\"\n",
+    "REQUIRED_PACKAGES = [\n",
+    "    \"explainable-ai-sdk==1.3.0\",\n",
+    "    \"tensorflow-io==0.16.0\",\n",
+    "    \"pyarrow\",\n",
+    "]\n",
     "\n",
-    "**Note**: the build and submit step will take about 5 minutes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "96f085de",
-   "metadata": {},
-   "source": [
-    "#### Create Artifact Repository for custom container images"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1422,
-   "id": "7ff20309",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ARTIFACT_REPOSITORY=\"online-retail-clv\""
+    "setup(\n",
+    "    name=\"clv_prebuilt\",\n",
+    "    version=\"0.1\",\n",
+    "    install_requires=REQUIRED_PACKAGES,\n",
+    "    packages=find_packages(),\n",
+    "    include_package_data=True,\n",
+    "    description=\"CLV prebuilt.\",\n",
+    ")\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "02eebd3b",
+   "execution_count": 56,
+   "id": "2bd25ac0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "running sdist\n",
+      "running egg_info\n",
+      "writing clv_prebuilt.egg-info/PKG-INFO\n",
+      "writing dependency_links to clv_prebuilt.egg-info/dependency_links.txt\n",
+      "writing requirements to clv_prebuilt.egg-info/requires.txt\n",
+      "writing top-level names to clv_prebuilt.egg-info/top_level.txt\n",
+      "reading manifest file 'clv_prebuilt.egg-info/SOURCES.txt'\n",
+      "writing manifest file 'clv_prebuilt.egg-info/SOURCES.txt'\n",
+      "warning: sdist: standard file not found: should have one of README, README.rst, README.txt, README.md\n",
+      "\n",
+      "running check\n",
+      "warning: check: missing required meta-data: url\n",
+      "\n",
+      "warning: check: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) must be supplied\n",
+      "\n",
+      "creating clv_prebuilt-0.1\n",
+      "creating clv_prebuilt-0.1/clv_prebuilt.egg-info\n",
+      "creating clv_prebuilt-0.1/trainer\n",
+      "copying files to clv_prebuilt-0.1...\n",
+      "copying setup.py -> clv_prebuilt-0.1\n",
+      "copying clv_prebuilt.egg-info/PKG-INFO -> clv_prebuilt-0.1/clv_prebuilt.egg-info\n",
+      "copying clv_prebuilt.egg-info/SOURCES.txt -> clv_prebuilt-0.1/clv_prebuilt.egg-info\n",
+      "copying clv_prebuilt.egg-info/dependency_links.txt -> clv_prebuilt-0.1/clv_prebuilt.egg-info\n",
+      "copying clv_prebuilt.egg-info/requires.txt -> clv_prebuilt-0.1/clv_prebuilt.egg-info\n",
+      "copying clv_prebuilt.egg-info/top_level.txt -> clv_prebuilt-0.1/clv_prebuilt.egg-info\n",
+      "copying trainer/__init__.py -> clv_prebuilt-0.1/trainer\n",
+      "copying trainer/model.py -> clv_prebuilt-0.1/trainer\n",
+      "copying trainer/task.py -> clv_prebuilt-0.1/trainer\n",
+      "Writing clv_prebuilt-0.1/setup.cfg\n",
+      "Creating tar archive\n",
+      "removing 'clv_prebuilt-0.1' (and everything under it)\n"
+     ]
+    }
+   ],
    "source": [
-    "# Create an Artifact Repository using the gcloud CLI.\n",
-    "!gcloud artifacts repositories create $ARTIFACT_REPOSITORY \\\n",
-    "--repository-format=docker \\\n",
-    "--location=$REGION \\\n",
-    "--description=\"Artifact registry for ML custom training images for predictive CLV\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "29a0bc3e",
-   "metadata": {},
-   "source": [
-    "#### Create `cloudbuild.yaml` instructions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1424,
-   "id": "a709a863",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "IMAGE_NAME=\"dnn-regressor\"\n",
-    "IMAGE_TAG=\"latest\"\n",
-    "IMAGE_URI=f\"{REGION}-docker.pkg.dev/{PROJECT_ID}/{ARTIFACT_REPOSITORY}/{IMAGE_NAME}:{IMAGE_TAG}\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1427,
-   "id": "0347db70",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cloudbuild_yaml = f\"\"\"steps:\n",
-    "- name: 'gcr.io/cloud-builders/docker'\n",
-    "  args: [ 'build', '-t', '{IMAGE_URI}', '.' ]\n",
-    "images: \n",
-    "- '{IMAGE_URI}'\"\"\"\n",
-    "\n",
-    "with open(f\"{MODEL_NAME}/cloudbuild.yaml\", \"w\") as fp:\n",
-    "    fp.write(cloudbuild_yaml)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f01d262b",
-   "metadata": {},
-   "source": [
-    "#### Build and submit your container image to your Artifact Repository"
+    "!cd $MODEL_NAME && python ./setup.py sdist --formats=gztar"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "feb6b80b",
+   "execution_count": 59,
+   "id": "d4ae9fae",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!gcloud builds submit --timeout=15m --config {MODEL_NAME}/cloudbuild.yaml {MODEL_NAME}"
+    "!gsutil -q cp $MODEL_NAME/dist/clv_prebuilt-0.1.tar.gz gs://$GCS_BUCKET/sdist/"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4af33ffc",
-   "metadata": {},
-   "source": [
-    "Now that your custom container is built and stored in your Artifact Registry, its time to train our model in the cloud with Vertex AI."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f0eb9495",
+   "id": "2ddd0244",
    "metadata": {},
    "source": [
     "## Run a custom training job on Vertex AI"
@@ -2088,7 +2049,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "409a104e",
+   "id": "6b62bb86",
    "metadata": {},
    "source": [
     "Use the `CustomTrainingJob` class to define the job, which takes the following parameters specific to custom container training:\n",
@@ -2112,8 +2073,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1432,
-   "id": "1690db87",
+   "execution_count": 60,
+   "id": "33db0c5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2131,8 +2092,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1433,
-   "id": "b490e0e8",
+   "execution_count": 61,
+   "id": "85ff5ebd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2142,14 +2103,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c6380811",
+   "execution_count": 66,
+   "id": "243c67ca",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:google.cloud.aiplatform.training_jobs:Training Output directory:\n",
+      "gs://dsparing-sandbox/vertex-custom-training-online-retail-clv-3M-20210715213005 \n",
+      "INFO:google.cloud.aiplatform.training_jobs:View Training:\n",
+      "https://console.cloud.google.com/ai/platform/locations/us-central1/training/8252973860505255936?project=654544512569\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936 current state:\n",
+      "PipelineState.PIPELINE_STATE_RUNNING\n",
+      "INFO:google.cloud.aiplatform.training_jobs:View backing custom job:\n",
+      "https://console.cloud.google.com/ai/platform/locations/us-central1/training/1334318932957331456?project=654544512569\n",
+      "INFO:google.cloud.aiplatform.training_jobs:CustomPythonPackageTrainingJob run completed. Resource name: projects/654544512569/locations/us-central1/trainingPipelines/8252973860505255936\n",
+      "INFO:google.cloud.aiplatform.training_jobs:Model available at projects/654544512569/locations/us-central1/models/2850646622730190848\n"
+     ]
+    }
+   ],
    "source": [
-    "job = aiplatform.CustomContainerTrainingJob(\n",
-    "    display_name=\"online-retail-clv-3M-dnn-regressor\",\n",
-    "    container_uri=IMAGE_URI,\n",
+    "job = aiplatform.CustomPythonPackageTrainingJob(\n",
+    "    display_name=\"prebuilt-online-retail-clv-3M-dnn-regressor\",\n",
+    "    python_package_gcs_uri=f\"gs://{GCS_BUCKET}/sdist/clv_prebuilt-0.1.tar.gz\",\n",
+    "    python_module_name=\"trainer.task\",\n",
+    "    container_uri=\"us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-3:latest\",\n",
     "    # https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
     "    model_serving_container_image_uri=\"gcr.io/cloud-aiplatform/prediction/tf2-cpu.2-3:latest\",\n",
     ")\n",
@@ -2173,17 +2163,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1437,
-   "id": "171fe9ef",
+   "execution_count": 67,
+   "id": "c61f4c41",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'gs://dougkelly-vertex-demos-bucket/vertex-custom-training-online-retail-clv-3M-20210715060754/model'"
+       "'gs://dsparing-sandbox/vertex-custom-training-online-retail-clv-3M-20210715213005/model'"
       ]
      },
-     "execution_count": 1437,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2196,7 +2186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9c416f1",
+   "id": "d5013b4f",
    "metadata": {},
    "source": [
     "## Inspect model training performance with Vertex TensorBoard"
@@ -2204,7 +2194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "357889b1",
+   "id": "d42cdc85",
    "metadata": {},
    "source": [
     "[**Vertex TensorBoard**](https://cloud.google.com/vertex-ai/docs/experiments) is Google Cloud's managed version of open-source [**TensorBoard**](https://www.tensorflow.org/tensorboard) for ML experimental visualization. With Vertex TensorBoard you can track, visualize, and compare ML experiments and share them with your team. In addition to the powerful visualizations from open source TensorBoard, Vertex TensorBoard provides:\n",
@@ -2219,7 +2209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1999724",
+   "id": "673a794c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2229,8 +2219,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1444,
-   "id": "ddfe7ec0",
+   "execution_count": null,
+   "id": "6c38e8bd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2242,7 +2232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4ba95ab",
+   "id": "2838bb9d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2254,7 +2244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9f4e6264",
+   "id": "4f4c767a",
    "metadata": {},
    "source": [
     "You can view your model's logs go to the Vertex AI [**Experiments tab**](https://console.cloud.google.com/vertex-ai/experiments) in the Cloud Console."
@@ -2262,7 +2252,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9a93e234",
+   "id": "3be1cf88",
    "metadata": {},
    "source": [
     "## Build the Explanation Metadata and Parameters"
@@ -2270,7 +2260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "feaf3a6e",
+   "id": "ab997b17",
    "metadata": {},
    "source": [
     "[**Vertex Explainable AI**](https://cloud.google.com/vertex-ai/docs/explainable-ai) integrates feature attributions into Vertex AI. Vertex Explainable AI helps you understand your model's outputs for classification and regression tasks. Vertex AI tells you how much each feature in the data contributed to the predicted result. You can then use this information to verify that the model is behaving as expected, identify and mitigate biases in your models, and get ideas for ways to improve your model and your training data.\n",
@@ -2280,8 +2270,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1447,
-   "id": "104ad2d0",
+   "execution_count": null,
+   "id": "ca4e6eab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2290,8 +2280,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1448,
-   "id": "52fd9670",
+   "execution_count": null,
+   "id": "8a076dae",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2312,8 +2302,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1449,
-   "id": "25fa7773",
+   "execution_count": null,
+   "id": "4f04ad13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2326,8 +2316,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1450,
-   "id": "7e633bcd",
+   "execution_count": null,
+   "id": "ecf5e4a9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2351,7 +2341,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52f2ff8a",
+   "id": "41e7ae17",
    "metadata": {},
    "source": [
     "## Deploy a Vertex `Endpoint` for online predictions"
@@ -2359,7 +2349,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4c992be0",
+   "id": "71343969",
    "metadata": {},
    "source": [
     "Before you use your model to make predictions, you need to deploy it to an `Endpoint` object. When you deploy a model to an `Endpoint`, you associate physical (machine) resources with that model to enable it to serve online predictions. Online predictions have low latency requirements; providing resources to the model in advance reduces latency. You can do this by calling the deploy function on the `Model` resource. This will do two things:\n",
@@ -2385,7 +2375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "092a7ee4",
+   "id": "6601110f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2398,7 +2388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "058780ff",
+   "id": "da8a66ff",
    "metadata": {},
    "source": [
     "## Get an online prediction and explanation from deployed model"
@@ -2406,7 +2396,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6921ed17",
+   "id": "b40894c5",
    "metadata": {},
    "source": [
     "Finally, you will use your `Endpoint` to retrieve predictions and feature attributions. This is an customer instance from the test set."
@@ -2414,8 +2404,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1452,
-   "id": "143f6525",
+   "execution_count": null,
+   "id": "f3c73545",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2431,7 +2421,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e7af0960",
+   "id": "3a84d8cf",
    "metadata": {},
    "source": [
     "To request predictions, you call the `predict()` method."
@@ -2439,28 +2429,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1453,
-   "id": "d0145253",
+   "execution_count": null,
+   "id": "c5bb0855",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Prediction(predictions=[[3279.93677]], deployed_model_id='14619106602909696', explanations=None)"
-      ]
-     },
-     "execution_count": 1453,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "endpoint.predict([test_instance_dict])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "82fb5352",
+   "id": "a5573645",
    "metadata": {},
    "source": [
     "To retrieve explanations (predictions + feature attributions), call the `explain()` method."
@@ -2468,8 +2447,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1454,
-   "id": "385452ee",
+   "execution_count": null,
+   "id": "40a039f1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2478,30 +2457,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1455,
-   "id": "78b3d38e",
+   "execution_count": null,
+   "id": "bbb2d78d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAeUAAAD4CAYAAADSD/6TAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAe/klEQVR4nO3de5xWZb338c9XDo6IaAjtrQ0ymJlhJeJ4yCOpWUGiPGqalhnbzauyPPQipbSDT7v9kPV0VOvBY5mhqXhug2QSiiAMyMlDWoLbMbeiEh7xMP6eP9Y1cTvec+Seua+B7/v1ul+z5lrXutZvrfsF3/taa82MIgIzMzOrvi2qXYCZmZkVHMpmZmaZcCibmZllwqFsZmaWCYeymZlZJvpWuwDrvYYMGRJ1dXXVLsPMrFdZvHjxsxExtNw6h7J1WV1dHQ0NDdUuw8ysV5H0eGvrfPnazMwsEw5lMzOzTDiUzczMMuF7ymZm1qu88cYbNDY2sn79+mqX0qaamhpqa2vp169fh7dxKJuZWa/S2NjINttsQ11dHZKqXU5ZEcFzzz1HY2MjI0aM6PB2vnxtZma9yvr169l+++2zDWQASWy//fadns07lM3MrNfJOZCbdaVGh7KZmVkmfE/ZzMx6tbopt1d0vNVTx3Wo38yZMznjjDNoamri1FNPZcqUKRu9b4eyVc3G/EPq6D8aM7Pu0NTUxGmnncbs2bOpra1l7733Zvz48YwcOXKjxvXlazMzs05auHAhu+yyCzvvvDP9+/fnhBNO4Oabb97ocR3KZmZmnfTkk08ybNiwf35fW1vLk08+udHjOpTNzMw6KSLe0VaJJ8IdymZmZp1UW1vLE0888c/vGxsb2XHHHTd6XIeymZlZJ+299948+uijrFq1itdff51rrrmG8ePHb/S4fvrazMx6tWr8NEbfvn258MIL+fjHP05TUxMTJ05k99133/hxK1CbmZnZZmfs2LGMHTu2omP68rWZmVkmHMrdTNIcSfUZ1PFFSSdXuw4zM2udL19XgIrn4BURb1W7ltZExK+qXYOZWaVERPZ/lKLcj021p9fNlCXdJGmxpAckTZL0JUkXlKw/RdIv0vK3JD0sabak6ZImtzHuHEk/lXSvpJWS9knt3y3dLq2rS6+HJF0MLAGGSTpb0gpJyyRNLRn+OEkLJT0i6aA0Tp2kuyUtSa/9U/sOkuZKWpr21dz/CEnzU9/rJA1s41imSnpQ0nJJPyo9Dkk7prGbX02ShksaKukGSYvS64BWxp4kqUFSw5o1a9p9v8zMKq2mpobnnnuuS6HXU5r/nnJNTU2ntuuNM+WJEfG8pK2ARcBhwDzg7LT+eOD76ZLxMcCeFMe5BFjczthbR8T+kg4GLgc+2E7/9wNfiIgvS/okcDSwb0S8ImlwSb++EbGPpLHAd4DDgWeAj0XEeknvA6YD9cCJwKyI+L6kPsAASUOA84DDI+JlSecAXwP+d8uC0n4nALtFREjarnR9RPwdGJX6ngYcEhGPS/od8JOIuEfSTsAs4AMtx4+IacA0gPr6+nz/RZjZJqu2tpbGxkZynxjU1NRQW1vbqW16YyifLmlCWh4GjAAek7Qf8ChFUM4DzgBujohXASTd2oGxpwNExFxJg1oGWhmPR8SCtHw4cEVEvJLGeL6k34z0dTFQl5b7ARdKGgU0Abum9kXA5ZL6ATdFxFJJhwAjgXnpck1/YH4rNb0ArAculXQ7cFu5TmkmfCpwUEn9I0suBw2StE1EvNjmGTAz62H9+vVjxIgR1S6jW/SqUJY0hiI8PpJmo3OAGuBa4NPAw8CNaYbYlZsNLWd+AbzJ2y/zl16LeLm0vDLbN3stfW1iwzk/C3ga2CONvx7++YHgYGAccJWkHwJrgdkR8Zl2DyDizXTp/TDgBOArwKGlfSTtAFwGjI+Il1LzFhTn9dX29mFmZt2jt91T3hZYmwJ5N2C/1D6D4tLxZygCGuAe4EhJNen+a0d+uvx4AEkHAusiYh2wGhid2kdTzMzLuQOYKGlA6ju4lX6lx/JUejjsc0CftN1w4JmIuIQiOEcDC4ADJO2S+gyQtGu5QdOxbhsRfwDOJF2qLlnfD/g9cE5EPNKi/q+U9HvbdmZm1v161UwZmAl8UdJy4C8UYUVErJX0IDAyIhamtkWSbgGWAY8DDcC6dsZfK+leYBAwMbXdAJwsaSnFpeVHym0YETNTkDVIeh34A/DNNvZ1MXCDpOOAu9gw6x4DfF3SG8BLwMkRsUbSKcB0SVumfue1Uss2wM2Saihm72e1WL8/sDdwvqTzU9tY4HTgonRu+wJzgS+2Ub+ZmVWYcn56bWNJGhgRL6XZ61xgUkQsaaXvHGByRDT0ZI29WX19fTQ0dP101U25vcvbVuPX6pmZVYKkxRFR9vdX9LaZcmdNkzSS4j7wr1sLZDMzsxxs0qEcESe2bJN0EdDyZ3B/FhFjeqSoCpJ0I++8x31ORMyqRj1mZrZxNulQLiciTqt2DZUSERPa72VmZr1Fb3v62szMbJO12c2ULR9+WMvM7O08UzYzM8uEQ9nMzCwTDmUzM7NMOJTNzMwy4VA2MzPLhEPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMOZTMzs0w4lM3MzDLhUDYzM8uEQ9nMzCwTDmUzM7NMOJTNzMwy4VA2MzPLhEPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy0Tfahdgm6+6KbdXuwQzsy5ZPXVct4zrmbKZmVkmHMpmZmaZcCibmZllwqFsZmaWCYeymZlZJhzKZmZmmXAoV5Ckb1a7BjMz670cypXVo6EsyT9nbma2CXEol5B0sqTlkpZJukrSlZKOLVn/Uvq6g6S5kpZKWinpIElTga1S29Wp39fS+pWSzkxtdZIelnRpar9a0uGS5kl6VNI+qd/Wki6XtEjS/ZKOSu2nSLpO0q3AHa0cx0BJd0paImlF87Zp3bfS/mdLmi5pcmp/r6SZkhZLulvSbt1yks3MrFWeaSWSdgfOBQ6IiGclDQZ+3Er3E4FZEfF9SX2AARFxt6SvRMSoNN5ewBeAfQEB90n6M7AW2AU4DpgELErjHQiMp5htH51q+VNETJS0HbBQ0h/T/j8CfDginm+lvvXAhIh4QdIQYIGkW4C9gGOAPSne+yXA4rTNNOCLEfGopH2Bi4FDO3j6zMysAhzKGxwKXB8RzwJExPOSWuu7CLhcUj/gpohYWqbPgcCNEfEygKQZwEHALcCqiFiR2h8A7oyIkLQCqEvbHwGMb57JAjXATml5dhuBDMWHgP+UdDDwFvAe4F9STTdHxKtp37emrwOB/YHrSo55y7IDS5MoPkyw0047letiZmZd5MvXGwiIFm1vks6RirTqDxARc4GDgSeBqySd3Mp4rXmtZPmtku/fYsMHJQHHRMSo9NopIh5K615u51hOAoYCe6WZ+9MUod5aTVsA/yjZ16iI+EC5jhExLSLqI6J+6NCh7ZRhZmad4VDe4E7g05K2B0iXr1dTXPIFOArol9YNB56JiEuAy4DRqc8bafYMMBc4WtIASVsDE4C7O1HPLOCr6cMAkvbsxLbbpvrekPRRYHhqvwc4UlJNmh2PA4iIF4BVko5L+5KkPTqxPzMzqwBfvk4i4gFJ3wf+LKkJuB84B7hZ0kKK0G6eoY4Bvi7pDeAloHmmPA1YLmlJRJwk6UpgYVp3aUTcL6mugyV9D/hpGk8UHxA+1cFtrwZuldQALAUeTse4KN1bXgY8DjQA69I2JwG/lHQexYePa1I/MzPrIYpoecXWNmWSBkbES5IGUMzmJ0XEkq6MVV9fHw0NDV2uxX+60cx6q435042SFkdEfbl1nilvfqZJGklxj/nXXQ1kMzOrPIdyLybpQ8BVLZpfi4h9W9smIk7s3qrMzKyrHMq9WPqxqlHVrsPMzCrDT1+bmZllwqFsZmaWCV++tqrZmKcXzcw2RZ4pm5mZZcKhbGZmlgmHspmZWSYcymZmZplwKJuZmWXCoWxmZpYJh7KZmVkmHMpmZmaZcCibmZllwqFsZmaWCYeymZlZJhzKZmZmmXAom5mZZcKhbGZmlgmHspmZWSYcymZmZplwKJuZmWXCoWxmZpYJh7KZmVkmHMpmZmaZcCibmZllom+1C7DNV92U26tdgplVyOqp46pdwibBM2UzM7NMOJTNzMwy4VA2MzPLhEPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMO5UTSHEn11a7DzMw2X5tVKKuQ5TFL6lPtGszMrLq6LaAk3SRpsaQHJE2S9CVJF5SsP0XSL9LytyQ9LGm2pOmSJrcx7hxJP5V0r6SVkvZJ7d8t3S6tq0uvhyRdDCwBhkk6W9IKScskTS0Z/jhJCyU9IumgNE6dpLslLUmv/VP7DpLmSlqa9tXc/whJ81Pf6yQNbONYVkv6tqR70r7fsa2kT0r6fck2YyTd2ta+0rjnp/YVknZr6xyl5c+mY18q6f+19iEhvZcNkhrWrFnT2qGZmVkXdOescWJE7AXUA6cDM4D/VbL+eODadMn4GGDPtL4jl5C3joj9gS8Dl3eg//uB30TEnsBI4Ghg34jYA7igpF/fiNgHOBP4Tmp7BvhYRIxONf88tZ8IzIqIUcAewFJJQ4DzgMNT/wbga+3Utj4iDgT+2Mq2s4H9JG2d+jeft/b29Wxq/yXQ6occAEkfSOMekI6nCTipXN+ImBYR9RFRP3To0HYOzczMOqM7/yDF6ZImpOVhwAjgMUn7AY9SBOU84Azg5oh4FaB5FtiO6QARMVfSIEnbtdP/8YhYkJYPB66IiFfSGM+X9JuRvi4G6tJyP+BCSaMowmrX1L4IuFxSP+CmiFgq6RCK0J8nCaA/ML+d2q5NX/crt21EvClpJnCkpOuBccDZQHv7Kj2W0g9D5RwG7AUsSmNtRfFhxMzMelC3hLKkMRTh95GIeEXSHKCGIoA+DTwM3BgRoZQCnRRlvn+Tt8/8a0qWXy4tr8z2zV5LX5vYcG7OAp6mmA1vAayHf34gOJgiJK+S9ENgLTA7Ij7TiWNprk1tbHstcBrwPLAoIl5M562tfZU7ltbOkYBfR8Q3OlG3mZlVWHddvt4WWJsCeTeKWSAUs7ejgc+wYYZ4D8UssCbdE+3I3/86HkDSgcC6iFgHrAZGp/bRFDPzcu4AJkoakPoO7sCxPBURbwGfA/qk7YYDz0TEJcBlad8LgAMk7ZL6DJC0a/lh36Gtbeek8f+dDeetK/taTflzdCdwrKR3p3WD0/GZmVkP6q5Qngn0lbQc+B5FgBARa4EHgeERsTC1LQJuAZZRhHYDsK6d8ddKuhf4FfBvqe0GYLCkpcCXgEfKbRgRM9P+GlLfNu+3AhcDn5e0gOLSdfPMdgzFfeT7Ke6J/ywi1gCnANPTsS8Admtn/Oa6Wt02IpqA24BPpq9t9m9D2XMUEQ9S3J++I401G9ihI3WbmVnlKKK1K7k9WIQ0MCJeSrPXucCkiFjSSt85wOSIaOjJGu2d6uvro6Gh629D3ZTbK1iNmVXT6qkduchpAJIWR0TZh5q780GvzpgmaSTFPc5ftxbIZmZmm7IsQjkiTmzZJuki4IAWzT+LiDE9UlQFSbqRd97jPiciZlWjHjMzy1MWoVxORJxW7RoqJSImtN/LzMw2d1n+ykkzM7PNUbYzZdv0+cEQM7O380zZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMOZTMzs0w4lM3MzDLhUDYzM8uEQ9nMzCwTDmUzM7NMOJTNzMwy4VA2MzPLhEPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMOZTMzs0w4lM3MzDLhUDYzM8uEQ9nMzCwTfatdgG2+6qbcXu0SsrB66rhql2BmmfBM2czMLBMOZTMzs0w4lM3MzDLhUDYzM8uEQ9nMzCwTDmUzM7NMOJTNzMwy4VDuRSTNkVRf7TrMzKx7OJQzo4LfFzOzzZD/8+8gSXWSHpJ0iaQHJN0haatW+s6R9FNJ90paKWmf1P5dSZNL+q1M4zaPfTGwBBgm6WxJKyQtkzS1ZPjjJC2U9Iikg0pqu1vSkvTaP7XvIGmupKVpX839j5A0P/W9TtLA1D5V0oOSlkv6UbecSDMza5VDuXPeB1wUEbsD/wCOaaPv1hGxP/Bl4PIOjP1+4DcRsScwEjga2Dci9gAuKOnXNyL2Ac4EvpPangE+FhGjgeOBn6f2E4FZETEK2ANYKmkIcB5weOrfAHxN0mBgArB7RHwY+I9yRUqaJKlBUsOaNWs6cFhmZtZR/t3XnbMqIpam5cVAXRt9pwNExFxJgyRt187Yj0fEgrR8OHBFRLySxni+pN+MMvvvB1woaRTQBOya2hcBl0vqB9wUEUslHUIR+vMkAfQH5gMvAOuBSyXdDtxWrsiImAZMA6ivr492jsnMzDrBodw5r5UsNwFlL18nLQMrgDd5+9WJmpLll0uWVWb7ljU0seH9Owt4mmI2vAVFuDZ/IDgYGAdcJemHwFpgdkR8puXA6TL7YcAJwFeAQ9s4PjMzqzBfvu4+xwNIOhBYFxHrgNXA6NQ+GhjRyrZ3ABMlDUh9B7ezr22BpyLiLeBzQJ+03XDgmYi4BLgs7XsBcICkXVKfAZJ2TfeVt42IP1BcGh/VhWM2M7ON4Jly91kr6V5gEDAxtd0AnCxpKcWl5UfKbRgRM9Ol6AZJrwN/AL7Zxr4uBm6QdBxwFxtm3WOAr0t6A3gJODki1kg6BZguacvU7zzgReBmSTUUM/WzOn3EZma2URTh24KVJmkOMDkiGqpdS3eqr6+PhoauH6L/nnLBf0/ZbPMiaXFElP2dE758bWZmlglfvt4Iki4CDmjR/LOIGFOFcszMrJdzKG+EiDit2jWYmdmmw5evzczMMuGZslWNH3AyM3s7z5TNzMwy4VA2MzPLhEPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMOZTMzs0w4lM3MzDLhUDYzM8uEQ9nMzCwTDmUzM7NMOJTNzMwy4VA2MzPLhEPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMOZTMzs0w4lM3MzDLhULaqqJtye7VLMDPLjkPZzMwsEw5lMzOzTDiUzczMMuFQNjMzy4RD2czMLBMOZTMzs0w4lM3MzDLhUDYzM8tEp0NZ0nclTe6OYtrY546Sru+B/YyRdFsXtttO0pe7o6YO7LtLNZuZWX56xUw5Iv4eEcdWu442bAd0ayhL6tud45uZWfV1KJQlnSvpL5L+CLw/tf27pEWSlkm6QdIASdtIWiWpX+ozSNJqSf0knS7pQUnLJV3Txr4OkbQ0ve5PY9ZJWpnWnyJphqSZkh6VdEHJtp+QtCTVdGdq21rS5anW+yUd1cFj3kfSvWmbeyU1H/fukham+pZLeh8wFXhvavthK+ONkTRX0o3pPPxK0hZp3Usl/Y6VdGVavlLSjyXdBfxA0i6S/piOb4mk96bNBkq6XtLDkq6WpLT9t9Nxr5Q0raT9He9FR8+TpEmSGiQ1rFmzpiOn0szMOioi2nwBewErgAHAIOCvwGRg+5I+/wF8NS1fARydlicB/zct/x3YMi1v18b+bgUOSMsDgb5AHbAytZ0CPAZsC9QAjwPDgKHAE8CI1G9w+vqfwGeb9ws8Amzdyr7HALel5UFA37R8OHBDWv4FcFJa7g9sVVpfG8c1BlgP7Az0AWYDx6Z1L5X0Oxa4Mi1fCdwG9Enf3wdMSMs16T0ZA6wDaik+ZM0HDiw9B2n5KuDI1t6Lzpyn5tdee+0VXTX8nNu6vK2ZWW8GNEQr/692ZKZ8EHBjRLwSES8At6T2D0q6W9IK4CRg99R+KfCFtPwFipAGWA5cLemzwJtt7G8e8GNJp6fAKNf3zohYFxHrgQeB4cB+wNyIWAUQEc+nvkcAUyQtBeZQhNlOHTjubYHr0gz9JyXHNx/4pqRzgOER8WoHxmq2MCIei4gmYDpwYAe2uS4imiRtA7wnIm4EiIj1EfFKybiNEfEWsJTiQwLARyXdl96jQ0uOodx70dXzZGZmFdLRe8pRpu1K4CsR8SHgfIr/xImIeUCdpEMoZngrU/9xwEUUM+/Frd0jjYipwKkUM9AFknYr0+21kuUmitm0WqlTwDERMSq9doqIh9o82sL3gLsi4oPAkSXH9ztgPPAqMEvSoR0Yq1nL+qJMe02LPi+XHEdr3nE+JNUAF1PMxj8EXFIydrn3oqvnyczMKqQjoTwXmCBpqzRbOzK1bwM8le4fn9Rim99QzASvAEj3TodFxF3A2RSXRweW25mk90bEioj4AdAAlAvlcuYDh0gakcYZnNpnAV8tuZ+6ZwfH2xZ4Mi2fUlLfzsBjEfFziqsGHwZepDgf7dlH0oh0Po4H7kntT0v6QGqfUG7DdJWiUdLRqY4tJQ1oY1/NAfyspIEUl8Xbei+6ep7MzKxC2g3liFgCXEtxWfQG4O606lsU9zhnAw+32Oxq4F0UwQzFPdTfpsuo9wM/iYh/tLLLM9ODScsoZqP/1ZEDiYg1FPewZ6Rtr02rvgf0A5anS9Hf68h4wAXA/5E0L9Xf7HhgZbrMuxvwm4h4DpiX6i77oFcyn+KhsJXAKuDG1D6F4t7xn4Cn2tj+c8DpkpYD9wL/2lrHdH4voXge4CZgUVrV2nvR1fNkZmYVouKec4UHlY4FjoqIz1V88F5K0hhgckR8qsqlVEx9fX00NDR0adu6Kbezeuq4CldkZpY/SYsjor7cuor/7KukXwCfBMZWemwzM7NNWcVDOSK+2pF+kr4AnNGieV5EnFbpmsrs++PAD1o0r4qIsvdzOzn2hyh+/KjUaxGxL8VTzWZmZmVV7bdERcQVbPhxqZ7e9yyKB5u6Y+wVwKjuGNvMzDZtveLXbJqZmW0OHMpWFX7Iy8zsnRzKZmZmmXAom5mZZcKhbGZmlgmHspmZWSYcymZmZplwKJuZmWXCoWxmZpYJh7KZmVkmHMpmZmaZcCibmZllolv+nrJtHiStAR7fiCGGAM9WqJxKcl2dl2ttrqvzcq1tU6preEQMLbfCoWxVI6mhtT/0XU2uq/Nyrc11dV6utW0udfnytZmZWSYcymZmZplwKFs1Tat2Aa1wXZ2Xa22uq/NyrW2zqMv3lM3MzDLhmbKZmVkmHMpmZmaZcChbj5P0CUl/kfRXSVN6eN/DJN0l6SFJD0g6I7UPljRb0qPp67tKtvlGqvUvkj7ezfX1kXS/pNsyq2s7SddLejidu4/kUJuks9L7uFLSdEk11apL0uWSnpG0sqSt07VI2kvSirTu55LUDXX9ML2XyyXdKGm7HOoqWTdZUkga0tN1tVWbpK+m/T8g6YJuqS0i/PKrx15AH+BvwM5Af2AZMLIH978DMDotbwM8AowELgCmpPYpwA/S8shU45bAiFR7n26s72vA74Db0ve51PVr4NS03B/Yrtq1Ae8BVgFbpe9/D5xSrbqAg4HRwMqStk7XAiwEPgII+C/gk91Q1xFA37T8g1zqSu3DgFkUv5hoSE/X1cY5+yjwR2DL9P27u6M2z5Stp+0D/DUiHouI14FrgKN6aucR8VRELEnLLwIPUfznfhRF8JC+Hp2WjwKuiYjXImIV8Nd0DBUnqRYYB1xa0pxDXYMo/pO6DCAiXo+If+RQG9AX2EpSX2AA8Pdq1RURc4HnWzR3qhZJOwCDImJ+FP+r/6Zkm4rVFRF3RMSb6dsFQG0OdSU/Ac4GSp9C7rG62qjtS8DUiHgt9XmmO2pzKFtPew/wRMn3jamtx0mqA/YE7gP+JSKegiK4gXenbj1Z708p/jN6q6Qth7p2BtYAV6RL65dK2rratUXEk8CPgP8GngLWRcQd1a6rhc7W8p603JM1TqSYxVW9LknjgScjYlmLVTmcr12BgyTdJ+nPkvbujtocytbTyt1T6fGfy5M0ELgBODMiXmira5m2itcr6VPAMxGxuKOblGnrrvPYl+JS3i8jYk/gZYpLsa3pqXP2LopZyghgR2BrSZ+tdl0d1FotPVqjpHOBN4Grq12XpAHAucC3y62uVl0l+gLvAvYDvg78Pt0jrmhtDmXraY0U94ya1VJccuwxkvpRBPLVETEjNT+dLjeRvjZfmuqpeg8AxktaTXFJ/1BJv82gruZ9NUbEfen76ylCutq1HQ6siog1EfEGMAPYP4O6SnW2lkY2XEru1holfR74FHBSurxa7breS/EBa1n6d1ALLJH0r1Wuq1kjMCMKCymuaA2pdG0OZetpi4D3SRohqT9wAnBLT+08fbK9DHgoIn5csuoW4PNp+fPAzSXtJ0jaUtII4H0UD29UVER8IyJqI6KO4pz8KSI+W+26Um3/Azwh6f2p6TDgwQxq+29gP0kD0vt6GMUzAtWuq1SnakmXuF+UtF86ppNLtqkYSZ8AzgHGR8QrLeqtSl0RsSIi3h0RdenfQSPFQ5n/U826StwEHAogaVeKBx6frXhtG/uUml9+dfYFjKV46vlvwLk9vO8DKS4hLQeWptdYYHvgTuDR9HVwyTbnplr/QgWe7OxAjWPY8PR1FnUBo4CGdN5uoriMV/XagPOBh4GVwFUUT8BWpS5gOsW97TcoAuXfulILUJ+O52/AhaTfvFjhuv5KcR+0+d/Ar3Koq8X61aSnr3uyrjbOWX/gt2lfS4BDu6M2/5pNMzOzTPjytZmZWSYcymZmZplwKJuZmWXCoWxmZpYJh7KZmVkmHMpmZmaZcCibmZll4v8DzkqCNr8pq2AAAAAASUVORK5CYII=\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pd.DataFrame.from_dict(explanations.explanations[0].attributions[0].feature_attributions, orient='index').plot(kind='barh');"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "90370413",
+   "id": "855faacd",
    "metadata": {},
    "source": [
     "Based on the feature attributions, your model has learned that customer age and average purchase revenue are the most important features in predicting this customer's monetary value over the 3-month test period. This lines up with your model learning that this customer has a relatively lengthy relationship of multiple moderate purchases."
@@ -2509,7 +2475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83f02f35",
+   "id": "130655f2",
    "metadata": {},
    "source": [
     "## Next steps"
@@ -2517,7 +2483,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e15f2ff1",
+   "id": "4509a6b1",
    "metadata": {},
    "source": [
     "Congratulations! In this lab, you walked through a machine learning experimentation workflow using Google Cloud's BigQuery for data storage and analysis and Vertex AI machine learning services to train and deploy a TensorFlow model to predict customer lifetime value. You progressed from training a TensorFlow model locally to training on the cloud with Vertex AI and leveraged several new unified platform capabilities such as Vertex TensorBoard and prediction feature attributions."
@@ -2525,7 +2491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30e173b0",
+   "id": "2fb8dc3c",
    "metadata": {},
    "source": [
     "## License"
@@ -2534,7 +2500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4505a575",
+   "id": "fd2fbdab",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2556,9 +2522,9 @@
  ],
  "metadata": {
   "environment": {
-   "name": "tf2-gpu.2-3.m71",
+   "name": "tf2-gpu.2-3.m74",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m71"
+   "uri": "gcr.io/deeplearning-platform-release/tf2-gpu.2-3:m74"
   },
   "kernelspec": {
    "display_name": "Python 3",


### PR DESCRIPTION
Feel free to ignore this PR -- I only created it to let ReviewNB diff it with the branch vertex-pipelines-demo; to show the diff from Custom Container Training to Pre-Built Container Training.

Note that the prediction container could also be changed from Deep Learning Containers to Vertex AI pre-built Prediction Container, but I did not try that here.