### PR TITLE
Update datastore.py to use correct env var

### DIFF
--- a/courses/developingapps/v1.3/python/datastore/end/quiz/gcp/datastore.py
+++ b/courses/developingapps/v1.3/python/datastore/end/quiz/gcp/datastore.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-project_id = os.getenv('GCLOUD_PROJECT')
+project_id = os.getenv('GOOGLE_CLOUD_PROJECT')
 
 from flask import current_app
 from google.cloud import datastore


### PR DESCRIPTION
Update datastore.py to use correct env var in cloud shell. GCLOUD_PROJECT is not used in cloud shell, another alternative would be to set the env var before execution by running the following bash script

```bash
export GCLOUD_PROJECT=$GOOGLE_CLOUD_PROJECT
```