### PR TITLE
Update to log4j 2.17.0

### DIFF
--- a/blogs/microservices-demo-1/src/adservice/build.gradle
+++ b/blogs/microservices-demo-1/src/adservice/build.gradle
@@ -29,6 +29,7 @@ def opencensusVersion = "0.30.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.15.0" // CURRENT_GRPC_VERSION
 def jacksonVersion = "2.9.6"
 def prometheusVersion = "0.3.0"
+def log4j2Version = "2.17.0"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.8'
@@ -54,7 +55,7 @@ dependencies {
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
                 "io.prometheus:simpleclient_httpserver:${prometheusVersion}",
-                "org.apache.logging.log4j:log4j-core:2.17.0"
+                "org.apache.logging.log4j:log4j-core:${log4j2Version}"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",

--- a/blogs/microservices-demo-1/src/adservice/build.gradle
+++ b/blogs/microservices-demo-1/src/adservice/build.gradle
@@ -54,7 +54,7 @@ dependencies {
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
                 "io.prometheus:simpleclient_httpserver:${prometheusVersion}",
-                "org.apache.logging.log4j:log4j-core:2.16.0"
+                "org.apache.logging.log4j:log4j-core:2.17.0"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",

--- a/blogs/microservices-demo-1/src/adservice/build.gradle
+++ b/blogs/microservices-demo-1/src/adservice/build.gradle
@@ -29,7 +29,6 @@ def opencensusVersion = "0.30.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.15.0" // CURRENT_GRPC_VERSION
 def jacksonVersion = "2.9.6"
 def prometheusVersion = "0.3.0"
-def log4j2Version = "2.17.0"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.8'
@@ -55,7 +54,7 @@ dependencies {
                 "io.grpc:grpc-netty:${grpcVersion}",
                 "io.grpc:grpc-services:${grpcVersion}",
                 "io.prometheus:simpleclient_httpserver:${prometheusVersion}",
-                "org.apache.logging.log4j:log4j-core:${log4j2Version}"
+                "org.apache.logging.log4j:log4j-core:2.17.0"
 
         runtime "com.fasterxml.jackson.core:jackson-core:${jacksonVersion}",
                 "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}",


### PR DESCRIPTION
See https://logging.apache.org/log4j/2.x/changes-report.html#a2.17.0

Motivation:

log4j 2.16 was recently discovered to be vulnerable to an infinite recursion DOS. Version 2.17 fixes LOG4J2-3230.

Modification:

- CLA is signed for this repo
- Change the version from 2.16 to 2.17 for log4j.

Result:

This PR updates log4j to 2.17, which includes a patch for the issue.