### PR TITLE
Updated the static k8s version (1.23.12-gke.1600) in create_gke.sh file

### DIFF
--- a/courses/ahybrid/v1.0/common/scripts/create_gke.sh
+++ b/courses/ahybrid/v1.0/common/scripts/create_gke.sh
@@ -17,6 +17,7 @@ echo "Creating the gke cluster..."
 gcloud beta container clusters create ${C1_NAME} \
     --zone ${C1_ZONE} \
     --no-enable-basic-auth \
+    --cluster-version 1.23.12-gke.1600 \
     --enable-autoupgrade \
     --max-surge-upgrade 1 \
     --max-unavailable-upgrade 0 \


### PR DESCRIPTION
- Updated the static k8s version (1.23.12-gke.1600) in create_gke.sh file as we are unable to create cluster by using the k8s latest release i.e 1.24 (default version).
- We have tested the lab (AHYBRID071) using this change and we are able to create a cluster and also the lab is working functionally fine.