### PR TITLE
fix notebook link type in 3_keras_sequential_api.ipynb

### DIFF
--- a/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
+++ b/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We wrote these functions for reading data from the csv files above in the [previous notebook](./2a_dataset_api.ipynb)."
+    "We wrote these functions for reading data from the csv files above in the [previous notebook](./2_dataset_api.ipynb)."
    ]
   },
   {


### PR DESCRIPTION
correcting a typo in the path to the previous notebook