### PR TITLE
Fix: pin shapely < 2.0.0 to fix cannot import name 'WKBWriter'

### DIFF
--- a/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/intro_to_vertex_pipelines.ipynb
+++ b/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/intro_to_vertex_pipelines.ipynb
@@ -268,7 +268,7 @@
    ],
    "source": [
     "# Install necessary libraries\n",
-    "!pip3 install {USER_FLAG} google-cloud-aiplatform==1.0.0 --upgrade\n",
+    "!pip3 install {USER_FLAG} google-cloud-aiplatform==1.0.0 "shapely<2" --upgrade\n",
     "!pip3 install {USER_FLAG} kfp google-cloud-pipeline-components==0.1.1 --upgrade"
    ]
   },

--- a/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/intro_to_vertex_pipelines.ipynb
+++ b/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/intro_to_vertex_pipelines.ipynb
@@ -268,7 +268,7 @@
    ],
    "source": [
     "# Install necessary libraries\n",
-    "!pip3 install {USER_FLAG} google-cloud-aiplatform==1.0.0 "shapely<2" --upgrade\n",
+    "!pip3 install {USER_FLAG} google-cloud-aiplatform==1.0.0 'shapely<2' --upgrade\n",
     "!pip3 install {USER_FLAG} kfp google-cloud-pipeline-components==0.1.1 --upgrade"
    ]
   },


### PR DESCRIPTION
Use [workaround](https://stackoverflow.com/questions/74831594/cannot-import-name-wkbwriter-from-shapely-geos-when-import-google-cloud-ai-p) to fix following issue in the notebook:
```
cannot import name 'WKBWriter' from 'shapely.geos' when import google cloud ai platform]
``` 

Note: This notebook and lab itself needs a refresh as while executing it shows several deprecation warnings while new versions of APIs and libraries are already available (i.e. google-cloud-pipeline-components 2.6.0 vs 0.1.1 used or google-cloud-aiplatform 1.36.4 vs 1.0.0).