### PR TITLE
Updated libraries and docker image versions

### DIFF
--- a/quests/vertex-ai/vertex-challenge-lab/requirements.txt
+++ b/quests/vertex-ai/vertex-challenge-lab/requirements.txt
@@ -1,5 +1,5 @@
-google-cloud-aiplatform==1.8.0
-tensorflow-text==2.6.0
-tf-models-official==2.6.0
-kfp==1.8.9
-google_cloud_pipeline_components==0.2.0
+google-cloud-aiplatform==1.22.0
+tensorflow-text==2.11.0
+tf-models-official==2.11.3
+kfp==1.8.19
+google_cloud_pipeline_components==1.0.39

--- a/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
+++ b/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
@@ -1019,7 +1019,7 @@
     "%%writefile {MODEL_DIR}/Dockerfile\n",
     "# Specifies base image and tag.\n",
     "# https://cloud.google.com/vertex-ai/docs/training/pre-built-containers\n",
-    "FROM us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-6:latest\n",
+    "FROM us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:latest\n",
     "\n",
     "# Sets the container working directory.\n",
     "WORKDIR /root\n",
@@ -1068,8 +1068,8 @@
    "outputs": [],
    "source": [
     "%%writefile {MODEL_DIR}/requirements.txt\n",
-    "tf-models-official==2.6.0\n",
-    "tensorflow-text==2.6.0\n",
+    "tf-models-official==2.11.3\n",
+    "tensorflow-text==2.11.0\n",
     "tensorflow-hub==0.12.0"
    ]
   },
@@ -1245,7 +1245,7 @@
    "source": [
     "# Pre-built Vertex model serving container for deployment.\n",
     "# https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
-    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-6:latest\""
+    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:latest\""
    ]
   },
   {


### PR DESCRIPTION
Users of Qwiklab GSP354 which uses this repo (specifically the notebook vertex-challenge-lab.ipynb) reported bugs when running the pipeline. Lab was taken offline for maintenance. We identified the Python libraries and Docker images needed to be updated, since the last commit is over 2 years old. This PR should solve it. Can you please expedite the approval so we can bring the lab back online?