### PR TITLE
Update taxi_streaming_pipeline_test.py

### DIFF
--- a/quests/dataflow_python/8b_Stream_Testing_Pipeline/lab/taxi_streaming_pipeline_test.py
+++ b/quests/dataflow_python/8b_Stream_Testing_Pipeline/lab/taxi_streaming_pipeline_test.py
@@ -78,7 +78,7 @@ class TaxiWindowingTest(unittest.TestCase):
 #                              | TaxiCountTransform()
 #                            )
 
-#             assert_that(taxi_counts, equal_to(EXPECTED_RESULTS))
+#             assert_that(taxi_counts, equal_to_per_window(EXPECTED_RESULTS))
 
 if __name__ == '__main__':
     with open('testing.out', 'w') as f:


### PR DESCRIPTION
In this lab we have to test a stream pipeline, for test in this case we have to consider the window, so I've changed the method equal_to to equal_to_per_window, to test the case where a window time is being considered
