### PR TITLE
Fixed bug: cannot import name 'WKBWriter' from 'shapely.geos'

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/python.BQ_explore_data.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/python.BQ_explore_data.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --user google-cloud-bigquery==2.34.4"
+    "!pip install --user google-cloud-bigquery==2.34.4 \"shapely<2\""
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/launching_into_ml/solutions/python.BQ_explore_data.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/solutions/python.BQ_explore_data.ipynb
@@ -54,7 +54,7 @@
    "outputs": [],
    "source": [
     "# Install the Google Cloud BigQuery library\n",
-    "!pip install --user google-cloud-bigquery==2.34.4"
+    "!pip install --user google-cloud-bigquery==2.34.4 \"shapely<2\""
    ]
   },
   {


### PR DESCRIPTION
I encountered this error while doing the lab:
cannot import name 'WKBWriter' from 'shapely.geos'

I found the solution onthe internet:
https://stackoverflow.com/questions/74831594/cannot-import-name-wkbwriter-from-shapely-geos-when-import-google-cloud-ai-p
https://www.youtube.com/watch?v=3vpuvc85npU

It has worked for me in the Google Cloud lab environment. I have fixed it in both notebooks: lab and solution.