### PR TITLE
Fix display name

### DIFF
--- a/courses/streaming/process/sandiego/create_cbt.sh
+++ b/courses/streaming/process/sandiego/create_cbt.sh
@@ -1,1 +1,1 @@
-gcloud beta bigtable instances create sandiego --cluster=cpb210 --cluster-zone=us-central1-b --display-name=="San Diego Freeway data" --instance-type=DEVELOPMENT
+gcloud beta bigtable instances create sandiego --cluster=cpb210 --cluster-zone=us-central1-b --display-name="San Diego Freeway data" --instance-type=DEVELOPMENT


### PR DESCRIPTION
As currently implemented, the display name ends up being `=San Diego Freeway data`. This update fixes the name so that it shows up as `San Diego Freeway data`.