### PR TITLE
Update 3_keras_sequential_api.ipynb

### DIFF
--- a/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
+++ b/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
@@ -61,7 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install google-cloud-aiplatform==1.20.0"
+    "!pip install google-cloud-aiplatform==1.20.0" "shapely<2"
    ]
   },
   {


### PR DESCRIPTION
The lab fails because of an issue described here: https://github.com/googleapis/python-aiplatform/issues/1852

Workaround is to pin the shapely version to <2.0.0