### PR TITLE
Fix the "input_dim" of the dense layer

### DIFF
--- a/courses/machine_learning/deepdive2/feature_engineering/solutions/3_keras_basic_feat_eng.ipynb
+++ b/courses/machine_learning/deepdive2/feature_engineering/solutions/3_keras_basic_feat_eng.ipynb
@@ -1922,7 +1922,7 @@
     "# `tf.keras.Sequential()` groups a linear stack of layers into a tf.keras.Model.\n",
     "model = tf.keras.Sequential([\n",
     "  feature_layer,\n",
-    "  layers.Dense(12, input_dim=8, activation='relu'),\n",
+    "  layers.Dense(12, input_dim=len(feature_columns), activation='relu'),\n",
     "  layers.Dense(8, activation='relu'),\n",
     "  layers.Dense(1, activation='linear',  name='median_house_value')\n",
     "])\n",


### PR DESCRIPTION
After adding more features, including bucketized feature and feature crosses, the number of features is no longer 8. The number of 8 comes from the first model, which only has numeric features. This is a silent error and model trains without error but the whole goal of this tutorial is to add more features and reduce the "mean squared error". After changing this line, my `mse` reduced from `14850733056` to `14575827968`.