### PR TITLE
pin down the google-api-core for bigquery 1.25.0

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/python.BQ_explore_data.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/python.BQ_explore_data.ipynb
@@ -50,7 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --user google-cloud-bigquery==1.25.0"
+    "!pip install --user google-cloud-bigquery==1.25.0 google-api-core==1.33.2"
    ]
   },
   {


### PR DESCRIPTION
otherwise will get `ERROR: _blocking_poll() got an unexpected keyword argument 'retry' `