### PR TITLE
Update Transformer link pointing into TensorFlow repo code, fixes #2426

### DIFF
--- a/courses/machine_learning/deepdive2/production_ml/labs/keras.ipynb
+++ b/courses/machine_learning/deepdive2/production_ml/labs/keras.ipynb
@@ -983,7 +983,7 @@
       "source": [
         "### Examples and Tutorials\n",
         "Here are some examples for using distribution strategy with keras fit/compile:\n",
-        "1. [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer/transformer_main.py) example trained using `tf.distribute.MirroredStrategy`\n",
+        "1. [Transformer](https://github.com/tensorflow/models/blob/master/official/legacy/transformer/transformer_main.py) example trained using `tf.distribute.MirroredStrategy`\n",
         "2. [NCF](https://github.com/tensorflow/models/blob/master/official/recommendation/ncf_keras_main.py) example trained using `tf.distribute.MirroredStrategy`.\n",
         "\n",
         "More examples listed in the [Distribution strategy guide](https://raw.githubusercontent.com/tensorflow/docs/master/site/en/guide/distributed_training.ipynb#examples_and_tutorials)"

--- a/courses/machine_learning/deepdive2/production_ml/solutions/keras.ipynb
+++ b/courses/machine_learning/deepdive2/production_ml/solutions/keras.ipynb
@@ -992,7 +992,7 @@
       "source": [
         "### Examples and Tutorials\n",
         "Here are some examples for using distribution strategy with keras fit/compile:\n",
-        "1. [Transformer](https://github.com/tensorflow/models/blob/master/official/nlp/transformer/transformer_main.py) example trained using `tf.distribute.MirroredStrategy`\n",
+        "1. [Transformer](https://github.com/tensorflow/models/blob/master/official/legacy/transformer/transformer_main.py) example trained using `tf.distribute.MirroredStrategy`\n",
         "2. [NCF](https://github.com/tensorflow/models/blob/master/official/recommendation/ncf_keras_main.py) example trained using `tf.distribute.MirroredStrategy`.\n",
         "\n",
         "More examples listed in the [Distribution strategy guide](https://raw.githubusercontent.com/tensorflow/docs/master/site/en/guide/distributed_training.ipynb#examples_and_tutorials)"


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/training-data-analyst/issues/2426