### PR TITLE
Upgrade log4j = 2.16.0

### DIFF
--- a/blogs/microservices-demo-1/src/adservice/build.gradle
+++ b/blogs/microservices-demo-1/src/adservice/build.gradle
@@ -54,7 +54,7 @@ dependencies {
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
                 "io.prometheus:simpleclient_httpserver:${prometheusVersion}",
-                "org.apache.logging.log4j:log4j-core:2.11.1"
+                "org.apache.logging.log4j:log4j-core:2.16.0"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",


### PR DESCRIPTION
This is meant to address the log4j vulnerability omg/45447.

- Please validate the fix and working
- If this requires additional updates, let's consider deprecating.