### PR TITLE
Update the prediction image to use the latest build

### DIFF
--- a/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
+++ b/quests/vertex-ai/vertex-challenge-lab/vertex-challenge-lab.ipynb
@@ -1245,7 +1245,7 @@
    "source": [
     "# Pre-built Vertex model serving container for deployment.\n",
     "# https://cloud.google.com/vertex-ai/docs/predictions/pre-built-containers\n",
-    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:dlenvx_build_20230330_2001_RC00\""
+    "SERVING_IMAGE_URI = \"us-docker.pkg.dev/vertex-ai/prediction/tf2-cpu.2-11:latest\""
    ]
   },
   {


### PR DESCRIPTION
As requested by the Vertex Serving team, we should be using the latest image for prediciton. They are backwards compatible. 