### PR TITLE
Update openpyxl so pandas can convert xlsx to csv

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
@@ -8,4 +8,4 @@ google-cloud-aiplatform[tensorboard]>=1.8.0
 six==1.15.0
 wget==3.2
 xlrd==2.0.1
-openpyxl==3.0.7
+openpyxl==3.0.10


### PR DESCRIPTION
The lab is broken and unable to convert the xlsx file to csv. Without that the data cannot be added to BigQuery and the lab cannot be completed. Changing the openpxyl version fixes this.