### PR TITLE
fix comments in improve_data_quality lab

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/improve_data_quality.ipynb
@@ -636,7 +636,7 @@
      }
    ],
    "source": [
-    "df_transport.groupby('Fuel').first() # Get the first entry for each month. "
+    "df_transport.groupby('Fuel').first() # Get the first entry for each fuel type. "
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/launching_into_ml/solutions/improve_data_quality.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/solutions/improve_data_quality.ipynb
@@ -641,7 +641,7 @@
     "# The .groupby() function is used for spliting the data into groups based on some criteria.\n",
     "grouped_data = df_transport.groupby(['Zip Code','Model Year','Fuel','Make','Light_Duty','Vehicles'])\n",
     "\n",
-    " # Get the first entry for each month.\n",
+    " # Get the first entry for each fuel type.\n",
     "df_transport.groupby('Fuel').first()"
    ]
   },


### PR DESCRIPTION
Fixing a misleading comment about df_transport.groupby('Fuel').first() which is actually group by fuel type, not by month.