### PR TITLE
feat: Update outdated beam sdk

### DIFF
--- a/blogs/dataflowsql/bq_in_df/pom.xml
+++ b/blogs/dataflowsql/bq_in_df/pom.xml
@@ -25,7 +25,7 @@
   <version>1.1</version>
 
   <properties>
-    <beam.version>2.16.0</beam.version>
+    <beam.version>2.32.0</beam.version>
 
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>

--- a/courses/streaming/process/sandiego/pom.xml
+++ b/courses/streaming/process/sandiego/pom.xml
@@ -26,7 +26,7 @@
 
 
   <properties>
-    <beam.version>2.20.0</beam.version>
+    <beam.version>2.32.0</beam.version>
 
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>

--- a/quests/data-science-on-gcp-edition1_tf2/04_streaming/realtime/chapter4/pom.xml
+++ b/quests/data-science-on-gcp-edition1_tf2/04_streaming/realtime/chapter4/pom.xml
@@ -25,7 +25,7 @@
   <version>1.1</version>
 
   <properties>
-    <beam.version>2.13.0</beam.version>
+    <beam.version>2.32.0</beam.version>
 
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>

--- a/quests/data-science-on-gcp-edition1_tf2/08_dataflow/chapter8/pom.xml
+++ b/quests/data-science-on-gcp-edition1_tf2/08_dataflow/chapter8/pom.xml
@@ -25,7 +25,7 @@
   <version>1.1</version>
 
   <properties>
-    <beam.version>2.13.0</beam.version>
+    <beam.version>2.32.0</beam.version>
 
     <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>


### PR DESCRIPTION
All of others beam sdk has been upgraded into 2.32, and yet there still some
other project that used deprecated version.