### PR TITLE
Adding Lombok version on pom.xml

### DIFF
--- a/courses/java-microservices/spring-cloud-gcp-guestbook/1-bootstrap/guestbook-service/pom.xml
+++ b/courses/java-microservices/spring-cloud-gcp-guestbook/1-bootstrap/guestbook-service/pom.xml
@@ -47,6 +47,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.22</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Fixing an issue of running app on openjdk 18.0.2.1 2022-08-18.

Below error is thrown when trying to run compile maven goal.

```sh
Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project guestbook: 
Fatal error compiling: java.lang.IllegalAccessError: class lombok.javac.apt.LombokProcessor (in unnamed module @0x5b40de43) cannot access class 
com.sun.tools.javac.processing.JavacProcessingEnvironment (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.processing to unnamed module @0x5b40de43 
```