### PR TITLE
Wrong indentation is making get_scal return None

### DIFF
--- a/courses/machine_learning/deepdive2/feature_engineering/solutions/3_keras_basic_feat_eng.ipynb
+++ b/courses/machine_learning/deepdive2/feature_engineering/solutions/3_keras_basic_feat_eng.ipynb
@@ -889,7 +889,7 @@
     "        mini = train[feature].min()\n",
     "        maxi = train[feature].max()\n",
     "        return (x - mini)/(maxi-mini)\n",
-    "        return(minmax)"
+    "    return(minmax)"
    ]
   },
   {


### PR DESCRIPTION
The function get_scal should return the resulting minmax function, but, due to the wrong indentation in the outer return statement, it is returning None. This does not provoke an error since, further down, the argument normalizer_fn of numeric_column accepts None, but the result of training is wrong (as if no normalization was applied).