### PR TITLE
region is mandatory flag for later Beam versions

### DIFF
--- a/courses/streaming/process/sandiego/run_oncloud.sh
+++ b/courses/streaming/process/sandiego/run_oncloud.sh
@@ -21,7 +21,8 @@ mvn compile -e exec:java \
       -Dexec.args="--project=$PROJECT \
       --stagingLocation=gs://$BUCKET/staging/ $* \
       --tempLocation=gs://$BUCKET/staging/ \
-      --runner=DataflowRunner"
+      --runner=DataflowRunner \
+      --region=us-central1"
 
 
 # If you run into quota problems, add this option the command line above


### PR DESCRIPTION
When using a later than 2.20.0 Beam version region is a mandatory flag. Updated to correctly finish Qwiklabs lab.