### PR TITLE
updated version to 1.22.0

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
@@ -1,4 +1,4 @@
-google-cloud-aiplatform[tensorboard]==1.2.0
+google-cloud-aiplatform[tensorboard]==1.22.0
 six==1.15.0
 wget==3.2
 xlrd==2.0.1

--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
@@ -1,4 +1,8 @@
-google-cloud-aiplatform[tensorboard]==1.22.0
+tensorflow>=2.11.0
+pyarrow==6.0.1
+httplib2>=0.20.4
+grpcio-status>=1.38.1
+google-cloud-aiplatform[tensorboard]==1.2.0
 six==1.15.0
 wget==3.2
 xlrd==2.0.1


### PR DESCRIPTION
The latest version of google-cloud-aiplatform[tensorboard] is 1.22.0, needed to fix b/270080160