### PR TITLE
Update used package to latest supported

### DIFF
--- a/courses/streaming/process/sandiego/pom.xml
+++ b/courses/streaming/process/sandiego/pom.xml
@@ -26,7 +26,7 @@
 
 
   <properties>
-    <beam.version>2.20.0</beam.version>
+    <beam.version>2.37.0</beam.version>
 
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>


### PR DESCRIPTION
Qwiklabs lab can not be completed with deprecated Beam version. Update file to currently latest version 2.37.0