### PR TITLE
Fix Python requirements for `courses/developingapps/v1.3/python`

### DIFF
--- a/courses/developingapps/v1.2/python/appengine/end/frontend/requirements.txt
+++ b/courses/developingapps/v1.2/python/appengine/end/frontend/requirements.txt
@@ -11,3 +11,4 @@ grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
 gunicorn>=19.7.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/appengine/end/requirements.txt
+++ b/courses/developingapps/v1.2/python/appengine/end/requirements.txt
@@ -10,4 +10,4 @@ google-cloud-language>=0.31.0
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
-
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/appengine/start/frontend/requirements.txt
+++ b/courses/developingapps/v1.2/python/appengine/start/frontend/requirements.txt
@@ -11,3 +11,4 @@ grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
 gunicorn>=19.7.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/appengine/start/requirements.txt
+++ b/courses/developingapps/v1.2/python/appengine/start/requirements.txt
@@ -10,4 +10,4 @@ google-cloud-language>=0.31.0
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
-
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/bonus/answer_backend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/bonus/answer_backend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=19.7.1
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/bonus/backend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/bonus/backend/requirements.txt
@@ -8,4 +8,4 @@ gunicorn>=19.7.1
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
-
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/bonus/frontend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/bonus/frontend/requirements.txt
@@ -6,3 +6,4 @@ google-cloud-datastore>=1.4.0
 google-cloud-spanner>=0.30.0
 google-cloud-storage>=1.7.0
 gunicorn>=19.7.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/bonus/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/bonus/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=0.31.0
 grpcio>=1.24.1
 grpcio-gcp>=0.2.0
 grpcio-tools>=1.25.0
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/end/backend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/end/backend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=19.7.1
 grpcio>=1.33.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.33.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/end/frontend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/end/frontend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=19.7.1
 grpcio>=1.33.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.33.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/end/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/end/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.0.0
 grpcio>=1.33.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.33.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/start/backend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/start/backend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=19.7.1
 grpcio>=1.33.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.33.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/start/frontend/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/start/frontend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=19.7.1
 grpcio>=1.33.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.33.1
+urllib3<2.0

--- a/courses/developingapps/v1.2/python/kubernetesengine/start/requirements.txt
+++ b/courses/developingapps/v1.2/python/kubernetesengine/start/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.0.0
 grpcio>=1.33.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.33.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/appengine/end/frontend/requirements.txt
+++ b/courses/developingapps/v1.3/python/appengine/end/frontend/requirements.txt
@@ -11,3 +11,4 @@ grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
 gunicorn>=20.1.0
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/appengine/end/requirements.txt
+++ b/courses/developingapps/v1.3/python/appengine/end/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.2.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/appengine/start/frontend/requirements.txt
+++ b/courses/developingapps/v1.3/python/appengine/start/frontend/requirements.txt
@@ -11,3 +11,4 @@ grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
 gunicorn>=20.1.0
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/appengine/start/requirements.txt
+++ b/courses/developingapps/v1.3/python/appengine/start/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.2.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/bonus/answer_backend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/bonus/answer_backend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=20.1.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/bonus/backend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/bonus/backend/requirements.txt
@@ -8,4 +8,4 @@ gunicorn>=20.1.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
-
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/bonus/frontend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/bonus/frontend/requirements.txt
@@ -6,3 +6,4 @@ google-cloud-datastore>=2.1.4
 google-cloud-spanner>=3.6.0
 google-cloud-storage>=1.41.0
 gunicorn>=20.1.0
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/bonus/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/bonus/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.2.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/end/backend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/end/backend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=20.1.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/end/frontend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/end/frontend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=20.1.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/end/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/end/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.2.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/start/backend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/start/backend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=20.1.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/start/frontend/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/start/frontend/requirements.txt
@@ -8,3 +8,4 @@ gunicorn>=20.1.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0

--- a/courses/developingapps/v1.3/python/kubernetesengine/start/requirements.txt
+++ b/courses/developingapps/v1.3/python/kubernetesengine/start/requirements.txt
@@ -10,3 +10,4 @@ google-cloud-language>=2.2.0
 grpcio>=1.38.1
 grpcio-gcp>=0.2.2
 grpcio-tools>=1.38.1
+urllib3<2.0


### PR DESCRIPTION
I want to fix the issue on GKE.

urllib3 v2.0 only supports OpenSSL 1.1.1+
See: https://github.com/urllib3/urllib3/issues/2168

However, `gcr.io/google_appengine/python` is currently providing "OpenSSL 1.0.2g  1 Mar 2016". Therefore, the code in `courses/developingapps/v1.3/python/kubernetesengine` will not work properly.

You will need to add:

```
urllib3<2.0
```

Additionally, a similar issue could occur with `courses/developingapps/v1.3/python/appengine`. But as of 2023-10-28, `python_version: 3` refers to Python 3.6. And when `pip3 install -r /app/requirements.txt` is executed in Python 3.6, `urllib3<2.0` seems to be automatically added due to dependency issues. Therefore, it appears there is currently no issue with App Engine Flexible (although I propose a change).

https://cloud.google.com/appengine/docs/flexible/python/runtime

> - Version 3.8 and later are built using buildpacks which enables you to choose an operating system. To use these new runtimes, you must specify additional settings in your app.yaml file.
> - Version 3.7 and earlier are built using Docker and are based on Ubuntu 16.04.

As stated, from version 3.8 onwards, buildpacks are used, which allows you to choose an operating system. Therefore, the situation might change if you decide to upgrade to version 3.8 or later.

By the way, why does the bonus directory specify 3.7, while start and end specify 3.6?

https://github.com/GoogleCloudPlatform/training-data-analyst/blob/1977ae1245d6af82c700db0aa93505135b811b96/courses/developingapps/v1.3/python/kubernetesengine/bonus/frontend/Dockerfile#L3

https://github.com/GoogleCloudPlatform/training-data-analyst/blob/1977ae1245d6af82c700db0aa93505135b811b96/courses/developingapps/v1.3/python/kubernetesengine/end/frontend/Dockerfile#L3

-----

I tested `courses/developingapps/v1.3/python/appengine` and `courses/developingapps/v1.3/python/kubernetesengine`.