### PR TITLE
using correct Docker images

### DIFF
--- a/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
+++ b/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
@@ -1245,7 +1245,7 @@
    "source": [
     "# Pre-built Vertex model serving container for deployment.\n",
     "# https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
-    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-11:latest\""
+    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-11:dlenvx_build_20230330_2001_RC00\""
    ]
   },
   {

--- a/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
+++ b/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
@@ -1019,7 +1019,7 @@
     "%%writefile {MODEL_DIR}/Dockerfile\n",
     "# Specifies base image and tag.\n",
     "# https://cloud.google.com/vertex-ai/docs/training/pre-built-containers\n",
-    "FROM us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:latest\n",
+    "FROM us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:dlenvx_build_20230330_2001_RC00\n",
     "\n",
     "# Sets the container working directory.\n",
     "WORKDIR /root\n",
@@ -1245,7 +1245,7 @@
    "source": [
     "# Pre-built Vertex model serving container for deployment.\n",
     "# https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
-    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:latest\""
+    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-11:latest\""
    ]
   },
   {
@@ -1561,7 +1561,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
+++ b/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
@@ -1019,7 +1019,7 @@
     "%%writefile {MODEL_DIR}/Dockerfile\n",
     "# Specifies base image and tag.\n",
     "# https://cloud.google.com/vertex-ai/docs/training/pre-built-containers\n",
-    "FROM us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:dlenvx_build_20230330_2001_RC00\n",
+    "FROM us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-11:latest\n",
     "\n",
     "# Sets the container working directory.\n",
     "WORKDIR /root\n",
@@ -1245,7 +1245,7 @@
    "source": [
     "# Pre-built Vertex model serving container for deployment.\n",
     "# https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
-    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/training/tf-cpu.2-11:dlenvx_build_20230330_2001_RC00\""
+    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:dlenvx_build_20230330_2001_RC00\""
    ]
   },
   {


### PR DESCRIPTION
On March 31st, there was a change in the Vertex AI Prediction Docker image which caused this pipeline to fail. Somehow the image does not contain Python anymore, so you cannot install libraries. We are going to need to pin the prediction image to guarantee the pipeline works.