### PR TITLE
Use wordpress 5.9 image for Cloud SQL Lab

### DIFF
--- a/courses/ak8s/v1.1/Cloud_SQL/sql-proxy.yaml
+++ b/courses/ak8s/v1.1/Cloud_SQL/sql-proxy.yaml
@@ -15,8 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: gcr.io/cloud-marketplace/google/wordpress:5.3
-          #image: wordpress:5.3
+          image: gcr.io/cloud-marketplace/google/wordpress:5.9
           ports:
             - containerPort: 80
           env:


### PR DESCRIPTION
Move from wordpress 5.3 to 5.9 as 5.3 is deprecated in the container registry