### PR TITLE
d6-jm-certex-ai-forecasting-notebook-update

### DIFF
--- a/courses/machine_learning/deepdive2/mlops_vertexai_manage_features/labs/feature_store_streaming_ingestion_sdk.ipynb
+++ b/courses/machine_learning/deepdive2/mlops_vertexai_manage_features/labs/feature_store_streaming_ingestion_sdk.ipynb
@@ -153,7 +153,8 @@
         "                         numpy\\\n",
         "                         pandas\\\n",
         "                         db-dtypes\\\n",
-        "                         pyarrow -q"
+        "                         pyarrow -q\\\n",
+        "                         --user"
       ]
     },
     {


### PR DESCRIPTION
Update to Feature Store Notebook to implment correct pip module installation. 

Lab has been trested against this and the notebook is currently only used with OCBL431. 