### PR TITLE
Ss ms cbl155 cloudsql b263851689 oos

### DIFF
--- a/courses/ak8s/v1.1/Cloud_SQL/sql-proxy.yaml
+++ b/courses/ak8s/v1.1/Cloud_SQL/sql-proxy.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: gcr.io/cloud-marketplace/google/wordpress:latest
+          image: gcr.io/cloud-marketplace/google/wordpress:5.9
           #image: wordpress:5.9
           ports:
             - containerPort: 80

--- a/courses/ak8s/v1.1/Cloud_SQL/sql-proxy.yaml
+++ b/courses/ak8s/v1.1/Cloud_SQL/sql-proxy.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: gcr.io/cloud-marketplace/google/wordpress:5.9
+          image: gcr.io/cloud-marketplace/google/wordpress:latest
           #image: wordpress:5.9
           ports:
             - containerPort: 80
@@ -41,7 +41,7 @@ spec:
         # $PROJECT:$REGION:$INSTANCE
         # [START proxy_container]
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
                     "-instances=<INSTANCE_CONNECTION_NAME>=tcp:3306",
                     "-credential_file=/secrets/cloudsql/key.json"]


### PR DESCRIPTION
In this pull request, the sql-proxy.yaml was updated in the following way:

1. The version of  - name: cloudsql-proxy
          image: gcr.io/cloudsql-docker/gce-proxy:1.11 was updated to the :latest flag, as deployment was continually failing. The :latest flag did not allow a deployment when applied to the wordpress image. 