### PR TITLE
Correct typo in function argument name doc string

### DIFF
--- a/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
+++ b/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
@@ -288,7 +288,7 @@
     "\n",
     "\n",
     "def load_data():\n",
-    "    \"\"\"Loads data into preprocessed (train_x, train_y, eval_y, eval_y)\n",
+    "    \"\"\"Loads data into preprocessed (train_x, train_y, eval_x, eval_y)\n",
     "    dataframes.\n",
     "\n",
     "    Returns:\n",
@@ -1076,7 +1076,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Go back to the lab instructions to answer some multiple choice questions to reinforce your uncerstanding of some of these lab's concepts.**"
+    "**Go back to the lab instructions to answer some multiple choice questions to reinforce your understanding of some of these lab's concepts.**"
    ]
   },
   {


### PR DESCRIPTION
1. I think that there is typographic error in the load_data docstring args where `eval_y` has been duplicated
2. `Uncerstanding` is likely supposed to be 'understanding'?

Thanks for putting the tutorial together, very informative.

(I've just signed an Individual CLA as per your [contrib](https://github.com/GoogleCloudPlatform/training-data-analyst/blob/42d572e6e4552f09216a7e9e25710c39a4fa1c06/CONTRIBUTING.md) )