### PR TITLE
GSP076 : Vertex AI Workbench Notebook: Qwik Start (Notebook Update)

### DIFF
--- a/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
+++ b/self-paced-labs/ai-platform-qwikstart/ai_platform_qwik_start.ipynb
@@ -771,7 +771,7 @@
     "os.environ[\"PROJECT\"] = PROJECT\n",
     "os.environ[\"BUCKET_NAME\"] = BUCKET_NAME\n",
     "os.environ[\"REGION\"] = REGION\n",
-    "os.environ[\"TFVERSION\"] = \"2.6\"\n",
+    "os.environ[\"TFVERSION\"] = \"2.11\"\n",
     "os.environ[\"PYTHONVERSION\"] = \"3.7\""
    ]
   },


### PR DESCRIPTION
- Updated the TF version to `2.11` in `ai_platform_qwik_start.ipynb` notebook.
- Buganzier : http://b/325014437