### PR TITLE
When runnin This in vertaxAI Shapely breaks, This is to fix that break

### DIFF
--- a/courses/machine_learning/deepdive2/production_ml/babyweight/train_deploy.ipynb
+++ b/courses/machine_learning/deepdive2/production_ml/babyweight/train_deploy.ipynb
@@ -73,7 +73,7 @@
     }
    ],
    "source": [
-    "!pip install --user google-cloud-bigquery==2.26.0"
+    "!pip install --user google-cloud-bigquery==3.13.0"
    ]
   },
   {


### PR DESCRIPTION
 bigquery import error yields WKBWriter error "ImportError: cannot impport name 'WKBWriter' from 'shapely.geos' (/opt/conda/lib/python3.9/site-packages/shapely/geos.py)" this is to fix that error