### PR TITLE
Update requirements.txt - fixing broken deps in codelab

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
@@ -5,7 +5,7 @@ grpcio-status>=1.38.1
 google-api-python-client>=1.8.0
 apache-beam>=2.28.0
 google-cloud-aiplatform[tensorboard]>=1.8.0
-six==1.15.0
+six==1.16.0
 wget==3.2
 xlrd==2.0.1
-openpyxl==3.0.7
+openpyxl==3.0.10


### PR DESCRIPTION
Deps are out of date, breaking workflow for: https://www.cloudskillsboost.google/games/3306/labs/20551

More info:

If you follow the instructions and use the newest 2.x per these instructions "In the New instance menu, choose the latest version of TensorFlow Enterprise 2.x in Environment" there are broken dependencies.  When you download the data and convert it to csv pandas cant run.

internal ref: b/323433962