### PR TITLE
Vertex AI pipelines intro - fixes `emojize` params

### DIFF
--- a/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/intro_to_vertex_pipelines.ipynb
+++ b/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/intro_to_vertex_pipelines.ipynb
@@ -619,7 +619,7 @@
     "):\n",
     "    import emoji\n",
     "    emoji_text = text\n",
-    "    emoji_str = emoji.emojize(':' + emoji_text + ':', use_aliases=True)\n",
+    "    emoji_str = emoji.emojize(':' + emoji_text + ':', language="alias")\n",
     "    print(\"output one: {}; output_two: {}\".format(emoji_text, emoji_str))\n",
     "    return (emoji_text, emoji_str)"
    ]

--- a/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/solutions/intro_to_vertex_pipelines.ipynb
+++ b/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/solutions/intro_to_vertex_pipelines.ipynb
@@ -619,7 +619,7 @@
     "):\n",
     "    import emoji\n",
     "    emoji_text = text\n",
-    "    emoji_str = emoji.emojize(':' + emoji_text + ':', use_aliases=True)\n",
+    "    emoji_str = emoji.emojize(':' + emoji_text + ':', language="alias")\n",
     "    print(\"output one: {}; output_two: {}\".format(emoji_text, emoji_str))\n",
     "    return (emoji_text, emoji_str)"
    ]


### PR DESCRIPTION
v2.0.0 of python emoji library removed the `use_aliases` param.

Trying to use `use_aliases` param causes the pipleline to fail.
This change solves the issue, and pipeline succeeds.