### PR TITLE
textEmbedding-removed deployment

### DIFF
--- a/courses/machine_learning/deepdive2/text_classification/labs/reusable_embeddings.ipynb
+++ b/courses/machine_learning/deepdive2/text_classification/labs/reusable_embeddings.ipynb
@@ -2,15 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Reusable Embeddings\n",
     "\n",
     "**Learning Objectives**\n",
     "1. Learn how to use a pre-trained TF Hub text modules to generate sentence vectors.\n",
     "1. Learn how to incorporate a pre-trained TF-Hub module into a Keras model.\n",
-    "1. Learn how to deploy and use a text model on CAIP. \n",
-    "\n",
     "\n",
     "\n",
     "## Introduction\n",
@@ -21,50 +18,49 @@
     "First, we will load and pre-process the texts and labels so that they are suitable to be fed to sequential Keras models with first layer being TF-hub pre-trained modules. Thanks to this first layer, we won't need to tokenize and integerize the text before passing it to our models. The pre-trained layer will take care of that for us, and consume directly raw text. However, we will still have to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
     "\n",
     "Then we will build, train and compare simple DNN models starting with different pre-trained TF-Hub layers."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import os\n",
     "\n",
     "from google.cloud import bigquery\n",
     "import pandas as pd"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "source": [
+    "%load_ext google.cloud.bigquery"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "The google.cloud.bigquery extension is already loaded. To reload it, use:\n",
       "  %reload_ext google.cloud.bigquery\n"
      ]
     }
    ],
-   "source": [
-    "%load_ext google.cloud.bigquery"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Replace the variable values in the cell below:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "PROJECT = \"cloud-training-demos\"  # Replace with your PROJECT\n",
     "BUCKET = PROJECT \n",
@@ -73,54 +69,94 @@
     "os.environ['PROJECT'] = PROJECT\n",
     "os.environ['BUCKET'] = BUCKET\n",
     "os.environ['REGION'] = REGION"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Create a Dataset from BigQuery \n",
     "\n",
     "Hacker news headlines are available as a BigQuery public dataset. The [dataset](https://bigquery.cloud.google.com/table/bigquery-public-data:hacker_news.stories?tab=details) contains all headlines from the sites inception in October 2006 until October 2015. \n",
     "\n",
     "Here is a sample of the dataset:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "source": [
+    "%%bigquery --project $PROJECT\n",
+    "\n",
+    "SELECT\n",
+    "    url, title, score\n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.full`\n",
+    "WHERE\n",
+    "    LENGTH(title) > 10\n",
+    "    AND score > 10\n",
+    "    AND LENGTH(url) > 0\n",
+    "LIMIT 10"
+   ],
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Query is running:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "3bcdab5bc931436e8e1a828e24183747",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Downloading:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "03eb58f0245b473280e245f29141ae44",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                                 url  \\\n",
+       "0  http://www.businessweek.com/technology/how-sof...   \n",
+       "1  http://www.businessinsider.com/henry-blodget-a...   \n",
+       "2                          https://www.babeloop.com/   \n",
+       "3                https://github.com/pksunkara/alpaca   \n",
+       "4  http://www.zetalab.de/blog/developing-an-app-f...   \n",
+       "5  http://www.uxpx.net/2011/02/16/why-you-choose-...   \n",
+       "6  https://www.reddit.com/r/technology/comments/3...   \n",
+       "7                             http://meettheboss.tv/   \n",
+       "8  http://digg.com/story/r/how_google_can_still_b...   \n",
+       "9  http://www.youtube.com/watch?v=_3XjMjG6pEo&fea...   \n",
+       "\n",
+       "                                               title  score  \n",
+       "0       How Software is Harming Science, Engineering     11  \n",
+       "1         Andreessen: Watching Netscape Disintegrate     11  \n",
+       "2  Show HN: Babeloop, a new music sight-reading w...     12  \n",
+       "3  Show HN: Given an API, Generate client librari...    268  \n",
+       "4  Developing an App for iOS, Android and Windows...     13  \n",
+       "5                        Why you choose turbotax.com     13  \n",
+       "6         Anti TPP Site Blocked by Google & Facebook     13  \n",
+       "7             Ask HN: Review our Business TV Startup     13  \n",
+       "8  How Google can still become the greatest compa...     13  \n",
+       "9  Hacking a crowd of 430 hackers with 1720 balloons     14  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -209,94 +245,88 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                                 url  \\\n",
-       "0  http://www.businessweek.com/technology/how-sof...   \n",
-       "1  http://www.businessinsider.com/henry-blodget-a...   \n",
-       "2                          https://www.babeloop.com/   \n",
-       "3                https://github.com/pksunkara/alpaca   \n",
-       "4  http://www.zetalab.de/blog/developing-an-app-f...   \n",
-       "5  http://www.uxpx.net/2011/02/16/why-you-choose-...   \n",
-       "6  https://www.reddit.com/r/technology/comments/3...   \n",
-       "7                             http://meettheboss.tv/   \n",
-       "8  http://digg.com/story/r/how_google_can_still_b...   \n",
-       "9  http://www.youtube.com/watch?v=_3XjMjG6pEo&fea...   \n",
-       "\n",
-       "                                               title  score  \n",
-       "0       How Software is Harming Science, Engineering     11  \n",
-       "1         Andreessen: Watching Netscape Disintegrate     11  \n",
-       "2  Show HN: Babeloop, a new music sight-reading w...     12  \n",
-       "3  Show HN: Given an API, Generate client librari...    268  \n",
-       "4  Developing an App for iOS, Android and Windows...     13  \n",
-       "5                        Why you choose turbotax.com     13  \n",
-       "6         Anti TPP Site Blocked by Google & Facebook     13  \n",
-       "7             Ask HN: Review our Business TV Startup     13  \n",
-       "8  How Google can still become the greatest compa...     13  \n",
-       "9  Hacking a crowd of 430 hackers with 1720 balloons     14  "
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 4
     }
    ],
-   "source": [
-    "%%bigquery --project $PROJECT\n",
-    "\n",
-    "SELECT\n",
-    "    url, title, score\n",
-    "FROM\n",
-    "    `bigquery-public-data.hacker_news.full`\n",
-    "WHERE\n",
-    "    LENGTH(title) > 10\n",
-    "    AND score > 10\n",
-    "    AND LENGTH(url) > 0\n",
-    "LIMIT 10"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's do some regular expression parsing in BigQuery to get the source of the newspaper article from the URL. For example, if the url is http://mobile.nytimes.com/...., I want to be left with <i>nytimes</i>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "source": [
+    "%%bigquery --project $PROJECT\n",
+    "\n",
+    "SELECT\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source,\n",
+    "    COUNT(title) AS num_articles\n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.full`\n",
+    "WHERE\n",
+    "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
+    "    AND LENGTH(title) > 10\n",
+    "GROUP BY\n",
+    "    source\n",
+    "ORDER BY num_articles DESC\n",
+    "  LIMIT 100"
+   ],
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Query is running:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "aed7cb8b7d11416b98f5863207853a4a",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Downloading:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "93ff6b4a40634ec5a059dde32093d99b",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "          source  num_articles\n",
+       "0         github        139395\n",
+       "1         medium        125985\n",
+       "2        youtube        101025\n",
+       "3        nytimes         73114\n",
+       "4       blogspot         59863\n",
+       "..           ...           ...\n",
+       "95  nextplatform          2647\n",
+       "96     anandtech          2629\n",
+       "97   extremetech          2598\n",
+       "98      politico          2594\n",
+       "99       9to5mac          2590\n",
+       "\n",
+       "[100 rows x 2 columns]"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -380,83 +410,24 @@
        "</table>\n",
        "<p>100 rows × 2 columns</p>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "          source  num_articles\n",
-       "0         github        139395\n",
-       "1         medium        125985\n",
-       "2        youtube        101025\n",
-       "3        nytimes         73114\n",
-       "4       blogspot         59863\n",
-       "..           ...           ...\n",
-       "95  nextplatform          2647\n",
-       "96     anandtech          2629\n",
-       "97   extremetech          2598\n",
-       "98      politico          2594\n",
-       "99       9to5mac          2590\n",
-       "\n",
-       "[100 rows x 2 columns]"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 5
     }
    ],
-   "source": [
-    "%%bigquery --project $PROJECT\n",
-    "\n",
-    "SELECT\n",
-    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source,\n",
-    "    COUNT(title) AS num_articles\n",
-    "FROM\n",
-    "    `bigquery-public-data.hacker_news.full`\n",
-    "WHERE\n",
-    "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
-    "    AND LENGTH(title) > 10\n",
-    "GROUP BY\n",
-    "    source\n",
-    "ORDER BY num_articles DESC\n",
-    "  LIMIT 100"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now that we have good parsing of the URL to get the source, let's put together a dataset of source and titles. This will be our labeled dataset for machine learning."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "SELECT \n",
-      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
-      "    source\n",
-      "FROM\n",
-      "  (\n",
-      "SELECT\n",
-      "    title,\n",
-      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source\n",
-      "    \n",
-      "FROM\n",
-      "    `bigquery-public-data.hacker_news.full`\n",
-      "WHERE\n",
-      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
-      "    AND LENGTH(title) > 10\n",
-      ")\n",
-      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
-      "\n"
-     ]
-    }
-   ],
    "source": [
     "regex = '.*://(.[^/]+)/'\n",
     "\n",
@@ -484,23 +455,63 @@
     "\"\"\".format(sub_query=sub_query)\n",
     "\n",
     "print(query)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "SELECT \n",
+      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
+      "    source\n",
+      "FROM\n",
+      "  (\n",
+      "SELECT\n",
+      "    title,\n",
+      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source\n",
+      "    \n",
+      "FROM\n",
+      "    `bigquery-public-data.hacker_news.full`\n",
+      "WHERE\n",
+      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
+      "    AND LENGTH(title) > 10\n",
+      ")\n",
+      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
+      "\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset). AutoML however figures out on its own how to create these splits, so we won't need to do that here. \n",
     "\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "source": [
+    "bq = bigquery.Client(project=PROJECT)\n",
+    "title_dataset = bq.query(query).to_dataframe()\n",
+    "title_dataset.head()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                               title  source\n",
+       "0                              php bdd is now  nice   github\n",
+       "1                                     skinny vagrant  github\n",
+       "2  want to control an angularjs app using your we...  github\n",
+       "3  show hn  authority  orm-neutral  oo rails auth...  github\n",
+       "4                      just ported mongobox to redis  github"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -553,30 +564,16 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                               title  source\n",
-       "0                              php bdd is now  nice   github\n",
-       "1                                     skinny vagrant  github\n",
-       "2  want to control an angularjs app using your we...  github\n",
-       "3  show hn  authority  orm-neutral  oo rails auth...  github\n",
-       "4                      just ported mongobox to redis  github"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 7
     }
    ],
-   "source": [
-    "bq = bigquery.Client(project=PROJECT)\n",
-    "title_dataset = bq.query(query).to_dataframe()\n",
-    "title_dataset.head()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "AutoML for text classification requires that\n",
     "* the dataset be in csv form with \n",
@@ -584,38 +581,42 @@
     "* the last colum to be the text labels\n",
     "\n",
     "The dataset we pulled from BiqQuery satisfies these requirements."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "source": [
+    "print(\"The full dataset contains {n} titles\".format(n=len(title_dataset)))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "The full dataset contains 266442 titles\n"
      ]
     }
    ],
-   "source": [
-    "print(\"The full dataset contains {n} titles\".format(n=len(title_dataset)))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's make sure we have roughly the same number of labels for each of our three labels:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "source": [
+    "title_dataset.source.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        139395\n",
@@ -624,43 +625,38 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 9
     }
    ],
-   "source": [
-    "title_dataset.source.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Finally we will save our data, which is currently in-memory, to disk.\n",
     "\n",
     "We will create a csv file containing the full dataset and another containing only 1000 articles for development.\n",
     "\n",
     "**Note:** It may take a long time to train AutoML on the full dataset, so we recommend to use the sample dataset for the purpose of learning the tool. \n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "DATADIR = './data/'\n",
     "\n",
     "if not os.path.exists(DATADIR):\n",
     "    os.makedirs(DATADIR)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "FULL_DATASET_NAME = 'titles_full.csv'\n",
     "FULL_DATASET_PATH = os.path.join(DATADIR, FULL_DATASET_NAME)\n",
@@ -670,21 +666,27 @@
     "\n",
     "title_dataset.to_csv(\n",
     "    FULL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now let's sample 1000 articles from the full dataset and make sure we have enough examples for each label in our sample dataset (see [here](https://cloud.google.com/natural-language/automl/docs/beginners-guide) for further details on how to prepare data for AutoML)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "source": [
+    "sample_title_dataset = title_dataset.sample(n=1000)\n",
+    "sample_title_dataset.source.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        528\n",
@@ -693,49 +695,35 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 12
     }
    ],
-   "source": [
-    "sample_title_dataset = title_dataset.sample(n=1000)\n",
-    "sample_title_dataset.source.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's write the sample datatset to disk."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "SAMPLE_DATASET_NAME = 'titles_sample.csv'\n",
     "SAMPLE_DATASET_PATH = os.path.join(DATADIR, SAMPLE_DATASET_NAME)\n",
     "\n",
     "sample_title_dataset.to_csv(\n",
     "    SAMPLE_DATASET_PATH, header=False, index=False, encoding='utf-8')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.6.5\n"
-     ]
-    }
-   ],
    "source": [
     "import datetime\n",
     "import os\n",
@@ -752,72 +740,98 @@
     "\n",
     "\n",
     "print(tf.__version__)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "2.6.5\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%matplotlib inline"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's start by specifying where the information about the trained models will be saved as well as where our dataset is located:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "MODEL_DIR = \"./text_models\"\n",
     "DATA_DIR = \"./data\""
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Loading the dataset"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "As in the previous labs, our dataset consists of titles of articles along with the label indicating from which source these articles have been taken from (GitHub, Tech-Crunch, or the New-York Times):"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "source": [
+    "ls ./data/"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "titles_full.csv  titles_sample.csv\n"
      ]
     }
    ],
-   "source": [
-    "ls ./data/"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "source": [
+    "DATASET_NAME = \"titles_full.csv\"\n",
+    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
+    "COLUMNS = ['title', 'source']\n",
+    "\n",
+    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
+    "titles_df.head()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                               title      source\n",
+       "0  a powerful  disturbing history of residential ...     nytimes\n",
+       "1  why are eggs sold by the dozen  why not by 10s...     nytimes\n",
+       "2  a curated list of awesome machine learning fra...      github\n",
+       "3  hn greasemonkey script  show user reputation k...      github\n",
+       "4  zurb launches foundation 3 to take on twitter ...  techcrunch"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -870,43 +884,30 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                               title      source\n",
-       "0  a powerful  disturbing history of residential ...     nytimes\n",
-       "1  why are eggs sold by the dozen  why not by 10s...     nytimes\n",
-       "2  a curated list of awesome machine learning fra...      github\n",
-       "3  hn greasemonkey script  show user reputation k...      github\n",
-       "4  zurb launches foundation 3 to take on twitter ...  techcrunch"
       ]
      },
-     "execution_count": 18,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 18
     }
    ],
-   "source": [
-    "DATASET_NAME = \"titles_full.csv\"\n",
-    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
-    "COLUMNS = ['title', 'source']\n",
-    "\n",
-    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
-    "titles_df.head()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's look again at the number of examples per label to make sure we have a well-balanced dataset:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "source": [
+    "titles_df.source.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        139395\n",
@@ -915,38 +916,33 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 19,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 19
     }
    ],
-   "source": [
-    "titles_df.source.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Preparing the labels"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "In this lab, we will use pre-trained [TF-Hub embeddings modules for english](https://tfhub.dev/s?q=tf2%20embeddings%20text%20english) for the first layer of our models. One immediate\n",
     "advantage of doing so is that the TF-Hub embedding module will take care for us of processing the raw text. \n",
     "This also means that our model will be able to consume text directly instead of sequences of integers representing the words.\n",
     "\n",
     "However, as before, we still need to preprocess the labels into one-hot-encoded vectors:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "CLASSES = {\n",
     "    'github': 0,\n",
@@ -954,26 +950,31 @@
     "    'techcrunch': 2\n",
     "}\n",
     "N_CLASSES = len(CLASSES)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def encode_labels(sources):\n",
     "    classes = [CLASSES[source] for source in sources]\n",
     "    one_hots = to_categorical(classes, num_classes=N_CLASSES)\n",
     "    return one_hots"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "source": [
+    "encode_labels(titles_df.source[:4])"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0., 1., 0.],\n",
@@ -982,34 +983,29 @@
        "       [1., 0., 0.]], dtype=float32)"
       ]
      },
-     "execution_count": 22,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 22
     }
    ],
-   "source": [
-    "encode_labels(titles_df.source[:4])"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Preparing the train/test splits"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's split our data into train and test splits:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "N_TRAIN = int(len(titles_df) * 0.95)\n",
     "\n",
@@ -1018,25 +1014,30 @@
     "\n",
     "titles_valid, sources_valid = (\n",
     "    titles_df.title[N_TRAIN:], titles_df.source[N_TRAIN:])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To be on the safe side, we verify that the train and test splits\n",
     "have roughly the same number of examples per class.\n",
     "\n",
     "Since it is the case, accuracy will be a good metric to use to measure\n",
     "the performance of our models."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "source": [
+    "sources_train.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        132432\n",
@@ -1045,21 +1046,21 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 24,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 24
     }
    ],
-   "source": [
-    "sources_train.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "source": [
+    "sources_valid.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        6963\n",
@@ -1068,38 +1069,38 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 25,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 25
     }
    ],
-   "source": [
-    "sources_valid.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now let's create the features and labels we will feed our models with:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "X_train, Y_train = titles_train.values, encode_labels(sources_train)\n",
     "X_valid, Y_valid = titles_valid.values, encode_labels(sources_valid)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "source": [
+    "X_train[:3]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array(['a powerful  disturbing history of residential segregation in america',\n",
@@ -1108,21 +1109,21 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 27,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 27
     }
    ],
-   "source": [
-    "X_train[:3]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "source": [
+    "Y_train[:3]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0., 1., 0.],\n",
@@ -1130,25 +1131,21 @@
        "       [1., 0., 0.]], dtype=float32)"
       ]
      },
-     "execution_count": 28,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 28
     }
    ],
-   "source": [
-    "Y_train[:3]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## NNLM Model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We will first try a word embedding pre-trained using a [Neural Probabilistic Language Model](http://www.jmlr.org/papers/volume3/bengio03a/bengio03a.pdf). TF-Hub has a 50-dimensional one called \n",
     "[nnlm-en-dim50-with-normalization](https://tfhub.dev/google/tf2-preview/nnlm-en-dim50/1), which also\n",
@@ -1157,16 +1154,21 @@
     "### Lab Task 1a: Import NNLM TF Hub module into `KerasLayer`\n",
     "\n",
     "Once loaded from its url, the TF-hub module can be used as a normal Keras layer in a sequential or functional model. Since we have enough data to fine-tune the parameters of the pre-trained embedding itself, we will set `trainable=True` in the `KerasLayer` that loads the pre-trained embedding:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "source": [
+    "NNLM = \"https://tfhub.dev/google/nnlm-en-dim50/2\"\n",
+    "\n",
+    "nnlm_module = KerasLayer(# TODO)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:14:45.799376: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64\n",
       "2023-07-31 13:14:45.799417: W tensorflow/stream_executor/cuda/cuda_driver.cc:269] failed call to cuInit: UNKNOWN ERROR (303)\n",
@@ -1177,32 +1179,31 @@
      ]
     }
    ],
-   "source": [
-    "NNLM = \"https://tfhub.dev/google/nnlm-en-dim50/2\"\n",
-    "\n",
-    "nnlm_module = KerasLayer(# TODO)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Note that this TF-Hub embedding produces a single 50-dimensional vector when passed a sentence:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "### Lab Task 1b: Use module to encode a sentence string"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {},
+   "source": [
+    "nnlm_module(tf.constant([# TODO]))"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<tf.Tensor: shape=(1, 50), dtype=float32, numpy=\n",
@@ -1219,57 +1220,57 @@
        "      dtype=float32)>"
       ]
      },
-     "execution_count": 30,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 30
     }
    ],
-   "source": [
-    "nnlm_module(tf.constant([# TODO]))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Swivel Model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Then we will try a word embedding obtained using [Swivel](https://arxiv.org/abs/1602.02215), an algorithm that essentially factorizes word co-occurrence matrices to create the words embeddings. \n",
     "TF-Hub hosts the pretrained [gnews-swivel-20dim-with-oov](https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1) 20-dimensional Swivel module.\n",
     "\n",
     "### Lab Task 1c: Import Swivel TF Hub module into `KerasLayer`"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "SWIVEL = \"https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1\"\n",
     "swivel_module = KerasLayer(# TODO)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Similarly as the previous pre-trained embedding, it outputs a single vector when passed a sentence:\n",
     "\n",
     "### Lab Task 1d: Use module to encode a sentence string"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "source": [
+    "swivel_module(tf.constant([# TODO]))"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<tf.Tensor: shape=(1, 20), dtype=float32, numpy=\n",
@@ -1280,25 +1281,21 @@
        "      dtype=float32)>"
       ]
      },
-     "execution_count": 32,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 32
     }
    ],
-   "source": [
-    "swivel_module(tf.constant([# TODO]))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Building the models"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's write a function that \n",
     "\n",
@@ -1306,13 +1303,12 @@
     "* returns a compiled Keras sequential model starting with this pre-trained TF-hub layer, adding one or more dense relu layers to it, and ending with a softmax layer giving the probability of each of the classes:\n",
     "\n",
     "### Lab Task 2: Incorporate a pre-trained TF Hub module as first layer of Keras Sequential Model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def build_model(hub_module, name):\n",
     "    model = Sequential([\n",
@@ -1327,23 +1323,23 @@
     "        metrics=['accuracy']\n",
     "    )\n",
     "    return model"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's also wrap the training code into a `train_and_evaluate` function that \n",
     "* takes as input the training and validation data, as well as the compiled model itself, and the `batch_size`\n",
     "* trains the compiled model for 100 epochs at most, and does early-stopping when the validation loss is no longer decreasing\n",
     "* returns an `history` object, which will help us to plot the learning curves"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def train_and_evaluate(train_data, val_data, model, batch_size=5000):\n",
     "    X_train, Y_train = train_data\n",
@@ -1362,33 +1358,38 @@
     "        callbacks=TensorBoard(model_dir),\n",
     "    )\n",
     "    return history"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Training NNLM"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "data = (X_train, Y_train)\n",
     "val_data = (X_valid, Y_valid)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {},
+   "source": [
+    "nnlm_model = build_model(nnlm_module, 'nnlm')\n",
+    "nnlm_history = train_and_evaluate(data, val_data, nnlm_model)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:16:13.668869: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:16:13.668917: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n",
@@ -1396,31 +1397,31 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Epoch 1/50\n",
       " 1/51 [..............................] - ETA: 47s - loss: 1.1633 - accuracy: 0.2336"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:16:14.733319: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:16:14.733366: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       " 2/51 [>.............................] - ETA: 22s - loss: 1.1584 - accuracy: 0.2316"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:16:15.170245: I tensorflow/core/profiler/lib/profiler_session.cc:66] Profiler session collecting data.\n",
       "2023-07-31 13:16:15.173360: I tensorflow/core/profiler/lib/profiler_session.cc:164] Profiler session tear down.\n",
@@ -1440,8 +1441,8 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "51/51 [==============================] - 23s 446ms/step - loss: 0.9860 - accuracy: 0.6033 - val_loss: 0.7855 - val_accuracy: 0.7875\n",
       "Epoch 2/50\n",
@@ -1545,77 +1546,76 @@
      ]
     }
    ],
-   "source": [
-    "nnlm_model = build_model(nnlm_module, 'nnlm')\n",
-    "nnlm_history = train_and_evaluate(data, val_data, nnlm_model)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {},
+   "source": [
+    "history = nnlm_history\n",
+    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
+    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 38,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 38
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABI40lEQVR4nO3dd3xb5b0/8I8ka3hJ8pRH7NhkTydkuCZAGYY00DSMSynkRwIUKDRpgZRbkltIoL0QWkpuymqAstrLCOUSSpuUFUgImcSJQ6bJcGwn3kuyZVuSpfP749HwkB3bkXRs6/N+vc5L8tGR9fgkxB+e8X0UkiRJICIiIpKJUu4GEBERUXhjGCEiIiJZMYwQERGRrBhGiIiISFYMI0RERCQrhhEiIiKSFcMIERERyYphhIiIiGQVIXcD+sLlcqG8vByxsbFQKBRyN4eIiIj6QJIkNDU1IS0tDUplz/0fQyKMlJeXIyMjQ+5mEBER0QCUlZVhxIgRPb4+JMJIbGwsAPHD6PV6mVtDREREfWGxWJCRkeH9Pd6TIRFGPEMzer2eYYSIiGiIOdcUC05gJSIiIlkxjBAREZGsGEaIiIhIVkNizggREYU3SZLQ3t4Op9Mpd1OoA5VKhYiIiPMuu9HvMPLVV1/h6aefRkFBASoqKrBhwwZcd911vb5ny5YtWLZsGQ4fPoyMjAw88sgjuP322wfYZCIiCid2ux0VFRVoaWmRuynkR1RUFFJTU6HRaAb8PfodRqxWK3JycnDnnXfihhtuOOf1xcXFuPbaa3HvvffirbfewubNm3HXXXchNTUVc+fOHVCjiYgoPLhcLhQXF0OlUiEtLQ0ajYbFLwcJSZJgt9tRU1OD4uJijBkzptfCZr3pdxiZN28e5s2b1+fr161bh+zsbDzzzDMAgAkTJuDrr7/G//zP/zCMEBFRr+x2O1wuFzIyMhAVFSV3c6iLyMhIqNVqlJSUwG63Q6fTDej7BH0C686dO5Gfn9/p3Ny5c7Fz584e32Oz2WCxWDodREQUvgb6f9wUfIH4swn6n25lZSVMJlOncyaTCRaLBa2trX7fs3r1ahgMBu/BUvBERETD16CMmitWrIDZbPYeZWVlcjeJiIiIgiToS3tTUlJQVVXV6VxVVRX0ej0iIyP9vker1UKr1Qa7aUREREFz2WWXYdq0aVi7dq3cTRn0gt4zkpeXh82bN3c699lnnyEvLy/YH01ERERDQL/DSHNzMwoLC1FYWAhALN0tLCxEaWkpADHEsmjRIu/19957L06dOoVf//rXOHbsGF588UW89957ePDBBwPzE5yH174uxqMfHsLxqia5m0JERBS2+h1G9u7di+nTp2P69OkAgGXLlmH69OlYuXIlAKCiosIbTAAgOzsbGzduxGeffYacnBw888wz+Mtf/jIolvX+89ty/G1XCU7VWuVuChER9ZEkSWixt8tySJI0oDY3NDRg0aJFiIuLQ1RUFObNm4fjx497Xy8pKcH8+fMRFxeH6OhoTJo0CZs2bfK+d+HChUhKSkJkZCTGjBmD119/PSD3crDo95yRyy67rNc/jDfeeMPve/bv39/fjwq6WJ0aANDU1i5zS4iIqK9aHU5MXPmJLJ995LdzEaXp/3TL22+/HcePH8dHH30EvV6Phx9+GNdccw2OHDkCtVqNJUuWwG6346uvvkJ0dDSOHDmCmJgYAMCjjz6KI0eO4N///jcSExNx4sSJHlejDlVhvTdNrE78+JZWh8wtISKi4coTQrZv346LLroIAPDWW28hIyMDH374IW666SaUlpbixhtvxJQpUwAAF1xwgff9paWlmD59OmbOnAkAyMrKCvnPEGxhHUb07BkhIhpyItUqHPmtPEP9kWpVv99z9OhRREREIDc313suISEB48aNw9GjRwEAv/zlL3Hffffh008/RX5+Pm688UZMnToVAHDffffhxhtvxL59+3D11Vfjuuuu84aa4WJQ1hkJFb2nZ6SNPSNEREOFQqFAlCZCliNY++LcddddOHXqFG677TYcPHgQM2fOxHPPPQdAbMNSUlKCBx98EOXl5bjyyivx0EMPBaUdcgnrMOIZpmliGCEioiCZMGEC2tvbsXv3bu+5uro6FBUVYeLEid5zGRkZuPfee/HBBx/gV7/6FV555RXva0lJSVi8eDH+93//F2vXrsXLL78c0p8h2MJ7mCaSwzRERBRcY8aMwYIFC3D33XfjpZdeQmxsLJYvX4709HQsWLAAAPDAAw9g3rx5GDt2LBoaGvDll19iwoQJAICVK1dixowZmDRpEmw2G/71r395Xxsu2DMCDtMQEVFwvf7665gxYwZ++MMfIi8vD5IkYdOmTVCrxf8UO51OLFmyBBMmTMAPfvADjB07Fi+++CIAQKPRYMWKFZg6dSouvfRSqFQqvPvuu3L+OAGnkAa6aDqELBYLDAYDzGYz9Hp9wL7v5qNV+OmbezF1hAEfLb04YN+XiIgCo62tDcXFxcjOzh7w9vQUXL39GfX193eY94xwmIaIiEhuYR5GWGeEiIhIbmEdRjiBlYiISH5hHUY8PSN2pwttDqfMrSEiIgpPYR1GYjQR8NSv4YoaIiIieYR1GFEqFYjRegqfcaiGiIhIDmEdRgDf/jScxEpERCSPsA8jvpLw7BkhIiKSQ9iHEe7cS0REJK+wDyMsCU9ERINRVlYW1q5d26drFQoFPvzww6C2J5jCPoz4ao0wjBAREckh7MMI54wQERHJi2GEJeGJiIYWSQLsVnmOPu4t+/LLLyMtLQ0ul6vT+QULFuDOO+/EyZMnsWDBAphMJsTExGDWrFn4/PPPA3aLDh48iCuuuAKRkZFISEjAPffcg+bmZu/rW7ZswezZsxEdHQ2j0Yg5c+agpKQEAHDgwAFcfvnliI2NhV6vx4wZM7B3796Atc2fiKB+9yGAE1iJiIYYRwvwZJo8n/1f5YAm+pyX3XTTTfjFL36BL7/8EldeeSUAoL6+Hh9//DE2bdqE5uZmXHPNNXjiiSeg1Wrx17/+FfPnz0dRUREyMzPPq4lWqxVz585FXl4evvnmG1RXV+Ouu+7C0qVL8cYbb6C9vR3XXXcd7r77brzzzjuw2+3Ys2cPFO4qoAsXLsT06dPx5z//GSqVCoWFhVCr1efVpnMJ+zDi2bmXE1iJiChQ4uLiMG/ePLz99tveMPL+++8jMTERl19+OZRKJXJycrzX/+53v8OGDRvw0UcfYenSpef12W+//Tba2trw17/+FdHRIjg9//zzmD9/Pn7/+99DrVbDbDbjhz/8IUaNGgUAmDBhgvf9paWl+M///E+MHz8eADBmzJjzak9fhH0Y0Ud6VtOwZ4SIaEhQR4keCrk+u48WLlyIu+++Gy+++CK0Wi3eeust/OQnP4FSqURzczMee+wxbNy4ERUVFWhvb0draytKS0vPu4lHjx5FTk6ON4gAwJw5c+ByuVBUVIRLL70Ut99+O+bOnYurrroK+fn5+PGPf4zU1FQAwLJly3DXXXfhb3/7G/Lz83HTTTd5Q0uwcM4Ih2mIiIYWhUIMlchxeDY064P58+dDkiRs3LgRZWVl2LZtGxYuXAgAeOihh7BhwwY8+eST2LZtGwoLCzFlyhTY7fZg3bVOXn/9dezcuRMXXXQR1q9fj7Fjx2LXrl0AgMceewyHDx/Gtddeiy+++AITJ07Ehg0bgtoehhFOYCUioiDQ6XS44YYb8NZbb+Gdd97BuHHjcOGFFwIAtm/fjttvvx3XX389pkyZgpSUFJw+fTognzthwgQcOHAAVqvVe2779u1QKpUYN26c99z06dOxYsUK7NixA5MnT8bbb7/tfW3s2LF48MEH8emnn+KGG27A66+/HpC29STsw4hvAivDCBERBdbChQuxceNGvPbaa95eEUDMw/jggw9QWFiIAwcO4NZbb+228uZ8PlOn02Hx4sU4dOgQvvzyS/ziF7/AbbfdBpPJhOLiYqxYsQI7d+5ESUkJPv30Uxw/fhwTJkxAa2srli5dii1btqCkpATbt2/HN99802lOSTBwzoi7Z6TZ1g6XS4JS2fcuOCIiot5cccUViI+PR1FREW699Vbv+TVr1uDOO+/ERRddhMTERDz88MOwWCwB+cyoqCh88sknuP/++zFr1ixERUXhxhtvxJo1a7yvHzt2DG+++Sbq6uqQmpqKJUuW4Gc/+xna29tRV1eHRYsWoaqqComJibjhhhvw+OOPB6RtPVFIUh8XTcvIYrHAYDDAbDZDr9cH9Hu32p2YsPJjAMDBx672ziEhIiL5tbW1obi4GNnZ2dDpdHI3h/zo7c+or7+/w36YRqdWQq0SvSGcxEpERBR6YR9GFAoFV9QQEdGg9dZbbyEmJsbvMWnSJLmbFxBhP2cEEPNG6q12Fj4jIqJB50c/+hFyc3P9vhbsyqihwjCCjrVGGEaIiGhwiY2NRWxsrNzNCKqwH6YBOtYa4TANEdFgNATWWoStQPzZMIyAtUaIiAYrzzBES0uLzC2hnnj+bM5nyIjDNOjQM8IJrEREg4pKpYLRaER1dTUAUSND0Y+S7BQ8kiShpaUF1dXVMBqNUKlUA/5eDCPgzr1ERINZSkoKAHgDCQ0uRqPR+2c0UAwj8O3cy6W9RESDj0KhQGpqKpKTk+Fw8H8aBxO1Wn1ePSIeDCPgzr1EREOBSqUKyC8+Gnw4gRW+/Wm4cy8REVHoMYyAdUaIiIjkxDACX88Ih2mIiIhCj2EEgD6Sq2mIiIjkwjACX50R9owQERGFHsMIfHNGWuxOOJwumVtDREQUXhhG4OsZAYBm9o4QERGFFMMIALVKiUi1WLvOoRoiIqLQYhhx81Rh5SRWIiKi0GIYceP+NERERPJgGHHjihoiIiJ5MIy46T09IywJT0REFFIMI27sGSEiIpIHw4gb54wQERHJg2HEzbOahj0jREREocUw4qbnzr1ERESyYBhx8+zca2llzwgREVEoMYy4eeaMNNnYM0JERBRKDCNuXE1DREQkD4YRN30k64wQERHJgWHEjT0jRERE8mAYcfPOGWlrhyRJMreGiIgofDCMuHlW09idLtjaXTK3hoiIKHwwjLhFayKgUIjnrMJKREQUOgwjbkqlAjFa1hohIiIKNYaRDliFlYiIKPQGFEZeeOEFZGVlQafTITc3F3v27On1+rVr12LcuHGIjIxERkYGHnzwQbS1tQ2owcHEFTVERESh1+8wsn79eixbtgyrVq3Cvn37kJOTg7lz56K6utrv9W+//TaWL1+OVatW4ejRo3j11Vexfv16/Nd//dd5Nz7QvLVG2DNCREQUMv0OI2vWrMHdd9+NO+64AxMnTsS6desQFRWF1157ze/1O3bswJw5c3DrrbciKysLV199NW655ZZz9qbIQc+eESIiopDrVxix2+0oKChAfn6+7xsolcjPz8fOnTv9vueiiy5CQUGBN3ycOnUKmzZtwjXXXNPj59hsNlgslk5HKMRyzggREVHIRfTn4traWjidTphMpk7nTSYTjh075vc9t956K2pra3HxxRdDkiS0t7fj3nvv7XWYZvXq1Xj88cf707SA4M69REREoRf01TRbtmzBk08+iRdffBH79u3DBx98gI0bN+J3v/tdj+9ZsWIFzGaz9ygrKwt2MwGwZ4SIiEgO/eoZSUxMhEqlQlVVVafzVVVVSElJ8fueRx99FLfddhvuuusuAMCUKVNgtVpxzz334De/+Q2Uyu55SKvVQqvV9qdpAcHVNERERKHXr54RjUaDGTNmYPPmzd5zLpcLmzdvRl5ent/3tLS0dAscKpUKAAbdHjBcTUNERBR6/eoZAYBly5Zh8eLFmDlzJmbPno21a9fCarXijjvuAAAsWrQI6enpWL16NQBg/vz5WLNmDaZPn47c3FycOHECjz76KObPn+8NJbI59AHQWAJMuh6Iy/L2jFjYM0JERBQy/Q4jN998M2pqarBy5UpUVlZi2rRp+Pjjj72TWktLSzv1hDzyyCNQKBR45JFHcPbsWSQlJWH+/Pl44oknAvdTDNSO54DyfUDSeCAuy1uB1dLKnhEiIqJQUUiDbazED4vFAoPBALPZDL1eH7hv/LcbgJObgev+DEy7FftLG3D9izuQbozE9uVXBO5ziIiIwlBff3+H9940kUbx2NoIgKtpiIiI5BDmYSROPLY2AAD0ke7VNLZ2uFyDvsOIiIhoWAjvMKIzise2RgC+XXslCbDaOYmViIgoFMI7jHQZptFGKKFWKQCw1ggREVGohHkY6TxMo1AofCtqOG+EiIgoJMI7jHQZpgFYhZWIiCjUwjuMdOkZAXxVWLmihoiIKDTCPIwYxaN7zgjg6xnhzr1EREShEd5hxDNM09ogltAAiNWyZ4SIiCiUwjuMeIZpJCdgbwbgqzXC/WmIiIhCI7zDiDoSUGnE8y5VWLmahoiIKDTCO4woFN0msXI1DRERUWiFdxgBeqzCyp17iYiIQoNhxLuihj0jREREcmAY8Q7TNAJgnREiIqJQYxjpMkzjrTPCnhEiIqKQYBjpMoHVM2eEPSNEREShwTDSpQqrbwIre0aIiIhCgWGkYxVW+IZpWh1OOJwumRpFREQUPhhGPMM07jkjMe4wAgDNnDdCREQUdAwjXYZp1ColojQqAKzCSkREFAoMI10msAKsNUJERBRKDCNdlvYCHSaxsmeEiIgo6BhGPMM0bWbA5QTQodYIV9QQEREFHcOIp2cEEIEEvp17WWuEiIgo+BhGIjSAOlo892yW5y0Jz54RIiKiYGMYAbpNYvWVhGfPCBERUbAxjADdlvdyNQ0REVHoMIwAPe5PY2llzwgREVGwMYwAgM4gHj1zRtgzQkREFDIMI0CHYRp3z4hnAquNPSNERETBxjACdBimaQTAOiNEREShxDACdKvCyjojREREocMwAnTrGdHrWGeEiIgoVBhGgB6X9lraHJAkSZ42ERERhQmGEcA3TNOl6JnDKcHW7pKpUUREROGBYQTwDdO454xEayKgVIhTrMJKREQUXAwjQLdhGqVSgRgtV9QQERGFAsMI4OsZcViBdjuAjpvlsWeEiIgomBhGAEBrAOAel+myvNfCFTVERERBxTACAEoloNOL510msbJnhIiIKLgYRjxYa4SIiEgWDCMeXaqw6r0l4dkzQkREFEwMIx7enpGuwzTsGSEiIgomhhGPLst7uZqGiIgoNBhGPHqowsrVNERERMHFMOLRpQqrnjv3EhERhQTDiId3mMbTM8I6I0RERKHAMOLRZWlvLFfTEBERhQTDiEfXpb2RrDNCREQUCgwjHt2GaTwTWNkzQkREFEwMIx49DNM029rhckkyNYqIiGj4Yxjx6Li0V5K8q2kkCbDaOVRDREQULAwjHp6eEZcDcLRAp1ZBoxK3hytqiIiIgodhxEMTDSjF0IyvCit37iUiIgo2hhEPhcJPFVauqCEiIgo2hpGOulRhZa0RIiKi4GMY6ajL8l49e0aIiIiCjmGko56qsHLOCBERUdAwjHTUpQqrJ4ywZ4SIiCh4GEY66mGYhj0jREREwcMw0lG3YRp3GGllzwgREVGwMIx01GVpL+uMEBERBR/DSEfdlvZyNQ0REVGwDSiMvPDCC8jKyoJOp0Nubi727NnT6/WNjY1YsmQJUlNTodVqMXbsWGzatGlADQ4q75yRRgBcTUNERBQKEf19w/r167Fs2TKsW7cOubm5WLt2LebOnYuioiIkJyd3u95ut+Oqq65CcnIy3n//faSnp6OkpARGozEQ7Q8s75wR1hkhIiIKlX6HkTVr1uDuu+/GHXfcAQBYt24dNm7ciNdeew3Lly/vdv1rr72G+vp67NixA2q1+OWelZV1fq0Olh6X9rJnhIiIKFj6NUxjt9tRUFCA/Px83zdQKpGfn4+dO3f6fc9HH32EvLw8LFmyBCaTCZMnT8aTTz4Jp9PZ4+fYbDZYLJZOR0h0HKZxuXxLe7mahoiIKGj6FUZqa2vhdDphMpk6nTeZTKisrPT7nlOnTuH999+H0+nEpk2b8Oijj+KZZ57Bf//3f/f4OatXr4bBYPAeGRkZ/WnmwHl6RiABNot3NU2rwwmH0xWaNhAREYWZoK+mcblcSE5Oxssvv4wZM2bg5ptvxm9+8xusW7eux/esWLECZrPZe5SVlQW7mYJaB0REiuetDYjR+kaxOG+EiIgoOPo1ZyQxMREqlQpVVVWdzldVVSElJcXve1JTU6FWq6FSqbznJkyYgMrKStjtdmg0mm7v0Wq10Gq1/Wla4ETGAU2tQFsjIuKzEa1RwWp3oqnNgfjo7m0lIiKi89OvnhGNRoMZM2Zg8+bN3nMulwubN29GXl6e3/fMmTMHJ06cgMvlG+b47rvvkJqa6jeIyK7b8l6uqCEiIgqmfg/TLFu2DK+88grefPNNHD16FPfddx+sVqt3dc2iRYuwYsUK7/X33Xcf6uvrcf/99+O7777Dxo0b8eSTT2LJkiWB+ykCqUsVVm+tkVauqCEiIgqGfi/tvfnmm1FTU4OVK1eisrIS06ZNw8cff+yd1FpaWgql0pdxMjIy8Mknn+DBBx/E1KlTkZ6ejvvvvx8PP/xw4H6KQOpShVUf6dksjz0jREREwdDvMAIAS5cuxdKlS/2+tmXLlm7n8vLysGvXroF8VOh12bmXtUaIiIiCi3vTdNXTzr3sGSEiIgoKhpGuulRh1XPOCBERUVAxjHTVZZgmKVYsMa5ussnUICIiouGNYaSrLsM0qQYdAKDS3CpTg4iIiIY3hpGuvEt7GwEAKQZRkbXC3CZPe4iIiIY5hpGuuiztTXP3jDCMEBERBQfDSFddKrCmuMOIudWBFjtX1BAREQUaw0hXnmEaexPgdCBWp0ase8M89o4QEREFHsNIVzqD73mbGYCvd6SSYYSIiCjgGEa6UkUAWr147l7e6wkj5Y1cUUNERBRoDCP+dJk3kuZeUcOeESIiosBjGPGnSxVWb88IwwgREVHAMYz406UKKwufERERBQ/DiD9dq7AaWfiMiIgoWBhG/PFWYe3cM8IwQkREFHgMI/50qcKaysJnREREQcMw4k+XOSOxOjViWPiMiIgoKBhG/OmyWR7AwmdERETBwjDiT5dhGoDzRoiIiIKFYcSfLsM0QIcwwiqsREREAcUw4k+Xpb0AkOKuwlphYc8IERFRIDGM+NNlaS8ApHHOCBERUVAwjPjjGaZx2gCHGJbhZnlERETBwTDij1YPKFTiuWezPHcV1koO0xAREQUUw4g/CgWgM4jn7qEaT89IY4sDrXanXC0jIiIadhhGetJleW+sNgLRGtFbUsEN84iIiAKGYaQnXZb3KhQK74Z5nMRKREQUOAwjPfGzvNdTa6ScYYSIiChgGEZ64lne26EKa4res7yXwzRERESBwjDSE39VWN3DNOwZISIiChyGkZ70MkzDOSNERESBwzDSEz9VWLlZHhERUeAxjPTE78697v1pOGeEiIgoYBhGeuJnzggLnxEREQUew0hPvMM0jd5Tep2v8BnLwhMREQUGw0hP/AzTKBQKb+9IBTfMIyIiCgiGkZ54h2kaAUnynvbNG2HPCBERUSAwjPTE0zMiOQFbk/e0b0UNe0aIiIgCgWGkJ+pIQKUVz7m8l4iIKGgYRnrjGarpuLyXm+UREREFFMNIb/xUYU3hZnlERDRc1J8Cdr8MvLsQcMj3ey1Ctk8eCnqpwsrN8oiIaMixtwAl24HjnwEnPhNhxKN0JzDqclmaxTDSm16qsDa4C59FuuuOEBERDTqSBNSdAE58LgJIyXagvUMPiDICyPgeMPpKIGG0bM1kGOmNnyqsel0EojQqtNidqLS0ITsxWp62ERERdSVJQEMxcHq7CB6ntwPm0s7X6EeI8DHmKiD7+4BOL09bO2AY6Y2fKqyewmenaqyoMLcyjBARkXw8PR+nv/aFj6byzteoNEBmnggfo/OBpPGAQiFPe3vAMNIbP8M0AJBmiBRhpJGTWImIKISstUDFAfdRCJTuApqrOl+jVAPpM4CsOcDIOUBGLqCNkaW5fcUw0hs/wzSAb0UN96chIqKgkCTAchao+NYXPiq/Fee6UmmBEbN84WPELEATFfo2nweGkd74WdoLAGmswkpERIHkdIjAUbJD9HaU7QZaav1fmzAaSJkKpE4FRswWvSBqXWjbG2AMI73xs7QXAFI8+9NwmIaIiAbC1gyc2SOCR8kO4MxeoL3L/+AqI8T8jtQcd/jIAVImA9pYedocRAwjvfFTgRVgSXgiIuqnlnpRx8OzyqXyoNj7rKPIeDHRNPN74jFlypDv8egrhpHeeIdpzJ1Opxo5TENERL1oqhKho2SHeKw+0v0aY6Y7fOQBIy8CEsYAyvAsjM4w0hvPMI3NDLicgFIUOEvV+wqftTmc0KlZ+IyIKGxJkqhkWrYHKN0hAkjdie7XJY7zTTLNzAMM6aFv6yDFMNIbzzANALSZgah4AIA+MgKRahVaHU5UmtuQxVojREThw9EmltWW7RYBpGw3YK3pcpFCzO8Y2SF8xCTJ0dohgWGkNyo1oIkB7M1iEqs7jCgUCqQaReGzcnMrwwgR0XDlWWJ7Zi9w5hsRPMoLAZej83UqDZA2HciYDYy8GMjM9Q310zkxjJyLzugOI42dTqe6q7BWchIrEdHw0doAlO8HzhYAZ/eJx65FxQAgOlkEj4xcMeE0NQeI0Ia+vcMEw8i5RMYBljPdlvd6NszjihoioiGqtRGoOixWtpS7g4e/uR4KFWCaBIyYKTaVy5gNxGUNupLqQxnDyLmcc3kvV9QQEQ1qLhfQWCJCR9UhoPIQUHUQaCz1f31ctigk5jlSpwLqyNC2OcwwjJzLuUrCs2eEiGjwsNaKZbTVx9yPR0Xvh73J//WGDMA0GUibBqTPFPM+ohNC2mRiGDm3HqqwprmHacpZhZWIKPTsLaJ8evURoOaYCB3VR3suoa7SAMkTANMUscrFNFk8cpLpoMAwci4Jo8RjxYFOp7lZHhFRCNmtYiXL6a9FFdOzBd1XtAAAFGI+R/IEUUo9eYIIHoljxApJGpQYRs4l6xLxePprMe7oro7nmTNSb7Wz8BkRUaDZmoGyXb7wUb4PcLV3viY2VZRM94SO5AmisNgQ27GWGEbOLXUaoIkVE1irDorlWwAMkWoWPiMiOl8uF2AudQ+zuOd4eOZ7dN27xZABZF0sjpFzuKJlGGEYORdVBDAyDzj+KVC8zRtGFAqFqDVSa0UFwwgRUe8kSdTrqDrsm99RfQSoKQIcVv/vMWaKAmKeABI3MrRtppBhGOmLrEtEGDm9Dbhoqfd0qtETRri8l4jIy94C1LhXsVQdEctpq48ALXX+r1dpxPBKsnu4JWmCmFxqzAxtu0k2AwojL7zwAp5++mlUVlYiJycHzz33HGbPnn3O97377ru45ZZbsGDBAnz44YcD+Wh5ZLvnjZTsAJztorcEQIqehc+IKMy1mUV59PJ9onJp5SGxaRyk7tcqlED8KMA0EUie6Ase8Rd4/12l8NTvP/3169dj2bJlWLduHXJzc7F27VrMnTsXRUVFSE5O7vF9p0+fxkMPPYRLLrnkvBosi5SpgM4g/qOrPCCK4MA3iZW1RogoLDjaOlcrPbsPqDvu/9qoRNG7kTxJVC81TRQTTVk8jPzodxhZs2YN7r77btxxxx0AgHXr1mHjxo147bXXsHz5cr/vcTqdWLhwIR5//HFs27YNjY2N59XokFOqxGSpok1i3ognjBhZhZWIhhlJEoXD6k8B9Sfdj6eA2u/EPI+uK1oAwJAJpE8H0i4U8+pMk4CYnv/nlKirfoURu92OgoICrFixwntOqVQiPz8fO3fu7PF9v/3tb5GcnIyf/vSn2LZt2zk/x2azwWazeb+2WCz9aWZwZF3iDiNfARc/AKBjSXj2jBDRECNJImRUFIq5HZ7QUV8M2Hr5Nzc6SYSO9At9j9GJIWs2DU/9CiO1tbVwOp0wmUydzptMJhw7dszve77++mu8+uqrKCws7PPnrF69Go8//nh/mhZ8nnkjpbsApwNQqTlnhIiGBpcLaCgWczoqCsUcj4pvAZu5hzcoxDLa+GwxnyNhlHhMmQoYRnA5LQVcUGcMNTU14bbbbsMrr7yCxMS+J+cVK1Zg2bJl3q8tFgsyMjKC0cS+S54ERMYDrfVinDQzF2lGFj4jokHG6RDLZT2bwlUcEIe/3g6VVgyppE4FEsb4godxJKDWhb7tFLb6FUYSExOhUqlQVVXV6XxVVRVSUlK6XX/y5EmcPn0a8+fP955zuVzigyMiUFRUhFGjRnV7n1arhVar7U/Tgk+pBLLmAEf/CZz+CsjMhSFSDZ1aiTaHC1WWNoxMYK0RIgqh1kb3LrQHfUfNMcBp735thM63IVzqNPGYNJ4l0mlQ6FcY0Wg0mDFjBjZv3ozrrrsOgAgXmzdvxtKlS7tdP378eBw8eLDTuUceeQRNTU3405/+JH9vR39lf1+EkeJtwKX/CYVCgTRDJE7VWlHeyDBCREHQZhFDLPXFvnkdDafFo+Ws//doDWIlS8oUcaROA5LGMXjQoNXvYZply5Zh8eLFmDlzJmbPno21a9fCarV6V9csWrQI6enpWL16NXQ6HSZPntzp/UajEQC6nR8SPPvUlO0G2m1AhBYp7iqslRauqCGi89BcLXo5PIXC6k6IEGKt6f19hkxf6PAcxkzO66Ahpd9h5Oabb0ZNTQ1WrlyJyspKTJs2DR9//LF3UmtpaSmU7s3khp2kcUB0MmCtBs7sBbLmeHfvLW/kJFYi6gNHG1Bb5A4dh30BpLfQEZXom0wa536MvwBIHA1ExoWu7URBMqAJrEuXLvU7LAMAW7Zs6fW9b7zxxkA+cnBQKMT+CIc/EKXhs+YgzSBW1LDwGRF1YreK2hw1Rb6jtkgMt3TdAA4AoBCTR02TxIT5pLHu4JEtii4SDWOsv9tf2ZeIMFK8DbhsubdnhMt7icKMJImqzOYywHwGaCwTczlq3cHDXNbze3VGMZximuQ7kiYAmqhQtZ5oUGEY6a+sS8XjmT2Ao7VD4TPOGSEadlxOETCqDgF1JzsHD/MZwN7U+/ujk8QGcEljxcqVxLFiuDc2lXM6iDpgGOmvhFHiH5KmCqBsD1IN0wFwmIZoyGup7zyPo/qIKH/uaOn9fVGJohCYMUNMJk0cI4JH0jggKj40bSca4hhG+kuhEKtqDr4HnN6G1Nw8AEAdC58RDQ2SJHo4PMXAKg6InWabyv1fH6Fz7y47XlQlNWaI8GHIAPTpHFohCgCGkYHIdoeR4m0wXv4bFj4jGqw8ZdC9waNQPLY2+L/eOFIUBvPO5ZgsJpAq+T8ZRMHEMDIQnnojZwugcLQg1RCJ4lorKswMI0Qh53SIno6G02KlSkOx+/lp8dze3P09ygjR25GaIwqCpUwBkicCOn1o205EABhGBiYuS3TRmsuA0l1I0Ue7wwgnsRIFjcsJ1B4HKr8VvRtVh0XYaCzrYamsm3f/lRzfYZoERAyyLSeIwhjDyEB45o0ceFvMGzFeB4DLe4kCxtEqqpBWHhC7y1Z+K75u7yHwq7TifxLis0VtDu/zLFEcjGXQiQY1hpGBynaHkeJtSM38CQCuqCHqM1uzb5msucy3VNbzteUsILm6v08d7d5zZaoYWkkYLUJHTIrYzJKIhiSGkYHyzBsp348RE8Q/mqfrzrEEkCjcSJIIGGe+Ac4WiG0Uao4BbY3nfm90ki90pE4FUnJELwdDB9GwwzAyUMYM0QXccBoXq78DoMauk3VobLHDGKWRu3VE8rA1A+X7O4SPb4DmKv/X6gyiLodhRIc6HSPEOWMmEJPMwmBEYYJh5HxkXQI0nEaGeS/Gp1yNY5VN2HSwErfmZsrdMqLgcrQBdcfd+618J3o7PM+7Dq8oI8SE0RGzgPSZopfDkMGVK0TkxTByPrIvBfb/DSjehuum34Gn/n0MHxaeZRih4aPdLvZaqTwE1BwFatzBo7HE/5wOANCPAEbMdB+zxOoVdWRo201EQwrDyPnwzBup/BYLFkTj9x8De4rrcbaxFelG/uNLQ0xLvSiDXnlQhI/KgyJ4uBz+r9cZ3WXPx7r3XxkvekD0qSFtNhENfQwj50OfCiSMAeqOI7VxH2ZnxWN3cT0+KizHfZeNkrt1RP55qpJWHnSHD3fwsJzxf73OAJimuEuij3Mf48UEU87pIKIAYBg5X9mXiLHz09tw/fT7sLu4Hh/uP8swQoODrUnU56hy93ZUHRJfO6z+rzeOFKtXUqa6l9BOEfM7GDqIKIgYRs5X1iXA3teA4m2Y9/3fYuU/DqOoqglHKyyYkMoJehRCbWZRmbS8UOzBUl4I1J/0f61n8zfTZHGkThVDLDpDCBtMRCQwjJwvz7yRqoMwSE24fHwSPjlchQ8LzzKMUPBY60RvR8fg0VDs/9rYVBE4UtzBI2UKED8KUPE/fyIaHPiv0fmKSQKSJoiVBqe/xvXTZ+GTw1X4qLAcD88dD6WS3ds0QM52sWql9rhYMlv7ne95a73/9xgzfZu/pU0Tj9GJIWw0EVH/MYwEQvYlIoyc+ByXzbsWsboIVJjbsLu4HnmjEuRuHQ0FTofYf6Vsjziqj4ohFqe9hzcogLiR3YNHVHzo2kxEFCAMI4Ewdi6w52Vg/9+gm/pjXDM5Fev3luEfhWcZRsi/5hrgzB6gbDdQ9g1Qvg9o97O3UUQkkDgaSBzrPsaIx/hRgCYq9O0mIgoChpFAGHUlkHMLcOAd4P07cdMPPsL6vcDGgxV47EeToFOr5G4hycnWJJbOeuZ3lO3xP78jMg4YMRvImC16OZLGigJi3IuFiIY5hpFAUCiAa58Rv2xqjmLG3oeQrv8lzloc2FJUjR9MZhGosNHaILa8rzgggkfFAaDuJACpy4UKsZplxCwgI1cEkITRXEJLRGGJYSRQNNHAj/8KvHwZFKe34Q9po7HQchU+3F/OMDJctTb6VrKU7xdHY4n/a/UjxLyOlKm+UulcRktEBIBhJLCSxgI/ehb4v59iTvnr+L4yGV8cU8Lc6oAhUi136+h8tFncNTzcoaOiEKg/5f/auCz3xFL35NLUHK5oISLqBcNIoE35D6BkB7D3VTyrfRE/aH0S/z5YgZ/M5uZ5Q0ZzDVB5QAy3VH4rHnsqHmYcCaRNdx/TRPCIjAtpc4mIhjqGkWCY+yRwdi8MFQfwvOZZrNmfzTAyWJnPipUsnnkeld8CTRX+rzVkisCRNk2EDy6lJSIKCIaRYFDrgJvehGvdpZhhP47Ly15EeeNMpHEnX3m5nEDVYbGctnSXeDSX+blQASSMEvM7UnNEqfSUHCCay7SJiIKBYSRY4rOhvGEd8O6tuCtiEz7+/H+R9h93y92q8GJrAs7s9YWPM3sBe1PnaxQqIHkikJYjAkfqVFEyXRsjT5uJiMIQw0gwjb8WR7MXY0Lxm7j40CrgiiuB+AvkbtXw1G4XO9KeLRATTM/uA2qOoduSWk0skDELyPgekJkLpM9k8CAikhnDSJCl3rAae5/ehZnKIrS9fRt0P9sshnFo4FwuoO64CBxnC8Scj8qD/kunGzKAzO+JWh6Z3xO9IEoWoSMiGkwYRoLMGBuN97IeR3bJ3UioPQRsuAe45o9ATLLcTRsaJAmwnBWhwxM+Kg4ANkv3ayPjgLQLgfQLgfQZ4nmsKfRtJiKifmEYCYHLZk3DAyeW4E3N76E88g/g+OfA9+4D5vySha+6staKGh5n9/nCh7W6+3URke5VLZ7wcSEQl80KpkREQ5BCkqSudaoHHYvFAoPBALPZDL1eL3dz+q3N4cSs//4cE+0H8WraPxBT9614QWcELlkGzL4HUIfZShtJAhpO++p4VB7seVmtQgWYJnXu8UgaD6iYpYmIBrO+/v7mv+YhoFOrMG9KCt7b244n0q7G6vwSYPPvgNoi4LOVwK4/A99/GJj+/wDVMKzU6mgTk0mrDgGVh0ToqDzof6jFs6w2bboIHukzgJQp4RfWiIjCCHtGQmTHiVrc+pfd0KmV+NcvLsboxCjgwLvAltW+WhfxFwCX/waYdMPQ3am1udrdy3HQFz5qvwMkZ/drVRoxoTRliqjnkTIVME0EtLGhbzcREQVcX39/M4yEiCRJuO3VPfj6RC3Gp8TiwyVzoFOrgHYbsPd14KungZZacXH8KCD7EiAzT6wAMY4cHHMh7FagqVIMpTRVApbyzl/XnfA/vwMQk0tNk0XwSJkqHpPGDc+eICIiAsAwMihVN7Xhmj9tQ22zHYvyRuK3Cyb7XrQ1ieGaHc91H76ITXUvTXWHE9PkwM+XcLmA5irRS9NYKg5zGdBYJh4t5T0Mq3TlHmYxTQZSJrt7OyYD+rTBEaiIiChkGEYGqa3f1WDxa3sAAC/dNgNzJ6V0vqC1ESjZDpTuFFVDywsBl6PzNZoY8Us+OkGsxtEZgUijeNQZxblII6CJBmzNQJvZfTSKo7XR93Vro1g6az7jv05HV+poQJ8qAlJsivtwPzeOBJIniM8lIqKwxzAyiD256She/uoUDJFqbLr/EqT3tmeNvUUU9SrdCZTuFqXN+9RDMQAKJaBPF4XCjBmAMdP3XD9ChBDO5yAioj5iGBnE7O0u3LRuBw6cMWNWVhzeuft7iFD1ccKqywlUHxWHp6ejzezu7ejy3G4VvSienhJPL4r3a/ehTxWhQ5/GORxERBQwDCODXEmdFdc++zWabe345ZVjsOyqsXI3iYiIKKD6+vt7iK4fHfpGJkTjievFBNbnvziOnSfrZG4RERGRPBhGZLRgWjpumjECLgl4YP1+1Fv7MIGUiIhomGEYkdnjCybhgqRoVFls+PX7BzAERs2IiIgCimFEZlGaCDx3y3RoVEp8frQab+w4LXeTiIiIQophZBCYlGbAb66dAABYvekYDp01y9wiIiKi0GEYGSQW5Y3EVRNNsDtdWPr2PlSa2+RuEhERUUgwjAwSCoUCf7hxKtIMOpyua8H1L27H0YogFTcjIiIaRBhGBpG4aA3W/ywPo5NjUGFuw03rdmLb8Rq5m0VERBRUDCODTEZ8FP7v3ouQmx2PZls77nj9G7y3t0zuZhEREQUNw8ggZIhS468/nY0F09LQ7pLw6/e/xZrPvuOyXyIiGpYYRgYpbYQKa2+ehqWXjwYAPLv5OH719wOwt7tkbhkREVFgMYwMYgqFAg/NHYenbpgClVKBD/adxe2v74GlzSF304iIiAKGYWQI+MnsTLy6eCaiNSrsOFmH//jzDpxtbJW7WURERAHBMDJEXDYuGe/dmweTXovvqppx/Qvb8eWxarmbRUREdN4YRoaQSWkGbPj5HIwzxaK6yYY73vgGP3+rAFUWFkgjIqKhi2FkiEkzRmLDkotwz6UXQKVUYNPBSlz5zFa8ueM0nC6utiEioqGHYWQIitJE4L+umYB/Lr0Y0zKMaLa1Y9VHh3H9i9u5rw0REQ05DCND2MQ0Pf7vvovwuwWTEKuNwLdnzPjR81/jd/86AqutXe7mERER9QnDyBCnUipwW14WNv/q+7h2aipcEvDq18XIX7MVnxyulLt5RERE56SQhkBZT4vFAoPBALPZDL1eL3dzBrUtRdV49B+HUFYvlv7OyorDzy8fjcvGJkGhUMjcOiIiCid9/f3NMDIMtdqdePaL43h1WzHsTlGxdVKaHksuH40fTEqBUslQQkREwccwQqiytOGVr07hrd2laHU4AQCjkqLx88tG40fT0qBWcZSOiIiCp6+/vwf02+iFF15AVlYWdDodcnNzsWfPnh6vfeWVV3DJJZcgLi4OcXFxyM/P7/V6ChyTXodHfjgR25dfgV9eMRp6XQRO1ljxq78fwOV/3IK/7SpBmzukEBERyaXfYWT9+vVYtmwZVq1ahX379iEnJwdz585FdbX/aqBbtmzBLbfcgi+//BI7d+5ERkYGrr76apw9e/a8G099Ex+twbKrx2H78ivw8A/GIzFGgzMNrXj0w0O45A9f4k+fH8eZhha5m0lERGGq38M0ubm5mDVrFp5//nkAgMvlQkZGBn7xi19g+fLl53y/0+lEXFwcnn/+eSxatKhPn8lhmsBqtTux/ptSvPzVKZSbRfVWhQKYMyoRN80cgbmTUqBTq2RuJRERDXV9/f0d0Z9varfbUVBQgBUrVnjPKZVK5OfnY+fOnX36Hi0tLXA4HIiPj+/xGpvNBpvN5v3aYrH0p5l0DpEaFW6fk41bc0di08EKvLe3DDtO1uHrE7X4+kQtYnUR+FFOGn48MwNTRxi4CoeIiIKqX2GktrYWTqcTJpOp03mTyYRjx4716Xs8/PDDSEtLQ35+fo/XrF69Go8//nh/mkYDoIlQ4rrp6bhuejrK6lvwfsEZvF9wBmcbW/HW7lK8tbsUY00xuGlGBhZMT0NyrE7uJhMR0TAU0uUUTz31FN59911s2LABOl3Pv9hWrFgBs9nsPcrKykLYyvCUER+FB68ai22/vhxv3ZWLBdPSoI1Q4ruqZjyx6Shyn9yMG/+8Ay9tPYniWqvczSUiomGkXz0jiYmJUKlUqKqq6nS+qqoKKSkpvb73j3/8I5566il8/vnnmDp1aq/XarVaaLXa/jSNAkSpVGDO6ETMGZ0Ic6sD//q2HO8XnMH+0kYUlDSgoKQBq/99DGOSY3D1JBOunpjCoRwiIjovA5rAOnv2bDz33HMAxATWzMxMLF26tMcJrH/4wx/wxBNP4JNPPsH3vve9fjeSE1jlV2FuxedHqvDpkSrsPFmH9g47BKfodbhqogn5E02YnRWPSA0nvxIRURCLnq1fvx6LFy/GSy+9hNmzZ2Pt2rV47733cOzYMZhMJixatAjp6elYvXo1AOD3v/89Vq5cibfffhtz5szxfp+YmBjExMQE9Ieh0DC3OrClqBqfHq7ClqJqWO2+WiUalRIXjjRizqhEzBmTiKnpBkSwuBoRUVgKagXW559/Hk8//TQqKysxbdo0PPvss8jNzQUAXHbZZcjKysIbb7wBAMjKykJJSUm377Fq1So89thjAf1hKPTaHE7sPFmHTw5X4qvvarxLhT1itRHIvSABc0Yn4OLRiRidHMMhHSKiMMFy8BRykiThdF0Lvj5Rix0narHjZB3MrY5O1yTGaDFzZBwuHGnEjJFxmJRmYE0TIqJhimGEZOd0SThSbhHh5GQt9hTXw9bu6nSNRqXEpHQ9LsyMw4yRcbgwMw4pBi4hJiIaDhhGaNBpczjx7Rkz9pU2YF9JA/aVNqC22d7tujSDDpPTDZiUZsCkND0mpeuRotdxeIeIaIhhGKFBT5IklNW3oqC0HvtKxNLhY5UWuPz8jYyP1mBSmh4T0/TekJKVEA2VkgGFiGiwYhihIclqa8e3Z8w4XG7GkXILDpdbcKKmGU4/CUUbocSopBiMNcVgjCkW40yxGGuKxYi4SCgZUoiIZMcwQsNGm8OJosomHC634EiFGYfLLThaYUGbw+X3+ki1CqOTYzDGFIPRyTHITohGVmI0shKiWQOFiCiEGEZoWHO6JJTVt+C7qiYcr27Gd1VN+K6qGSdrmmFv9x9SACDVoENWQjSyk6K9ISU7MQoj4qK4qoeIKMAYRigstTtdKKlvwXF3OCmuteJUrRWna63dlhl3ZdJrkRkfhYz4KGR2OZJitZxAS0TUTwwjRF00WO3eYHK6zhdSSupa0Gxr7/W92ggl0o2RSI+LRJrB/WiMFOeMkUgx6KCJYKVZIqKO+vr7u18b5RENZXHRGsyI1mDGyLhO5yVJQmOLA6X1Ld6jrMPz8sZW2NpdOOXuZfFHoQCSY7VINUQizahDqiESqQbxmGLQIc2oQ3Ksjqt/iIj8YBihsKdQKBAXrUFctAY5GcZurzucLlQ0tuFsY6s4GlpR7nnuPuztLlRZbKiy2FBY5v9zVEoFkmO1SNbrkBSjRVJsh8P9dbL7a85fIaJwwjBCdA5qlRKZCVHITIjy+7okSahttqO8sRUV5lZUmNt8R6P4usrShnaX5D1/LrHaCCTptT2GFs+REK1lbwsRDXkMI0TnSaFQeMOBv54VQKz+qWu2odzchpomG2qabKhu8j2vafacs8He7kKTrR1NNe04VeN/WMhDqRAF4RJjfGEl0fsozsdHa5AQrUVctBraCPa4ENHgwzBCFAIqpQLJeh2S9b3vuyNJEixt7ah1hxNPQOkaWmqabKiz2uCSgNpmO2qb7ThW2XTOdsRoIxDvHpJKiNYgLkqDhBiNO7B4nmu9z6M0/CeCiIKP/9IQDSIKhQKGSDUMkWqMSorp9dp2pwv1LXbUNtlR02xDbYewUtvhsd7qQEOLHU6XhGZbO5pt7Sitb+lTe3RqJRKitUiIEcElPtrzqIax09caxEWrYYzUcFUREfUbwwjREBWhUiI5VqzSOReXS0JTWzvqrDY0tNhR12wXj1Y76pvtqLeK53VWG+qb7ai12mFvd6HN4fJO0u2raI0KxigRTuKiNDBGaWCMVCMuqkOAidYg3n1NfLQGkWoV67gQhTGGEaIwoFQqYIhSwxCl7tP1kiTBane6g4kIKPUtdjRY7WhocaDB2vFr97kWOyQJsNqdsNr7F2C0EcouvSwab3iJi/KEGvEYF6WBMVqNWG0EAwzRMMEwQkTdKBQKxGgjEKON6HEVUVdOl4SmNoc3mDS22NFgdaCx1SGet/iCjDfQWO2wO12wtbv6vNLII0KpgLFDYOkcXLqcixa9M8YoDiMRDUYMI0QUECqlQgzJRGmQjeg+vUeSJLTYnai3+oaNPCGl0RtqHN4g4wk1bQ4X2l2Sd/Juf0RpVN6eFmOXEOPpmTFGqb09NXHRGkRrOIxEFEwMI0QkG4VCgWhtBKK1EciI71sPDCB2cm7w9Lx0GCbq/Nz32Nhih7nVAZcEtNidaOnnMJJapeg8gTfGM+dFg3h3z0vH8BIfpeEO0UT9wDBCREOOTq1yl9yP7PN7PJN4G9y9K97hI/dQkmceTGOLHfXukFNvtcPW7oLDKaHavcy6r7QRSm848fa8RPt6YDquUPIcrLxL4YphhIjCQsdJvFl9HEYCgFa70ztZ1zOcVO8ZTnKHmY7DTI0tdjicEmztLlRa2lBp6fs8GM8QUsegYoxS+3phvL0v4hznwNBwwTBCRNSLSI0K6RqxO3NfeFYidVpp1OV5fYtYUu0JNvVWO9pd0oCGkDxLqY0dVh0ZO0zkjY9WIyFai0R3Vd74KA0iVAwwNLgwjBARBVDHlUh9nQcjSRKabO3eJdSeoNLgHjLyhRlP74wYRnINYCm1QgHERWmQGCO2C/AcCTG+cwkxogpvYoyWc18oJBhGiIhkplAooNepodf1fQjJ5ZJgaXN0W3XU2OKb1NvY6kC91YbaJlHQrs4qasF4emO+q2o+5+dEa1QinMSILQPE/BYtEmN8c10SorWId7/OeS80EAwjRERDkLLDUuq+BhinS0K91Y7aZhvqmsVjbbPYRqCu2Y66ZhFYaptsqG0WNWCsdies9S193kIgSqPqNCk33jNJN8b3PCFG6+2FieKyaQLDCBFR2FApfTtMn4skib2Mat0hpdYdVOqb3dsIWH3bCNRbbai3iom7nnkvZxr6NmykUyu9Q0NJMaKXJTFW490TKcn9WmKMCF4qJYPLcMQwQkRE3SgUCsTq1IjVqZGdeO6eF8+O0x0n6NZ7nvsJL7VNdrQ6nGhzuHCmoW/hRamAd4jIN8/FN+clqcO5hBgNtBEcMhoqGEaIiOi8ddxxuq/DRi32du+u06L3xdcLU+seRqpzDys1toiidZ6hJaDpnN8/VhfRKaB0DjCdz8VwryNZMYwQEZEsojQRyEzo2/5HDqcLDVa7d36LJ5TUubcE6Ph1ndUGh1MUuWtqa8epWus5v782QokE93yWBPfk3ET3qqKOq4s8Q0is7xJYDCNERDToqVVKJOt1SNbrznmtJEmwtLajplNg6dzj0jG8tNidsLW7UG5uQ3kfN2s0Rqm9PSxJsTpvT0tSbOcAkxCjQZSGv2rPhXeIiIiGFYXCV213dHLMOa+32tq981k8K4o8q4vqrXbUWjtM4m0WBerEEmoHTlSfuz2RapW7p0WEFLEc2l1Rt8PzhGgt4qLVYTlkxDBCRERhrT+bNbpcEsytDtHr0iSWRdc0+Xpcapps3sm6Nc022NtdaHU4cbax74XpNCqlewm0exl0tG9JtKc4nWe1UUL08ChMxzBCRETUR0qlQmx+GK3BWFNsr9d6tgbo2tvScWl016PV4YTd2b99jTr2vPgtSucOLfGDeNho8LWIiIhoGOi4NcDIhL6tMGq1O1HnrtviCTD1Vt9E3Tqrr0BdrdU+oJ4XT3jxVdUVvSwLczP73M5AYxghIiIaJCI1KozQRGFE3LmHjLr2vHhqu9RabR2eu4vSNdvPGV5+MDmFYYSIiIj6rr89L57wUt+hh6VjIboRcX3bmToYGEaIiIjCQMfw0pfaLqHEqi1EREQkK4YRIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLIaErv2SpIEALBYLDK3hIiIiPrK83vb83u8J0MijDQ1NQEAMjIyZG4JERER9VdTUxMMBkOPryukc8WVQcDlcqG8vByxsbFQKBQB+74WiwUZGRkoKyuDXq8P2Pcl/3i/Q4v3O7R4v0OL9zu0Bnq/JUlCU1MT0tLSoFT2PDNkSPSMKJVKjBgxImjfX6/X8y9zCPF+hxbvd2jxfocW73doDeR+99Yj4sEJrERERCQrhhEiIiKSVViHEa1Wi1WrVkGr1crdlLDA+x1avN+hxfsdWrzfoRXs+z0kJrASERHR8BXWPSNEREQkP4YRIiIikhXDCBEREcmKYYSIiIhkFdZh5IUXXkBWVhZ0Oh1yc3OxZ88euZs0LHz11VeYP38+0tLSoFAo8OGHH3Z6XZIkrFy5EqmpqYiMjER+fj6OHz8uT2OHgdWrV2PWrFmIjY1FcnIyrrvuOhQVFXW6pq2tDUuWLEFCQgJiYmJw4403oqqqSqYWD21//vOfMXXqVG/xp7y8PPz73//2vs57HTxPPfUUFAoFHnjgAe853u/Aeuyxx6BQKDod48eP974erPsdtmFk/fr1WLZsGVatWoV9+/YhJycHc+fORXV1tdxNG/KsVitycnLwwgsv+H39D3/4A5599lmsW7cOu3fvRnR0NObOnYu2trYQt3R42Lp1K5YsWYJdu3bhs88+g8PhwNVXXw2r1eq95sEHH8Q///lP/P3vf8fWrVtRXl6OG264QcZWD10jRozAU089hYKCAuzduxdXXHEFFixYgMOHDwPgvQ6Wb775Bi+99BKmTp3a6Tzvd+BNmjQJFRUV3uPrr7/2vha0+y2FqdmzZ0tLlizxfu10OqW0tDRp9erVMrZq+AEgbdiwwfu1y+WSUlJSpKefftp7rrGxUdJqtdI777wjQwuHn+rqagmAtHXrVkmSxP1Vq9XS3//+d+81R48elQBIO3fulKuZw0pcXJz0l7/8hfc6SJqamqQxY8ZIn332mfT9739fuv/++yVJ4t/tYFi1apWUk5Pj97Vg3u+w7Bmx2+0oKChAfn6+95xSqUR+fj527twpY8uGv+LiYlRWVna69waDAbm5ubz3AWI2mwEA8fHxAICCggI4HI5O93z8+PHIzMzkPT9PTqcT7777LqxWK/Ly8nivg2TJkiW49tprO91XgH+3g+X48eNIS0vDBRdcgIULF6K0tBRAcO/3kNgoL9Bqa2vhdDphMpk6nTeZTDh27JhMrQoPlZWVAOD33nteo4FzuVx44IEHMGfOHEyePBmAuOcajQZGo7HTtbznA3fw4EHk5eWhra0NMTEx2LBhAyZOnIjCwkLe6wB79913sW/fPnzzzTfdXuPf7cDLzc3FG2+8gXHjxqGiogKPP/44LrnkEhw6dCio9zsswwjRcLVkyRIcOnSo0xgvBd64ceNQWFgIs9mM999/H4sXL8bWrVvlbtawU1ZWhvvvvx+fffYZdDqd3M0JC/PmzfM+nzp1KnJzczFy5Ei89957iIyMDNrnhuUwTWJiIlQqVbcZwFVVVUhJSZGpVeHBc3957wNv6dKl+Ne//oUvv/wSI0aM8J5PSUmB3W5HY2Njp+t5zwdOo9Fg9OjRmDFjBlavXo2cnBz86U9/4r0OsIKCAlRXV+PCCy9EREQEIiIisHXrVjz77LOIiIiAyWTi/Q4yo9GIsWPH4sSJE0H9+x2WYUSj0WDGjBnYvHmz95zL5cLmzZuRl5cnY8uGv+zsbKSkpHS69xaLBbt37+a9HyBJkrB06VJs2LABX3zxBbKzszu9PmPGDKjV6k73vKioCKWlpbznAeJyuWCz2XivA+zKK6/EwYMHUVhY6D1mzpyJhQsXep/zfgdXc3MzTp48idTU1OD+/T6v6a9D2LvvvitptVrpjTfekI4cOSLdc889ktFolCorK+Vu2pDX1NQk7d+/X9q/f78EQFqzZo20f/9+qaSkRJIkSXrqqacko9Eo/eMf/5C+/fZbacGCBVJ2drbU2toqc8uHpvvuu08yGAzSli1bpIqKCu/R0tLivebee++VMjMzpS+++ELau3evlJeXJ+Xl5cnY6qFr+fLl0tatW6Xi4mLp22+/lZYvXy4pFArp008/lSSJ9zrYOq6mkSTe70D71a9+JW3ZskUqLi6Wtm/fLuXn50uJiYlSdXW1JEnBu99hG0YkSZKee+45KTMzU9JoNNLs2bOlXbt2yd2kYeHLL7+UAHQ7Fi9eLEmSWN776KOPSiaTSdJqtdKVV14pFRUVydvoIczfvQYgvf76695rWltbpZ///OdSXFycFBUVJV1//fVSRUWFfI0ewu68805p5MiRkkajkZKSkqQrr7zSG0Qkifc62LqGEd7vwLr55pul1NRUSaPRSOnp6dLNN98snThxwvt6sO63QpIk6fz6VoiIiIgGLiznjBAREdHgwTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrP4/DtZDT0NaIawAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABI40lEQVR4nO3dd3xb5b0/8I8ka3hJ8pRH7NhkTydkuCZAGYY00DSMSynkRwIUKDRpgZRbkltIoL0QWkpuymqAstrLCOUSSpuUFUgImcSJQ6bJcGwn3kuyZVuSpfP749HwkB3bkXRs6/N+vc5L8tGR9fgkxB+e8X0UkiRJICIiIpKJUu4GEBERUXhjGCEiIiJZMYwQERGRrBhGiIiISFYMI0RERCQrhhEiIiKSFcMIERERyYphhIiIiGQVIXcD+sLlcqG8vByxsbFQKBRyN4eIiIj6QJIkNDU1IS0tDUplz/0fQyKMlJeXIyMjQ+5mEBER0QCUlZVhxIgRPb4+JMJIbGwsAPHD6PV6mVtDREREfWGxWJCRkeH9Pd6TIRFGPEMzer2eYYSIiGiIOdcUC05gJSIiIlkxjBAREZGsGEaIiIhIVkNizggREYU3SZLQ3t4Op9Mpd1OoA5VKhYiIiPMuu9HvMPLVV1/h6aefRkFBASoqKrBhwwZcd911vb5ny5YtWLZsGQ4fPoyMjAw88sgjuP322wfYZCIiCid2ux0VFRVoaWmRuynkR1RUFFJTU6HRaAb8PfodRqxWK3JycnDnnXfihhtuOOf1xcXFuPbaa3HvvffirbfewubNm3HXXXchNTUVc+fOHVCjiYgoPLhcLhQXF0OlUiEtLQ0ajYbFLwcJSZJgt9tRU1OD4uJijBkzptfCZr3pdxiZN28e5s2b1+fr161bh+zsbDzzzDMAgAkTJuDrr7/G//zP/zCMEBFRr+x2O1wuFzIyMhAVFSV3c6iLyMhIqNVqlJSUwG63Q6fTDej7BH0C686dO5Gfn9/p3Ny5c7Fz584e32Oz2WCxWDodREQUvgb6f9wUfIH4swn6n25lZSVMJlOncyaTCRaLBa2trX7fs3r1ahgMBu/BUvBERETD16CMmitWrIDZbPYeZWVlcjeJiIiIgiToS3tTUlJQVVXV6VxVVRX0ej0iIyP9vker1UKr1Qa7aUREREFz2WWXYdq0aVi7dq3cTRn0gt4zkpeXh82bN3c699lnnyEvLy/YH01ERERDQL/DSHNzMwoLC1FYWAhALN0tLCxEaWkpADHEsmjRIu/19957L06dOoVf//rXOHbsGF588UW89957ePDBBwPzE5yH174uxqMfHsLxqia5m0JERBS2+h1G9u7di+nTp2P69OkAgGXLlmH69OlYuXIlAKCiosIbTAAgOzsbGzduxGeffYacnBw888wz+Mtf/jIolvX+89ty/G1XCU7VWuVuChER9ZEkSWixt8tySJI0oDY3NDRg0aJFiIuLQ1RUFObNm4fjx497Xy8pKcH8+fMRFxeH6OhoTJo0CZs2bfK+d+HChUhKSkJkZCTGjBmD119/PSD3crDo95yRyy67rNc/jDfeeMPve/bv39/fjwq6WJ0aANDU1i5zS4iIqK9aHU5MXPmJLJ995LdzEaXp/3TL22+/HcePH8dHH30EvV6Phx9+GNdccw2OHDkCtVqNJUuWwG6346uvvkJ0dDSOHDmCmJgYAMCjjz6KI0eO4N///jcSExNx4sSJHlejDlVhvTdNrE78+JZWh8wtISKi4coTQrZv346LLroIAPDWW28hIyMDH374IW666SaUlpbixhtvxJQpUwAAF1xwgff9paWlmD59OmbOnAkAyMrKCvnPEGxhHUb07BkhIhpyItUqHPmtPEP9kWpVv99z9OhRREREIDc313suISEB48aNw9GjRwEAv/zlL3Hffffh008/RX5+Pm688UZMnToVAHDffffhxhtvxL59+3D11Vfjuuuu84aa4WJQ1hkJFb2nZ6SNPSNEREOFQqFAlCZCliNY++LcddddOHXqFG677TYcPHgQM2fOxHPPPQdAbMNSUlKCBx98EOXl5bjyyivx0EMPBaUdcgnrMOIZpmliGCEioiCZMGEC2tvbsXv3bu+5uro6FBUVYeLEid5zGRkZuPfee/HBBx/gV7/6FV555RXva0lJSVi8eDH+93//F2vXrsXLL78c0p8h2MJ7mCaSwzRERBRcY8aMwYIFC3D33XfjpZdeQmxsLJYvX4709HQsWLAAAPDAAw9g3rx5GDt2LBoaGvDll19iwoQJAICVK1dixowZmDRpEmw2G/71r395Xxsu2DMCDtMQEVFwvf7665gxYwZ++MMfIi8vD5IkYdOmTVCrxf8UO51OLFmyBBMmTMAPfvADjB07Fi+++CIAQKPRYMWKFZg6dSouvfRSqFQqvPvuu3L+OAGnkAa6aDqELBYLDAYDzGYz9Hp9wL7v5qNV+OmbezF1hAEfLb04YN+XiIgCo62tDcXFxcjOzh7w9vQUXL39GfX193eY94xwmIaIiEhuYR5GWGeEiIhIbmEdRjiBlYiISH5hHUY8PSN2pwttDqfMrSEiIgpPYR1GYjQR8NSv4YoaIiIieYR1GFEqFYjRegqfcaiGiIhIDmEdRgDf/jScxEpERCSPsA8jvpLw7BkhIiKSQ9iHEe7cS0REJK+wDyMsCU9ERINRVlYW1q5d26drFQoFPvzww6C2J5jCPoz4ao0wjBAREckh7MMI54wQERHJi2GEJeGJiIYWSQLsVnmOPu4t+/LLLyMtLQ0ul6vT+QULFuDOO+/EyZMnsWDBAphMJsTExGDWrFn4/PPPA3aLDh48iCuuuAKRkZFISEjAPffcg+bmZu/rW7ZswezZsxEdHQ2j0Yg5c+agpKQEAHDgwAFcfvnliI2NhV6vx4wZM7B3796Atc2fiKB+9yGAE1iJiIYYRwvwZJo8n/1f5YAm+pyX3XTTTfjFL36BL7/8EldeeSUAoL6+Hh9//DE2bdqE5uZmXHPNNXjiiSeg1Wrx17/+FfPnz0dRUREyMzPPq4lWqxVz585FXl4evvnmG1RXV+Ouu+7C0qVL8cYbb6C9vR3XXXcd7r77brzzzjuw2+3Ys2cPFO4qoAsXLsT06dPx5z//GSqVCoWFhVCr1efVpnMJ+zDi2bmXE1iJiChQ4uLiMG/ePLz99tveMPL+++8jMTERl19+OZRKJXJycrzX/+53v8OGDRvw0UcfYenSpef12W+//Tba2trw17/+FdHRIjg9//zzmD9/Pn7/+99DrVbDbDbjhz/8IUaNGgUAmDBhgvf9paWl+M///E+MHz8eADBmzJjzak9fhH0Y0Ud6VtOwZ4SIaEhQR4keCrk+u48WLlyIu+++Gy+++CK0Wi3eeust/OQnP4FSqURzczMee+wxbNy4ERUVFWhvb0draytKS0vPu4lHjx5FTk6ON4gAwJw5c+ByuVBUVIRLL70Ut99+O+bOnYurrroK+fn5+PGPf4zU1FQAwLJly3DXXXfhb3/7G/Lz83HTTTd5Q0uwcM4Ih2mIiIYWhUIMlchxeDY064P58+dDkiRs3LgRZWVl2LZtGxYuXAgAeOihh7BhwwY8+eST2LZtGwoLCzFlyhTY7fZg3bVOXn/9dezcuRMXXXQR1q9fj7Fjx2LXrl0AgMceewyHDx/Gtddeiy+++AITJ07Ehg0bgtoehhFOYCUioiDQ6XS44YYb8NZbb+Gdd97BuHHjcOGFFwIAtm/fjttvvx3XX389pkyZgpSUFJw+fTognzthwgQcOHAAVqvVe2779u1QKpUYN26c99z06dOxYsUK7NixA5MnT8bbb7/tfW3s2LF48MEH8emnn+KGG27A66+/HpC29STsw4hvAivDCBERBdbChQuxceNGvPbaa95eEUDMw/jggw9QWFiIAwcO4NZbb+228uZ8PlOn02Hx4sU4dOgQvvzyS/ziF7/AbbfdBpPJhOLiYqxYsQI7d+5ESUkJPv30Uxw/fhwTJkxAa2srli5dii1btqCkpATbt2/HN99802lOSTBwzoi7Z6TZ1g6XS4JS2fcuOCIiot5cccUViI+PR1FREW699Vbv+TVr1uDOO+/ERRddhMTERDz88MOwWCwB+cyoqCh88sknuP/++zFr1ixERUXhxhtvxJo1a7yvHzt2DG+++Sbq6uqQmpqKJUuW4Gc/+xna29tRV1eHRYsWoaqqComJibjhhhvw+OOPB6RtPVFIUh8XTcvIYrHAYDDAbDZDr9cH9Hu32p2YsPJjAMDBx672ziEhIiL5tbW1obi4GNnZ2dDpdHI3h/zo7c+or7+/w36YRqdWQq0SvSGcxEpERBR6YR9GFAoFV9QQEdGg9dZbbyEmJsbvMWnSJLmbFxBhP2cEEPNG6q12Fj4jIqJB50c/+hFyc3P9vhbsyqihwjCCjrVGGEaIiGhwiY2NRWxsrNzNCKqwH6YBOtYa4TANEdFgNATWWoStQPzZMIyAtUaIiAYrzzBES0uLzC2hnnj+bM5nyIjDNOjQM8IJrEREg4pKpYLRaER1dTUAUSND0Y+S7BQ8kiShpaUF1dXVMBqNUKlUA/5eDCPgzr1ERINZSkoKAHgDCQ0uRqPR+2c0UAwj8O3cy6W9RESDj0KhQGpqKpKTk+Fw8H8aBxO1Wn1ePSIeDCPgzr1EREOBSqUKyC8+Gnw4gRW+/Wm4cy8REVHoMYyAdUaIiIjkxDACX88Ih2mIiIhCj2EEgD6Sq2mIiIjkwjACX50R9owQERGFHsMIfHNGWuxOOJwumVtDREQUXhhG4OsZAYBm9o4QERGFFMMIALVKiUi1WLvOoRoiIqLQYhhx81Rh5SRWIiKi0GIYceP+NERERPJgGHHjihoiIiJ5MIy46T09IywJT0REFFIMI27sGSEiIpIHw4gb54wQERHJg2HEzbOahj0jREREocUw4qbnzr1ERESyYBhx8+zca2llzwgREVEoMYy4eeaMNNnYM0JERBRKDCNuXE1DREQkD4YRN30k64wQERHJgWHEjT0jRERE8mAYcfPOGWlrhyRJMreGiIgofDCMuHlW09idLtjaXTK3hoiIKHwwjLhFayKgUIjnrMJKREQUOgwjbkqlAjFa1hohIiIKNYaRDliFlYiIKPQGFEZeeOEFZGVlQafTITc3F3v27On1+rVr12LcuHGIjIxERkYGHnzwQbS1tQ2owcHEFTVERESh1+8wsn79eixbtgyrVq3Cvn37kJOTg7lz56K6utrv9W+//TaWL1+OVatW4ejRo3j11Vexfv16/Nd//dd5Nz7QvLVG2DNCREQUMv0OI2vWrMHdd9+NO+64AxMnTsS6desQFRWF1157ze/1O3bswJw5c3DrrbciKysLV199NW655ZZz9qbIQc+eESIiopDrVxix2+0oKChAfn6+7xsolcjPz8fOnTv9vueiiy5CQUGBN3ycOnUKmzZtwjXXXNPj59hsNlgslk5HKMRyzggREVHIRfTn4traWjidTphMpk7nTSYTjh075vc9t956K2pra3HxxRdDkiS0t7fj3nvv7XWYZvXq1Xj88cf707SA4M69REREoRf01TRbtmzBk08+iRdffBH79u3DBx98gI0bN+J3v/tdj+9ZsWIFzGaz9ygrKwt2MwGwZ4SIiEgO/eoZSUxMhEqlQlVVVafzVVVVSElJ8fueRx99FLfddhvuuusuAMCUKVNgtVpxzz334De/+Q2Uyu55SKvVQqvV9qdpAcHVNERERKHXr54RjUaDGTNmYPPmzd5zLpcLmzdvRl5ent/3tLS0dAscKpUKAAbdHjBcTUNERBR6/eoZAYBly5Zh8eLFmDlzJmbPno21a9fCarXijjvuAAAsWrQI6enpWL16NQBg/vz5WLNmDaZPn47c3FycOHECjz76KObPn+8NJbI59AHQWAJMuh6Iy/L2jFjYM0JERBQy/Q4jN998M2pqarBy5UpUVlZi2rRp+Pjjj72TWktLSzv1hDzyyCNQKBR45JFHcPbsWSQlJWH+/Pl44oknAvdTDNSO54DyfUDSeCAuy1uB1dLKnhEiIqJQUUiDbazED4vFAoPBALPZDL1eH7hv/LcbgJObgev+DEy7FftLG3D9izuQbozE9uVXBO5ziIiIwlBff3+H9940kUbx2NoIgKtpiIiI5BDmYSROPLY2AAD0ke7VNLZ2uFyDvsOIiIhoWAjvMKIzise2RgC+XXslCbDaOYmViIgoFMI7jHQZptFGKKFWKQCw1ggREVGohHkY6TxMo1AofCtqOG+EiIgoJMI7jHQZpgFYhZWIiCjUwjuMdOkZAXxVWLmihoiIKDTCPIwYxaN7zgjg6xnhzr1EREShEd5hxDNM09ogltAAiNWyZ4SIiCiUwjuMeIZpJCdgbwbgqzXC/WmIiIhCI7zDiDoSUGnE8y5VWLmahoiIKDTCO4woFN0msXI1DRERUWiFdxgBeqzCyp17iYiIQoNhxLuihj0jREREcmAY8Q7TNAJgnREiIqJQYxjpMkzjrTPCnhEiIqKQYBjpMoHVM2eEPSNEREShwTDSpQqrbwIre0aIiIhCgWGkYxVW+IZpWh1OOJwumRpFREQUPhhGPMM07jkjMe4wAgDNnDdCREQUdAwjXYZp1ColojQqAKzCSkREFAoMI10msAKsNUJERBRKDCNdlvYCHSaxsmeEiIgo6BhGPMM0bWbA5QTQodYIV9QQEREFHcOIp2cEEIEEvp17WWuEiIgo+BhGIjSAOlo892yW5y0Jz54RIiKiYGMYAbpNYvWVhGfPCBERUbAxjADdlvdyNQ0REVHoMIwAPe5PY2llzwgREVGwMYwAgM4gHj1zRtgzQkREFDIMI0CHYRp3z4hnAquNPSNERETBxjACdBimaQTAOiNEREShxDACdKvCyjojREREocMwAnTrGdHrWGeEiIgoVBhGgB6X9lraHJAkSZ42ERERhQmGEcA3TNOl6JnDKcHW7pKpUUREROGBYQTwDdO454xEayKgVIhTrMJKREQUXAwjQLdhGqVSgRgtV9QQERGFAsMI4OsZcViBdjuAjpvlsWeEiIgomBhGAEBrAOAel+myvNfCFTVERERBxTACAEoloNOL510msbJnhIiIKLgYRjxYa4SIiEgWDCMeXaqw6r0l4dkzQkREFEwMIx7enpGuwzTsGSEiIgomhhGPLst7uZqGiIgoNBhGPHqowsrVNERERMHFMOLRpQqrnjv3EhERhQTDiId3mMbTM8I6I0RERKHAMOLRZWlvLFfTEBERhQTDiEfXpb2RrDNCREQUCgwjHt2GaTwTWNkzQkREFEwMIx49DNM029rhckkyNYqIiGj4Yxjx6Li0V5K8q2kkCbDaOVRDREQULAwjHp6eEZcDcLRAp1ZBoxK3hytqiIiIgodhxEMTDSjF0IyvCit37iUiIgo2hhEPhcJPFVauqCEiIgo2hpGOulRhZa0RIiKi4GMY6ajL8l49e0aIiIiCjmGko56qsHLOCBERUdAwjHTUpQqrJ4ywZ4SIiCh4GEY66mGYhj0jREREwcMw0lG3YRp3GGllzwgREVGwMIx01GVpL+uMEBERBR/DSEfdlvZyNQ0REVGwDSiMvPDCC8jKyoJOp0Nubi727NnT6/WNjY1YsmQJUlNTodVqMXbsWGzatGlADQ4q75yRRgBcTUNERBQKEf19w/r167Fs2TKsW7cOubm5WLt2LebOnYuioiIkJyd3u95ut+Oqq65CcnIy3n//faSnp6OkpARGozEQ7Q8s75wR1hkhIiIKlX6HkTVr1uDuu+/GHXfcAQBYt24dNm7ciNdeew3Lly/vdv1rr72G+vp67NixA2q1+OWelZV1fq0Olh6X9rJnhIiIKFj6NUxjt9tRUFCA/Px83zdQKpGfn4+dO3f6fc9HH32EvLw8LFmyBCaTCZMnT8aTTz4Jp9PZ4+fYbDZYLJZOR0h0HKZxuXxLe7mahoiIKGj6FUZqa2vhdDphMpk6nTeZTKisrPT7nlOnTuH999+H0+nEpk2b8Oijj+KZZ57Bf//3f/f4OatXr4bBYPAeGRkZ/WnmwHl6RiABNot3NU2rwwmH0xWaNhAREYWZoK+mcblcSE5Oxssvv4wZM2bg5ptvxm9+8xusW7eux/esWLECZrPZe5SVlQW7mYJaB0REiuetDYjR+kaxOG+EiIgoOPo1ZyQxMREqlQpVVVWdzldVVSElJcXve1JTU6FWq6FSqbznJkyYgMrKStjtdmg0mm7v0Wq10Gq1/Wla4ETGAU2tQFsjIuKzEa1RwWp3oqnNgfjo7m0lIiKi89OvnhGNRoMZM2Zg8+bN3nMulwubN29GXl6e3/fMmTMHJ06cgMvlG+b47rvvkJqa6jeIyK7b8l6uqCEiIgqmfg/TLFu2DK+88grefPNNHD16FPfddx+sVqt3dc2iRYuwYsUK7/X33Xcf6uvrcf/99+O7777Dxo0b8eSTT2LJkiWB+ykCqUsVVm+tkVauqCEiIgqGfi/tvfnmm1FTU4OVK1eisrIS06ZNw8cff+yd1FpaWgql0pdxMjIy8Mknn+DBBx/E1KlTkZ6ejvvvvx8PP/xw4H6KQOpShVUf6dksjz0jREREwdDvMAIAS5cuxdKlS/2+tmXLlm7n8vLysGvXroF8VOh12bmXtUaIiIiCi3vTdNXTzr3sGSEiIgoKhpGuulRh1XPOCBERUVAxjHTVZZgmKVYsMa5ussnUICIiouGNYaSrLsM0qQYdAKDS3CpTg4iIiIY3hpGuvEt7GwEAKQZRkbXC3CZPe4iIiIY5hpGuuiztTXP3jDCMEBERBQfDSFddKrCmuMOIudWBFjtX1BAREQUaw0hXnmEaexPgdCBWp0ase8M89o4QEREFHsNIVzqD73mbGYCvd6SSYYSIiCjgGEa6UkUAWr147l7e6wkj5Y1cUUNERBRoDCP+dJk3kuZeUcOeESIiosBjGPGnSxVWb88IwwgREVHAMYz406UKKwufERERBQ/DiD9dq7AaWfiMiIgoWBhG/PFWYe3cM8IwQkREFHgMI/50qcKaysJnREREQcMw4k+XOSOxOjViWPiMiIgoKBhG/OmyWR7AwmdERETBwjDiT5dhGoDzRoiIiIKFYcSfLsM0QIcwwiqsREREAcUw4k+Xpb0AkOKuwlphYc8IERFRIDGM+NNlaS8ApHHOCBERUVAwjPjjGaZx2gCHGJbhZnlERETBwTDij1YPKFTiuWezPHcV1koO0xAREQUUw4g/CgWgM4jn7qEaT89IY4sDrXanXC0jIiIadhhGetJleW+sNgLRGtFbUsEN84iIiAKGYaQnXZb3KhQK74Z5nMRKREQUOAwjPfGzvNdTa6ScYYSIiChgGEZ64lne26EKa4res7yXwzRERESBwjDSE39VWN3DNOwZISIiChyGkZ70MkzDOSNERESBwzDSEz9VWLlZHhERUeAxjPTE78697v1pOGeEiIgoYBhGeuJnzggLnxEREQUew0hPvMM0jd5Tep2v8BnLwhMREQUGw0hP/AzTKBQKb+9IBTfMIyIiCgiGkZ54h2kaAUnynvbNG2HPCBERUSAwjPTE0zMiOQFbk/e0b0UNe0aIiIgCgWGkJ+pIQKUVz7m8l4iIKGgYRnrjGarpuLyXm+UREREFFMNIb/xUYU3hZnlERDRc1J8Cdr8MvLsQcMj3ey1Ctk8eCnqpwsrN8oiIaMixtwAl24HjnwEnPhNhxKN0JzDqclmaxTDSm16qsDa4C59FuuuOEBERDTqSBNSdAE58LgJIyXagvUMPiDICyPgeMPpKIGG0bM1kGOmNnyqsel0EojQqtNidqLS0ITsxWp62ERERdSVJQEMxcHq7CB6ntwPm0s7X6EeI8DHmKiD7+4BOL09bO2AY6Y2fKqyewmenaqyoMLcyjBARkXw8PR+nv/aFj6byzteoNEBmnggfo/OBpPGAQiFPe3vAMNIbP8M0AJBmiBRhpJGTWImIKISstUDFAfdRCJTuApqrOl+jVAPpM4CsOcDIOUBGLqCNkaW5fcUw0hs/wzSAb0UN96chIqKgkCTAchao+NYXPiq/Fee6UmmBEbN84WPELEATFfo2nweGkd74WdoLAGmswkpERIHkdIjAUbJD9HaU7QZaav1fmzAaSJkKpE4FRswWvSBqXWjbG2AMI73xs7QXAFI8+9NwmIaIiAbC1gyc2SOCR8kO4MxeoL3L/+AqI8T8jtQcd/jIAVImA9pYedocRAwjvfFTgRVgSXgiIuqnlnpRx8OzyqXyoNj7rKPIeDHRNPN74jFlypDv8egrhpHeeIdpzJ1Opxo5TENERL1oqhKho2SHeKw+0v0aY6Y7fOQBIy8CEsYAyvAsjM4w0hvPMI3NDLicgFIUOEvV+wqftTmc0KlZ+IyIKGxJkqhkWrYHKN0hAkjdie7XJY7zTTLNzAMM6aFv6yDFMNIbzzANALSZgah4AIA+MgKRahVaHU5UmtuQxVojREThw9EmltWW7RYBpGw3YK3pcpFCzO8Y2SF8xCTJ0dohgWGkNyo1oIkB7M1iEqs7jCgUCqQaReGzcnMrwwgR0XDlWWJ7Zi9w5hsRPMoLAZej83UqDZA2HciYDYy8GMjM9Q310zkxjJyLzugOI42dTqe6q7BWchIrEdHw0doAlO8HzhYAZ/eJx65FxQAgOlkEj4xcMeE0NQeI0Ia+vcMEw8i5RMYBljPdlvd6NszjihoioiGqtRGoOixWtpS7g4e/uR4KFWCaBIyYKTaVy5gNxGUNupLqQxnDyLmcc3kvV9QQEQ1qLhfQWCJCR9UhoPIQUHUQaCz1f31ctigk5jlSpwLqyNC2OcwwjJzLuUrCs2eEiGjwsNaKZbTVx9yPR0Xvh73J//WGDMA0GUibBqTPFPM+ohNC2mRiGDm3HqqwprmHacpZhZWIKPTsLaJ8evURoOaYCB3VR3suoa7SAMkTANMUscrFNFk8cpLpoMAwci4Jo8RjxYFOp7lZHhFRCNmtYiXL6a9FFdOzBd1XtAAAFGI+R/IEUUo9eYIIHoljxApJGpQYRs4l6xLxePprMe7oro7nmTNSb7Wz8BkRUaDZmoGyXb7wUb4PcLV3viY2VZRM94SO5AmisNgQ27GWGEbOLXUaoIkVE1irDorlWwAMkWoWPiMiOl8uF2AudQ+zuOd4eOZ7dN27xZABZF0sjpFzuKJlGGEYORdVBDAyDzj+KVC8zRtGFAqFqDVSa0UFwwgRUe8kSdTrqDrsm99RfQSoKQIcVv/vMWaKAmKeABI3MrRtppBhGOmLrEtEGDm9Dbhoqfd0qtETRri8l4jIy94C1LhXsVQdEctpq48ALXX+r1dpxPBKsnu4JWmCmFxqzAxtu0k2AwojL7zwAp5++mlUVlYiJycHzz33HGbPnn3O97377ru45ZZbsGDBAnz44YcD+Wh5ZLvnjZTsAJztorcEQIqehc+IKMy1mUV59PJ9onJp5SGxaRyk7tcqlED8KMA0EUie6Ase8Rd4/12l8NTvP/3169dj2bJlWLduHXJzc7F27VrMnTsXRUVFSE5O7vF9p0+fxkMPPYRLLrnkvBosi5SpgM4g/qOrPCCK4MA3iZW1RogoLDjaOlcrPbsPqDvu/9qoRNG7kTxJVC81TRQTTVk8jPzodxhZs2YN7r77btxxxx0AgHXr1mHjxo147bXXsHz5cr/vcTqdWLhwIR5//HFs27YNjY2N59XokFOqxGSpok1i3ognjBhZhZWIhhlJEoXD6k8B9Sfdj6eA2u/EPI+uK1oAwJAJpE8H0i4U8+pMk4CYnv/nlKirfoURu92OgoICrFixwntOqVQiPz8fO3fu7PF9v/3tb5GcnIyf/vSn2LZt2zk/x2azwWazeb+2WCz9aWZwZF3iDiNfARc/AKBjSXj2jBDRECNJImRUFIq5HZ7QUV8M2Hr5Nzc6SYSO9At9j9GJIWs2DU/9CiO1tbVwOp0wmUydzptMJhw7dszve77++mu8+uqrKCws7PPnrF69Go8//nh/mhZ8nnkjpbsApwNQqTlnhIiGBpcLaCgWczoqCsUcj4pvAZu5hzcoxDLa+GwxnyNhlHhMmQoYRnA5LQVcUGcMNTU14bbbbsMrr7yCxMS+J+cVK1Zg2bJl3q8tFgsyMjKC0cS+S54ERMYDrfVinDQzF2lGFj4jokHG6RDLZT2bwlUcEIe/3g6VVgyppE4FEsb4godxJKDWhb7tFLb6FUYSExOhUqlQVVXV6XxVVRVSUlK6XX/y5EmcPn0a8+fP955zuVzigyMiUFRUhFGjRnV7n1arhVar7U/Tgk+pBLLmAEf/CZz+CsjMhSFSDZ1aiTaHC1WWNoxMYK0RIgqh1kb3LrQHfUfNMcBp735thM63IVzqNPGYNJ4l0mlQ6FcY0Wg0mDFjBjZv3ozrrrsOgAgXmzdvxtKlS7tdP378eBw8eLDTuUceeQRNTU3405/+JH9vR39lf1+EkeJtwKX/CYVCgTRDJE7VWlHeyDBCREHQZhFDLPXFvnkdDafFo+Ws//doDWIlS8oUcaROA5LGMXjQoNXvYZply5Zh8eLFmDlzJmbPno21a9fCarV6V9csWrQI6enpWL16NXQ6HSZPntzp/UajEQC6nR8SPPvUlO0G2m1AhBYp7iqslRauqCGi89BcLXo5PIXC6k6IEGKt6f19hkxf6PAcxkzO66Ahpd9h5Oabb0ZNTQ1WrlyJyspKTJs2DR9//LF3UmtpaSmU7s3khp2kcUB0MmCtBs7sBbLmeHfvLW/kJFYi6gNHG1Bb5A4dh30BpLfQEZXom0wa536MvwBIHA1ExoWu7URBMqAJrEuXLvU7LAMAW7Zs6fW9b7zxxkA+cnBQKMT+CIc/EKXhs+YgzSBW1LDwGRF1YreK2hw1Rb6jtkgMt3TdAA4AoBCTR02TxIT5pLHu4JEtii4SDWOsv9tf2ZeIMFK8DbhsubdnhMt7icKMJImqzOYywHwGaCwTczlq3cHDXNbze3VGMZximuQ7kiYAmqhQtZ5oUGEY6a+sS8XjmT2Ao7VD4TPOGSEadlxOETCqDgF1JzsHD/MZwN7U+/ujk8QGcEljxcqVxLFiuDc2lXM6iDpgGOmvhFHiH5KmCqBsD1IN0wFwmIZoyGup7zyPo/qIKH/uaOn9fVGJohCYMUNMJk0cI4JH0jggKj40bSca4hhG+kuhEKtqDr4HnN6G1Nw8AEAdC58RDQ2SJHo4PMXAKg6InWabyv1fH6Fz7y47XlQlNWaI8GHIAPTpHFohCgCGkYHIdoeR4m0wXv4bFj4jGqw8ZdC9waNQPLY2+L/eOFIUBvPO5ZgsJpAq+T8ZRMHEMDIQnnojZwugcLQg1RCJ4lorKswMI0Qh53SIno6G02KlSkOx+/lp8dze3P09ygjR25GaIwqCpUwBkicCOn1o205EABhGBiYuS3TRmsuA0l1I0Ue7wwgnsRIFjcsJ1B4HKr8VvRtVh0XYaCzrYamsm3f/lRzfYZoERAyyLSeIwhjDyEB45o0ceFvMGzFeB4DLe4kCxtEqqpBWHhC7y1Z+K75u7yHwq7TifxLis0VtDu/zLFEcjGXQiQY1hpGBynaHkeJtSM38CQCuqCHqM1uzb5msucy3VNbzteUsILm6v08d7d5zZaoYWkkYLUJHTIrYzJKIhiSGkYHyzBsp348RE8Q/mqfrzrEEkCjcSJIIGGe+Ac4WiG0Uao4BbY3nfm90ki90pE4FUnJELwdDB9GwwzAyUMYM0QXccBoXq78DoMauk3VobLHDGKWRu3VE8rA1A+X7O4SPb4DmKv/X6gyiLodhRIc6HSPEOWMmEJPMwmBEYYJh5HxkXQI0nEaGeS/Gp1yNY5VN2HSwErfmZsrdMqLgcrQBdcfd+618J3o7PM+7Dq8oI8SE0RGzgPSZopfDkMGVK0TkxTByPrIvBfb/DSjehuum34Gn/n0MHxaeZRih4aPdLvZaqTwE1BwFatzBo7HE/5wOANCPAEbMdB+zxOoVdWRo201EQwrDyPnwzBup/BYLFkTj9x8De4rrcbaxFelG/uNLQ0xLvSiDXnlQhI/KgyJ4uBz+r9cZ3WXPx7r3XxkvekD0qSFtNhENfQwj50OfCiSMAeqOI7VxH2ZnxWN3cT0+KizHfZeNkrt1RP55qpJWHnSHD3fwsJzxf73OAJimuEuij3Mf48UEU87pIKIAYBg5X9mXiLHz09tw/fT7sLu4Hh/uP8swQoODrUnU56hy93ZUHRJfO6z+rzeOFKtXUqa6l9BOEfM7GDqIKIgYRs5X1iXA3teA4m2Y9/3fYuU/DqOoqglHKyyYkMoJehRCbWZRmbS8UOzBUl4I1J/0f61n8zfTZHGkThVDLDpDCBtMRCQwjJwvz7yRqoMwSE24fHwSPjlchQ8LzzKMUPBY60RvR8fg0VDs/9rYVBE4UtzBI2UKED8KUPE/fyIaHPiv0fmKSQKSJoiVBqe/xvXTZ+GTw1X4qLAcD88dD6WS3ds0QM52sWql9rhYMlv7ne95a73/9xgzfZu/pU0Tj9GJIWw0EVH/MYwEQvYlIoyc+ByXzbsWsboIVJjbsLu4HnmjEuRuHQ0FTofYf6Vsjziqj4ohFqe9hzcogLiR3YNHVHzo2kxEFCAMI4Ewdi6w52Vg/9+gm/pjXDM5Fev3luEfhWcZRsi/5hrgzB6gbDdQ9g1Qvg9o97O3UUQkkDgaSBzrPsaIx/hRgCYq9O0mIgoChpFAGHUlkHMLcOAd4P07cdMPPsL6vcDGgxV47EeToFOr5G4hycnWJJbOeuZ3lO3xP78jMg4YMRvImC16OZLGigJi3IuFiIY5hpFAUCiAa58Rv2xqjmLG3oeQrv8lzloc2FJUjR9MZhGosNHaILa8rzgggkfFAaDuJACpy4UKsZplxCwgI1cEkITRXEJLRGGJYSRQNNHAj/8KvHwZFKe34Q9po7HQchU+3F/OMDJctTb6VrKU7xdHY4n/a/UjxLyOlKm+UulcRktEBIBhJLCSxgI/ehb4v59iTvnr+L4yGV8cU8Lc6oAhUi136+h8tFncNTzcoaOiEKg/5f/auCz3xFL35NLUHK5oISLqBcNIoE35D6BkB7D3VTyrfRE/aH0S/z5YgZ/M5uZ5Q0ZzDVB5QAy3VH4rHnsqHmYcCaRNdx/TRPCIjAtpc4mIhjqGkWCY+yRwdi8MFQfwvOZZrNmfzTAyWJnPipUsnnkeld8CTRX+rzVkisCRNk2EDy6lJSIKCIaRYFDrgJvehGvdpZhhP47Ly15EeeNMpHEnX3m5nEDVYbGctnSXeDSX+blQASSMEvM7UnNEqfSUHCCay7SJiIKBYSRY4rOhvGEd8O6tuCtiEz7+/H+R9h93y92q8GJrAs7s9YWPM3sBe1PnaxQqIHkikJYjAkfqVFEyXRsjT5uJiMIQw0gwjb8WR7MXY0Lxm7j40CrgiiuB+AvkbtXw1G4XO9KeLRATTM/uA2qOoduSWk0skDELyPgekJkLpM9k8CAikhnDSJCl3rAae5/ehZnKIrS9fRt0P9sshnFo4FwuoO64CBxnC8Scj8qD/kunGzKAzO+JWh6Z3xO9IEoWoSMiGkwYRoLMGBuN97IeR3bJ3UioPQRsuAe45o9ATLLcTRsaJAmwnBWhwxM+Kg4ANkv3ayPjgLQLgfQLgfQZ4nmsKfRtJiKifmEYCYHLZk3DAyeW4E3N76E88g/g+OfA9+4D5vySha+6staKGh5n9/nCh7W6+3URke5VLZ7wcSEQl80KpkREQ5BCkqSudaoHHYvFAoPBALPZDL1eL3dz+q3N4cSs//4cE+0H8WraPxBT9614QWcELlkGzL4HUIfZShtJAhpO++p4VB7seVmtQgWYJnXu8UgaD6iYpYmIBrO+/v7mv+YhoFOrMG9KCt7b244n0q7G6vwSYPPvgNoi4LOVwK4/A99/GJj+/wDVMKzU6mgTk0mrDgGVh0ToqDzof6jFs6w2bboIHukzgJQp4RfWiIjCCHtGQmTHiVrc+pfd0KmV+NcvLsboxCjgwLvAltW+WhfxFwCX/waYdMPQ3am1udrdy3HQFz5qvwMkZ/drVRoxoTRliqjnkTIVME0EtLGhbzcREQVcX39/M4yEiCRJuO3VPfj6RC3Gp8TiwyVzoFOrgHYbsPd14KungZZacXH8KCD7EiAzT6wAMY4cHHMh7FagqVIMpTRVApbyzl/XnfA/vwMQk0tNk0XwSJkqHpPGDc+eICIiAsAwMihVN7Xhmj9tQ22zHYvyRuK3Cyb7XrQ1ieGaHc91H76ITXUvTXWHE9PkwM+XcLmA5irRS9NYKg5zGdBYJh4t5T0Mq3TlHmYxTQZSJrt7OyYD+rTBEaiIiChkGEYGqa3f1WDxa3sAAC/dNgNzJ6V0vqC1ESjZDpTuFFVDywsBl6PzNZoY8Us+OkGsxtEZgUijeNQZxblII6CJBmzNQJvZfTSKo7XR93Vro1g6az7jv05HV+poQJ8qAlJsivtwPzeOBJIniM8lIqKwxzAyiD256She/uoUDJFqbLr/EqT3tmeNvUUU9SrdCZTuFqXN+9RDMQAKJaBPF4XCjBmAMdP3XD9ChBDO5yAioj5iGBnE7O0u3LRuBw6cMWNWVhzeuft7iFD1ccKqywlUHxWHp6ejzezu7ejy3G4VvSienhJPL4r3a/ehTxWhQ5/GORxERBQwDCODXEmdFdc++zWabe345ZVjsOyqsXI3iYiIKKD6+vt7iK4fHfpGJkTjievFBNbnvziOnSfrZG4RERGRPBhGZLRgWjpumjECLgl4YP1+1Fv7MIGUiIhomGEYkdnjCybhgqRoVFls+PX7BzAERs2IiIgCimFEZlGaCDx3y3RoVEp8frQab+w4LXeTiIiIQophZBCYlGbAb66dAABYvekYDp01y9wiIiKi0GEYGSQW5Y3EVRNNsDtdWPr2PlSa2+RuEhERUUgwjAwSCoUCf7hxKtIMOpyua8H1L27H0YogFTcjIiIaRBhGBpG4aA3W/ywPo5NjUGFuw03rdmLb8Rq5m0VERBRUDCODTEZ8FP7v3ouQmx2PZls77nj9G7y3t0zuZhEREQUNw8ggZIhS468/nY0F09LQ7pLw6/e/xZrPvuOyXyIiGpYYRgYpbYQKa2+ehqWXjwYAPLv5OH719wOwt7tkbhkREVFgMYwMYgqFAg/NHYenbpgClVKBD/adxe2v74GlzSF304iIiAKGYWQI+MnsTLy6eCaiNSrsOFmH//jzDpxtbJW7WURERAHBMDJEXDYuGe/dmweTXovvqppx/Qvb8eWxarmbRUREdN4YRoaQSWkGbPj5HIwzxaK6yYY73vgGP3+rAFUWFkgjIqKhi2FkiEkzRmLDkotwz6UXQKVUYNPBSlz5zFa8ueM0nC6utiEioqGHYWQIitJE4L+umYB/Lr0Y0zKMaLa1Y9VHh3H9i9u5rw0REQ05DCND2MQ0Pf7vvovwuwWTEKuNwLdnzPjR81/jd/86AqutXe7mERER9QnDyBCnUipwW14WNv/q+7h2aipcEvDq18XIX7MVnxyulLt5RERE56SQhkBZT4vFAoPBALPZDL1eL3dzBrUtRdV49B+HUFYvlv7OyorDzy8fjcvGJkGhUMjcOiIiCid9/f3NMDIMtdqdePaL43h1WzHsTlGxdVKaHksuH40fTEqBUslQQkREwccwQqiytOGVr07hrd2laHU4AQCjkqLx88tG40fT0qBWcZSOiIiCp6+/vwf02+iFF15AVlYWdDodcnNzsWfPnh6vfeWVV3DJJZcgLi4OcXFxyM/P7/V6ChyTXodHfjgR25dfgV9eMRp6XQRO1ljxq78fwOV/3IK/7SpBmzukEBERyaXfYWT9+vVYtmwZVq1ahX379iEnJwdz585FdbX/aqBbtmzBLbfcgi+//BI7d+5ERkYGrr76apw9e/a8G099Ex+twbKrx2H78ivw8A/GIzFGgzMNrXj0w0O45A9f4k+fH8eZhha5m0lERGGq38M0ubm5mDVrFp5//nkAgMvlQkZGBn7xi19g+fLl53y/0+lEXFwcnn/+eSxatKhPn8lhmsBqtTux/ptSvPzVKZSbRfVWhQKYMyoRN80cgbmTUqBTq2RuJRERDXV9/f0d0Z9varfbUVBQgBUrVnjPKZVK5OfnY+fOnX36Hi0tLXA4HIiPj+/xGpvNBpvN5v3aYrH0p5l0DpEaFW6fk41bc0di08EKvLe3DDtO1uHrE7X4+kQtYnUR+FFOGn48MwNTRxi4CoeIiIKqX2GktrYWTqcTJpOp03mTyYRjx4716Xs8/PDDSEtLQ35+fo/XrF69Go8//nh/mkYDoIlQ4rrp6bhuejrK6lvwfsEZvF9wBmcbW/HW7lK8tbsUY00xuGlGBhZMT0NyrE7uJhMR0TAU0uUUTz31FN59911s2LABOl3Pv9hWrFgBs9nsPcrKykLYyvCUER+FB68ai22/vhxv3ZWLBdPSoI1Q4ruqZjyx6Shyn9yMG/+8Ay9tPYniWqvczSUiomGkXz0jiYmJUKlUqKqq6nS+qqoKKSkpvb73j3/8I5566il8/vnnmDp1aq/XarVaaLXa/jSNAkSpVGDO6ETMGZ0Ic6sD//q2HO8XnMH+0kYUlDSgoKQBq/99DGOSY3D1JBOunpjCoRwiIjovA5rAOnv2bDz33HMAxATWzMxMLF26tMcJrH/4wx/wxBNP4JNPPsH3vve9fjeSE1jlV2FuxedHqvDpkSrsPFmH9g47BKfodbhqogn5E02YnRWPSA0nvxIRURCLnq1fvx6LFy/GSy+9hNmzZ2Pt2rV47733cOzYMZhMJixatAjp6elYvXo1AOD3v/89Vq5cibfffhtz5szxfp+YmBjExMQE9Ieh0DC3OrClqBqfHq7ClqJqWO2+WiUalRIXjjRizqhEzBmTiKnpBkSwuBoRUVgKagXW559/Hk8//TQqKysxbdo0PPvss8jNzQUAXHbZZcjKysIbb7wBAMjKykJJSUm377Fq1So89thjAf1hKPTaHE7sPFmHTw5X4qvvarxLhT1itRHIvSABc0Yn4OLRiRidHMMhHSKiMMFy8BRykiThdF0Lvj5Rix0narHjZB3MrY5O1yTGaDFzZBwuHGnEjJFxmJRmYE0TIqJhimGEZOd0SThSbhHh5GQt9hTXw9bu6nSNRqXEpHQ9LsyMw4yRcbgwMw4pBi4hJiIaDhhGaNBpczjx7Rkz9pU2YF9JA/aVNqC22d7tujSDDpPTDZiUZsCkND0mpeuRotdxeIeIaIhhGKFBT5IklNW3oqC0HvtKxNLhY5UWuPz8jYyP1mBSmh4T0/TekJKVEA2VkgGFiGiwYhihIclqa8e3Z8w4XG7GkXILDpdbcKKmGU4/CUUbocSopBiMNcVgjCkW40yxGGuKxYi4SCgZUoiIZMcwQsNGm8OJosomHC634EiFGYfLLThaYUGbw+X3+ki1CqOTYzDGFIPRyTHITohGVmI0shKiWQOFiCiEGEZoWHO6JJTVt+C7qiYcr27Gd1VN+K6qGSdrmmFv9x9SACDVoENWQjSyk6K9ISU7MQoj4qK4qoeIKMAYRigstTtdKKlvwXF3OCmuteJUrRWna63dlhl3ZdJrkRkfhYz4KGR2OZJitZxAS0TUTwwjRF00WO3eYHK6zhdSSupa0Gxr7/W92ggl0o2RSI+LRJrB/WiMFOeMkUgx6KCJYKVZIqKO+vr7u18b5RENZXHRGsyI1mDGyLhO5yVJQmOLA6X1Ld6jrMPz8sZW2NpdOOXuZfFHoQCSY7VINUQizahDqiESqQbxmGLQIc2oQ3Ksjqt/iIj8YBihsKdQKBAXrUFctAY5GcZurzucLlQ0tuFsY6s4GlpR7nnuPuztLlRZbKiy2FBY5v9zVEoFkmO1SNbrkBSjRVJsh8P9dbL7a85fIaJwwjBCdA5qlRKZCVHITIjy+7okSahttqO8sRUV5lZUmNt8R6P4usrShnaX5D1/LrHaCCTptT2GFs+REK1lbwsRDXkMI0TnSaFQeMOBv54VQKz+qWu2odzchpomG2qabKhu8j2vafacs8He7kKTrR1NNe04VeN/WMhDqRAF4RJjfGEl0fsozsdHa5AQrUVctBraCPa4ENHgwzBCFAIqpQLJeh2S9b3vuyNJEixt7ah1hxNPQOkaWmqabKiz2uCSgNpmO2qb7ThW2XTOdsRoIxDvHpJKiNYgLkqDhBiNO7B4nmu9z6M0/CeCiIKP/9IQDSIKhQKGSDUMkWqMSorp9dp2pwv1LXbUNtlR02xDbYewUtvhsd7qQEOLHU6XhGZbO5pt7Sitb+lTe3RqJRKitUiIEcElPtrzqIax09caxEWrYYzUcFUREfUbwwjREBWhUiI5VqzSOReXS0JTWzvqrDY0tNhR12wXj1Y76pvtqLeK53VWG+qb7ai12mFvd6HN4fJO0u2raI0KxigRTuKiNDBGaWCMVCMuqkOAidYg3n1NfLQGkWoV67gQhTGGEaIwoFQqYIhSwxCl7tP1kiTBane6g4kIKPUtdjRY7WhocaDB2vFr97kWOyQJsNqdsNr7F2C0EcouvSwab3iJi/KEGvEYF6WBMVqNWG0EAwzRMMEwQkTdKBQKxGgjEKON6HEVUVdOl4SmNoc3mDS22NFgdaCx1SGet/iCjDfQWO2wO12wtbv6vNLII0KpgLFDYOkcXLqcixa9M8YoDiMRDUYMI0QUECqlQgzJRGmQjeg+vUeSJLTYnai3+oaNPCGl0RtqHN4g4wk1bQ4X2l2Sd/Juf0RpVN6eFmOXEOPpmTFGqb09NXHRGkRrOIxEFEwMI0QkG4VCgWhtBKK1EciI71sPDCB2cm7w9Lx0GCbq/Nz32Nhih7nVAZcEtNidaOnnMJJapeg8gTfGM+dFg3h3z0vH8BIfpeEO0UT9wDBCREOOTq1yl9yP7PN7PJN4G9y9K97hI/dQkmceTGOLHfXukFNvtcPW7oLDKaHavcy6r7QRSm848fa8RPt6YDquUPIcrLxL4YphhIjCQsdJvFl9HEYCgFa70ztZ1zOcVO8ZTnKHmY7DTI0tdjicEmztLlRa2lBp6fs8GM8QUsegYoxS+3phvL0v4hznwNBwwTBCRNSLSI0K6RqxO3NfeFYidVpp1OV5fYtYUu0JNvVWO9pd0oCGkDxLqY0dVh0ZO0zkjY9WIyFai0R3Vd74KA0iVAwwNLgwjBARBVDHlUh9nQcjSRKabO3eJdSeoNLgHjLyhRlP74wYRnINYCm1QgHERWmQGCO2C/AcCTG+cwkxogpvYoyWc18oJBhGiIhkplAooNepodf1fQjJ5ZJgaXN0W3XU2OKb1NvY6kC91YbaJlHQrs4qasF4emO+q2o+5+dEa1QinMSILQPE/BYtEmN8c10SorWId7/OeS80EAwjRERDkLLDUuq+BhinS0K91Y7aZhvqmsVjbbPYRqCu2Y66ZhFYaptsqG0WNWCsdies9S193kIgSqPqNCk33jNJN8b3PCFG6+2FieKyaQLDCBFR2FApfTtMn4skib2Mat0hpdYdVOqb3dsIWH3bCNRbbai3iom7nnkvZxr6NmykUyu9Q0NJMaKXJTFW490TKcn9WmKMCF4qJYPLcMQwQkRE3SgUCsTq1IjVqZGdeO6eF8+O0x0n6NZ7nvsJL7VNdrQ6nGhzuHCmoW/hRamAd4jIN8/FN+clqcO5hBgNtBEcMhoqGEaIiOi8ddxxuq/DRi32du+u06L3xdcLU+seRqpzDys1toiidZ6hJaDpnN8/VhfRKaB0DjCdz8VwryNZMYwQEZEsojQRyEzo2/5HDqcLDVa7d36LJ5TUubcE6Ph1ndUGh1MUuWtqa8epWus5v782QokE93yWBPfk3ET3qqKOq4s8Q0is7xJYDCNERDToqVVKJOt1SNbrznmtJEmwtLajplNg6dzj0jG8tNidsLW7UG5uQ3kfN2s0Rqm9PSxJsTpvT0tSbOcAkxCjQZSGv2rPhXeIiIiGFYXCV213dHLMOa+32tq981k8K4o8q4vqrXbUWjtM4m0WBerEEmoHTlSfuz2RapW7p0WEFLEc2l1Rt8PzhGgt4qLVYTlkxDBCRERhrT+bNbpcEsytDtHr0iSWRdc0+Xpcapps3sm6Nc022NtdaHU4cbax74XpNCqlewm0exl0tG9JtKc4nWe1UUL08ChMxzBCRETUR0qlQmx+GK3BWFNsr9d6tgbo2tvScWl016PV4YTd2b99jTr2vPgtSucOLfGDeNho8LWIiIhoGOi4NcDIhL6tMGq1O1HnrtviCTD1Vt9E3Tqrr0BdrdU+oJ4XT3jxVdUVvSwLczP73M5AYxghIiIaJCI1KozQRGFE3LmHjLr2vHhqu9RabR2eu4vSNdvPGV5+MDmFYYSIiIj6rr89L57wUt+hh6VjIboRcX3bmToYGEaIiIjCQMfw0pfaLqHEqi1EREQkK4YRIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLIaErv2SpIEALBYLDK3hIiIiPrK83vb83u8J0MijDQ1NQEAMjIyZG4JERER9VdTUxMMBkOPryukc8WVQcDlcqG8vByxsbFQKBQB+74WiwUZGRkoKyuDXq8P2Pcl/3i/Q4v3O7R4v0OL9zu0Bnq/JUlCU1MT0tLSoFT2PDNkSPSMKJVKjBgxImjfX6/X8y9zCPF+hxbvd2jxfocW73doDeR+99Yj4sEJrERERCQrhhEiIiKSVViHEa1Wi1WrVkGr1crdlLDA+x1avN+hxfsdWrzfoRXs+z0kJrASERHR8BXWPSNEREQkP4YRIiIikhXDCBEREcmKYYSIiIhkFdZh5IUXXkBWVhZ0Oh1yc3OxZ88euZs0LHz11VeYP38+0tLSoFAo8OGHH3Z6XZIkrFy5EqmpqYiMjER+fj6OHz8uT2OHgdWrV2PWrFmIjY1FcnIyrrvuOhQVFXW6pq2tDUuWLEFCQgJiYmJw4403oqqqSqYWD21//vOfMXXqVG/xp7y8PPz73//2vs57HTxPPfUUFAoFHnjgAe853u/Aeuyxx6BQKDod48eP974erPsdtmFk/fr1WLZsGVatWoV9+/YhJycHc+fORXV1tdxNG/KsVitycnLwwgsv+H39D3/4A5599lmsW7cOu3fvRnR0NObOnYu2trYQt3R42Lp1K5YsWYJdu3bhs88+g8PhwNVXXw2r1eq95sEHH8Q///lP/P3vf8fWrVtRXl6OG264QcZWD10jRozAU089hYKCAuzduxdXXHEFFixYgMOHDwPgvQ6Wb775Bi+99BKmTp3a6Tzvd+BNmjQJFRUV3uPrr7/2vha0+y2FqdmzZ0tLlizxfu10OqW0tDRp9erVMrZq+AEgbdiwwfu1y+WSUlJSpKefftp7rrGxUdJqtdI777wjQwuHn+rqagmAtHXrVkmSxP1Vq9XS3//+d+81R48elQBIO3fulKuZw0pcXJz0l7/8hfc6SJqamqQxY8ZIn332mfT9739fuv/++yVJ4t/tYFi1apWUk5Pj97Vg3u+w7Bmx2+0oKChAfn6+95xSqUR+fj527twpY8uGv+LiYlRWVna69waDAbm5ubz3AWI2mwEA8fHxAICCggI4HI5O93z8+PHIzMzkPT9PTqcT7777LqxWK/Ly8nivg2TJkiW49tprO91XgH+3g+X48eNIS0vDBRdcgIULF6K0tBRAcO/3kNgoL9Bqa2vhdDphMpk6nTeZTDh27JhMrQoPlZWVAOD33nteo4FzuVx44IEHMGfOHEyePBmAuOcajQZGo7HTtbznA3fw4EHk5eWhra0NMTEx2LBhAyZOnIjCwkLe6wB79913sW/fPnzzzTfdXuPf7cDLzc3FG2+8gXHjxqGiogKPP/44LrnkEhw6dCio9zsswwjRcLVkyRIcOnSo0xgvBd64ceNQWFgIs9mM999/H4sXL8bWrVvlbtawU1ZWhvvvvx+fffYZdDqd3M0JC/PmzfM+nzp1KnJzczFy5Ei89957iIyMDNrnhuUwTWJiIlQqVbcZwFVVVUhJSZGpVeHBc3957wNv6dKl+Ne//oUvv/wSI0aM8J5PSUmB3W5HY2Njp+t5zwdOo9Fg9OjRmDFjBlavXo2cnBz86U9/4r0OsIKCAlRXV+PCCy9EREQEIiIisHXrVjz77LOIiIiAyWTi/Q4yo9GIsWPH4sSJE0H9+x2WYUSj0WDGjBnYvHmz95zL5cLmzZuRl5cnY8uGv+zsbKSkpHS69xaLBbt37+a9HyBJkrB06VJs2LABX3zxBbKzszu9PmPGDKjV6k73vKioCKWlpbznAeJyuWCz2XivA+zKK6/EwYMHUVhY6D1mzpyJhQsXep/zfgdXc3MzTp48idTU1OD+/T6v6a9D2LvvvitptVrpjTfekI4cOSLdc889ktFolCorK+Vu2pDX1NQk7d+/X9q/f78EQFqzZo20f/9+qaSkRJIkSXrqqacko9Eo/eMf/5C+/fZbacGCBVJ2drbU2toqc8uHpvvuu08yGAzSli1bpIqKCu/R0tLivebee++VMjMzpS+++ELau3evlJeXJ+Xl5cnY6qFr+fLl0tatW6Xi4mLp22+/lZYvXy4pFArp008/lSSJ9zrYOq6mkSTe70D71a9+JW3ZskUqLi6Wtm/fLuXn50uJiYlSdXW1JEnBu99hG0YkSZKee+45KTMzU9JoNNLs2bOlXbt2yd2kYeHLL7+UAHQ7Fi9eLEmSWN776KOPSiaTSdJqtdKVV14pFRUVydvoIczfvQYgvf76695rWltbpZ///OdSXFycFBUVJV1//fVSRUWFfI0ewu68805p5MiRkkajkZKSkqQrr7zSG0Qkifc62LqGEd7vwLr55pul1NRUSaPRSOnp6dLNN98snThxwvt6sO63QpIk6fz6VoiIiIgGLiznjBAREdHgwTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrP4/DtZDT0NaIawAAAAASUVORK5CYII="
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABTvklEQVR4nO3deXwTdf4/8FeO5uqR3iel5b5si4J0q3gsVKu4/BBdFxEFWW9xV+26CiuX61HUr4gHirog3iLeu7C4WJVdkMtiVeQ+C/RuadImzdFkfn9MMm1oS5u0Sdryej4e85hkMpl8MnY3Lz6f93xGJgiCACIiIqIeTB7sBhARERF1hIGFiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHUwa7Ad3B6XSitLQU4eHhkMlkwW4OERERdYIgCKivr0dycjLk8rP3ofSJwFJaWorU1NRgN4OIiIh8cOLECfTr1++s+/SJwBIeHg5A/MIRERFBbg0RERF1htFoRGpqqvQ7fjZ9IrC4h4EiIiIYWIiIiHqZzpRzsOiWiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHY2AhIiKiHo+BhYiIiHo8BhYiIiLq8RhYiIiIqMdjYCEiIqIer0/c/JCIiIi6RhAEmG0O1JpsqDHZcNq1rjVZUWOyockhYMHvRgatfQwsREREfZQgCKgz21HdYEVVgxVV9VZUN9hQ3WBFdb1VXDfYUNMghhJrk7PdY6kUcsy/ZkSn7qzsDwwsREREvUyDtQlV9dYWiwXVDTbxcUPz9hqTFXaH4NWx1Uo5YkJViA5TITpULT52LQ6nAKWCgYWIiOic5HQKqLc2wdhoh6HRjlqTGD4q662orLegst6KKmPzY7PN4dXx9doQxIapEBumRly4WlrHhakRG+4ZTHQqRdB6Uc6GgYWIiMgPBEFAVYMVp0434uTpRpyqa8TJ02bUmmwwuIKJsbEJhkY76i12OL3rCIFOpUB8uCt4uMNHWIvnrmASE6aCWqnwz5cMIAYWIiIiLwiC2BtS0yAWpIo1IGIdSKnBFU5cAeVsNSFtUSvl0GtDEKkLQXy4RgwkEWrpcXy4GvER4uNQ9bn1E35ufVsiIqIWHE4BNQ1W1Ll6POrMdtSZm3tA6szi+rTZJl490yCubY7OBRG5DEiM0CAlSot+UTqkRGoRF66GXhsCvTYEEVqlax2CCE0INCG9vyfEXxhYiIioz3I6BVTWW3HytBknTptxslbsATlZZ8aJ2kaU1jWiyduxGJdQlQIxriGXGFcNSFKkBimRWqREaZEapUOiXoMQBac86w4MLERE1GsIggCjpQnVDVbUmmwdLlX11g57Q+QySD0eep1KHJJxDctI27UhUj1ITJgYTtgbElgMLEREFFROp4C6RrvrqhiLa64QK2oabNKcITUmq6tOpPPDMW4KuQxJeg1So3To5xqa6RelRWq0uE6I0EAh73lXxZAnBhYiIupW7l6QOrMNp81i/Ued2YbTJrE+pKrBikpjy4nMvJ8rJEytREyYClE6FWJCVYgKVUmX5bofR4WqEBemRpJeAyWHZXo9BhYiIuoUk7UJlfVWVBgtqDCKPSHi4+aekTqzHXWNdjh8qAuJdgWM2HBxHRPWfFmuew4RDsecuxhYiIjOcXaHE1X1VpQbLag0WlBusKDcaBUfu5ZKoxUN1iavjqtTKRClUyFSF+KxbjlvSHyE+DgmVA2Vkr0g1D4GFiKiPkIQBNSYbCg3WFBa14hyowXGRjvqrU1osDShwbVu+bzeIvaICJ3sEAlVKZAQoUG8a26QhAi167kGsWGuIRlXOOkLk5VRz8HAQkTUgwmCgAZrkzQfiHtda7KizCD2hpQaGlFmsKDMYIHNy4nK3JRyGRIimgNIQoQGiXoNEl3hxL0t7BybrIx6Dv7lEREFiDt8nDbZUWOy4rS5eSKyWrMNtQ02aYKyukY7DK5w4s08ITIZpELTRL0G0aEqhKqUCNMoEaZWIlyjRJg6RHoeplYi2lWkKueVMtSD+RRYli9fjmeffRbl5eXIysrCSy+9hHHjxrW5r91uR0FBAd566y2cOnUKw4YNw9NPP42rrrpK2mfx4sV47LHHPN43bNgw7Nu3z5fmERH5hSAIMNkcMDbaYbTYUW9pkh4bG8XhFeMZ28R183ZfJylTKeWI0oUgUquCXifOEyKGEi2SIzVI0muRpBd7QVgLQn2R14FlzZo1yM/Px4oVK5CdnY1ly5YhLy8P+/fvR3x8fKv958+fj3fffRdvvPEGhg8fjq+++gpTp07F999/j/PPP1/ab9SoUfj666+bG6Zk5w8R+YcgCGi0O6SaDrFXQxxmabU223HadbM6X25Q1xZtiALRZ16Cq1MhRqoBCUGkqw4kUiuueVUMnetkgtDZUitRdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33XcBiD0sn3/+OYqLi336EkajEXq9HgaDARERET4dg4h6J0EQUGuyocJoRUW9BRUGi/S4pkG8sqXB6oDJ2gSTK6CYbE1dCh4hChkiNO77vygRoQ1BuEbZapv4vOV2ccZUrYrhgwjw7vfbq24Mm82GoqIizJs3T9oml8uRm5uLrVu3tvkeq9UKjUbjsU2r1WLz5s0e2w4ePIjk5GRoNBrk5OSgoKAA/fv3b/eYVqtVem40Gr35GkTUw1mbHB43mmu51JjEO+SKc4BYOzX1entkMiBMpUTUGT0d0aEhiA5VS2uxxyNECh5qpRwyGes9iALJq8BSXV0Nh8OBhIQEj+0JCQnt1pvk5eVh6dKluPTSSzFo0CAUFhbi008/hcPhkPbJzs7G6tWrMWzYMJSVleGxxx7DJZdcgt27dyM8PLzVMQsKClrVvBBRz+Ce5dQ9g2nLdU2DDSZbEyx2BxrtDljsTjTaHLDYHdI293ZvxYapEB8uFpq6r3SJDVMjXKNEqEqJUFeBaaha4VoroVMpGDyIegm/F4q88MILuOOOOzB8+HDIZDIMGjQIs2fPxqpVq6R9rr76aulxZmYmsrOzkZaWho8++gi33XZbq2POmzcP+fn50nOj0YjU1FT/fhGic4ggCLA5nLA2OcUgYXOgzjXFuqFRrOmoc11iW2cWH582ifd9qWqw+nxpbUtKucyz1yOseer1mFBx1tMEV5FpXBgnHSPq67wKLLGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwWiwU1NTVITk7G3LlzMXDgwHY/JzIyEkOHDsWhQ4fafF2tVkOtVnvTdKJzliAIqDPbUWpoRGmdBWUe60bUme1SMLE2OWFtEtfeVbe1Fq5RuqZZF2c0jQtXIzZMhTC1EpoQBbQqBdRKca1RyqFVKaANUUATopBqP9j7QURuXgUWlUqFMWPGoLCwENdeey0Asei2sLAQ991331nfq9FokJKSArvdjk8++QR/+MMf2t23oaEBhw8fxi233OJN84j6PKdTQK3Zhqp6KwyNnpfLtryMtt4izt9RWW9FWZ0FjXZHxwc/C51KgUhtCPQ6lVTPEalTIVIrTrXuvsxWDCViOOFVLUTUnbweEsrPz8esWbMwduxYjBs3DsuWLYPJZMLs2bMBADNnzkRKSgoKCgoAANu3b8epU6cwevRonDp1CosXL4bT6cTDDz8sHfOhhx7C5MmTkZaWhtLSUixatAgKhQLTp0/vpq9J1LNZmxyoabBJtR6V9eLdbCvrLa7CUgsq68XXfJ3HIzZMhaQWc3a41zFh4o3k1Eo51EpxrQlRQB0ih1oph0rBAlMiCj6vA8u0adNQVVWFhQsXory8HKNHj8aGDRukQtySkhLI5c1jyRaLBfPnz8eRI0cQFhaGSZMm4Z133kFkZKS0z8mTJzF9+nTU1NQgLi4O48ePx7Zt2xAXF9f1b0gURE0OJ8qNFpw83YhTpxtRZmiU6jzcxajV9VYYLd7dVM49V4d4OW3bl9GGa5SIC1cjJVKLhAgNezyIqFfzeh6WnojzsFCwmKxN4t1sDRacqhNDycnTjTh52oyTp8Wbzzk62SOilMsQG6ZGbLh4tUt8uBrxEa6163FChDjkEqJggSkR9X5+m4eF6FxisTtw8nQjTpw2o6zOgnKDGEDKDBZUuNb1negZCVHIkBKpRb8oHZL0GqnOI9ZVhBrveq7XhnDohYioHQwsdM5yOAWUGy0oqTHjxGkzTtaaceJ0I0pqzThRa0ZlvbXjgwAIUyuRqNcgSa9Bvygd+kVpWyw6xIWpeVM5IqIuYmChPs1id+BErRnHa8w4XmtGSY3JtRaHbDqaITVUpUBqtE6sA9FrkBQhTkzmDigJERqEa0IC9G2IiM5dDCzUJzidAo7XmrGn1IhfSw3YU2bE/vJ6lBksZ31fiEIm9YqkRuuQGqVDarTWtdYhSsdhGiKinoCBhXoda5MDB8obsKfMgF9LjdhTasTeMiNMtrbnGglTK9E/Wof0WB36R4ciLUaHtGgd+sfokKTXQsHhGiKiHo+BhXo0u8OJgxUN+OVUHX46acAvJw3YV26E3dH6yhu1Uo7hieEYmRyBkcl6jEgMx4DYUESHqthLQkTUyzGwUI8hCAKO15ixq+Q0fj5pwM8n6/BrqRHWNu5LE6kLwajkCIxK1mNkUgRGJkdgYGwolLzcl4ioT2JgoaCqabBiy+EabDlYjc2HqnGqrrHVPuFqJTL66ZHRT4+sfpHISNGjX5SWvSZEROcQBhYKqEabAzuP1WLzoWpsPliNPWVGj9dDFDJk9YtEZr9IZKXqkZGiR3pMKC8LJiI6xzGwkN8drTahcG8FvtlXiR+OnW51KfGIpAiMHxyDiwfHYtyAaOhU/LMkIiJP/GWgbmd3OPHDsdP4Zl8FCvdW4ki1yeP1ZL0G44fE4uLBsbhoUCziwtVBaikREfUWDCzULU6bbNh0oApf763ApgNVHlPWhyhkyB4QgwnD43HZsDgMjA1l/QkREXmFgYV8Zmty4pt9Ffi46CS+3V/lcZO/6FAVLh8Wh9wRCbhkSCxngyUioi5hYCGv7Sk1Ym3RCXxRXIpak03aPjwxHBOGx2PiiASMTo3khGxERNRtGFioU06bbPii+BTWFp3Er6XNV/bEhatx3QUpuGFMPwyODw9iC4mIqC9jYKF2CYKAbUdq8c62Y/h6T6V0dU+IQobcEQm4YWw/XDokjpO1ERGR3zGwUCtNDif+vbscb/zvCH4+aZC2j0qOwO/H9MOU0SmIDlUFsYVERHSuYWAhidnWhI92nsDKLUdxolaccVatlOP6Mf0wI7s/RiXrg9xCIiI6VzGwEKrqrXjr+2N4Z9txGBrtAIAoXQhm5qRjZk4aYsI4TwoREQUXA8s57HiNCa9+dxif/ngKNtcNBtNidLj9koH4/QX9oFUpgtxCIiIiEQPLOajeYsfL3x7Cqs1HYXeIc6ec3z8Sd106EFeMTOTlyERE1OMwsJxDnE4BHxedxDNf7Ud1gxUAcOnQOPx5wmCMTY8OcuuIiIjax8ByjvjhWC0e++ce/HJKvOpnYGwoFvxuJH47PD7ILSMiIuoYA0sfV1rXiCX/3ocvfyoFAISrlbg/dwhm5qRDpeT8KURE1DswsPRRFrsDr206glc3HYLF7oRMBtx4YSr+cuUwxPKqHyIi6mUYWPqg/eX1uOudH3CsxgwAGJcejYWTR+K8FM6jQkREvRMDSx/z71/K8Je1P8FscyBJr8Gj14zANRlJkMl45Q8REfVeDCx9hNMpYOnGA3j520MAgIsHx+Dl6RcgilPoExFRH8DA0gcYGu14cE0xvtlXCQC4ffwAzL16OG9KSEREfQYDSy93qLIed75dhCPVJqiVciy5PgNTz+8X7GYRERF1KwaWXmzjngo8uKYYDdYmJOs1eO2Wscjox8JaIiLqexhYeiGnU8BL3xzC818fAACMGxCNV2ZcwMuViYioz2Jg6WWsTQ78+YMf8dWvFQCAWTlpmP+7kQhhvQoREfVhDCy9iCAIWPj5r/jq1wqoFHI8ce15+MOFqcFuFhERkd/59M/y5cuXIz09HRqNBtnZ2dixY0e7+9rtdvz973/HoEGDoNFokJWVhQ0bNnTpmOeqt74/hjU/nIBcBrw2cwzDChERnTO8Dixr1qxBfn4+Fi1ahF27diErKwt5eXmorKxsc//58+fjtddew0svvYQ9e/bg7rvvxtSpU/Hjjz/6fMxz0ZZD1Xh83V4AwNyrh+O3w3jTQiIiOnfIBEEQvHlDdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33Xd9OuaZjEYj9Ho9DAYDIiIivPk6vUJJjRn/b/lm1JntmHp+Cpb+IYsz1xIRUa/nze+3Vz0sNpsNRUVFyM3NbT6AXI7c3Fxs3bq1zfdYrVZoNBqPbVqtFps3b/b5mOeSBmsT7nj7B9SZ7cjqp0fBdRkMK0REdM7xKrBUV1fD4XAgISHBY3tCQgLKy8vbfE9eXh6WLl2KgwcPwul0YuPGjfj0009RVlbm8zGtViuMRqPH0hc5nQL+8lEx9lfUIy5cjdduGQtNiCLYzSIiIgo4v18L+8ILL2DIkCEYPnw4VCoV7rvvPsyePRtyue8fXVBQAL1eLy2pqX2z+PSFwoPSFUGv3TIGiXpNx28iIiLqg7xKDbGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwmkwnHjx/Hvn37EBYWhoEDB/p8zHnz5sFgMEjLiRMnvPkavcK/fynDC4UHAQBPTj0PF/SPCnKLiIiIgserwKJSqTBmzBgUFhZK25xOJwoLC5GTk3PW92o0GqSkpKCpqQmffPIJpkyZ4vMx1Wo1IiIiPJa+ZG+ZEX9Z+xMA4I8XD8ANY/3Qg2S3AKd2AYe+BmoOA46m7v8MIiKibuL1xHH5+fmYNWsWxo4di3HjxmHZsmUwmUyYPXs2AGDmzJlISUlBQUEBAGD79u04deoURo8ejVOnTmHx4sVwOp14+OGHO33Mc0mtyYY73v4BZpsD4wfH4m+Thnf9oKZqoPwXz6X6ACA4mveRhwDRA4CYwUDMINd6iLgOiwdY6EtEREHkdWCZNm0aqqqqsHDhQpSXl2P06NHYsGGDVDRbUlLiUZ9isVgwf/58HDlyBGFhYZg0aRLeeecdREZGdvqY5wq7w4l73yvCydONSIvR4eWbzoeys1PuCwJgrgGqDwI1h8Slcq8YTupL236PNhoISwBOHwOaGsUQU32g9X4hOkAVCijUgFINKDWAUuVaq5u3qyMATYRrrW/x2PVc7XquDhf3ZwgiIqJO8noelp6or8zDsmrzUfz9X3sQqlLgszkXY2hCeNs71hwGyn5qDibuxWJo/+DRA4HEDNeSKa7Dk8TQ4HQCxlMtjnUYqHEFn7oSQHB2/5eVKwFVmCvAhIkhRhUmPg6NB2KHAnFDxbW7nf7gdAJdKAAnIiLfefP7zXsJ9RB2hxP/+N8RAMDfrhnRdlg5fQz45gngl7XtHEUG6FObh3TihonhJGGkGAjaI5cDkaniMui3nq81WcUwY7cATRbxucMqrpssQJPNtbYAViNgMTavLYYzthkAW4N4XGcTYKkTl46owoDYIWJ4ca/DkwG7CbA2iMe01ouL9Ni13d7oWsxiG+1m13PXY6cdiBoApFwApIwBki8AkrIAla7jdhERUcAwsPQQ//q5FKUGC2LD1Lj+gn6eL5prgf89B+x4HXDYxG0pY8VAItWbDBZ7UUK03dswpVo8bndxOsUg0TJYWI2ez42nmoenao+Kr5X+KC7+cPqouOz+RHwuUwDxI4GU85tDTNww8VwQEVFQMLD0AIIg4LVNYu/K7IvTmyeHszcC218D/rcUsLqGewZcBlzxdyB5dHAa21VyuaumpZNDd002MUxU7XeFmIPi2lQl1tVIQ0nhzYv7uSpUXJQasQ4nxLVu+VymAKr2AqeKgFM/iuuGcqDiF3HZ9XZzW8ISxB6syFRA3w/Q9xfX7ueaSNblEBH5CQNLD7DpQBX2ldcjVKXAzdlpgNMB/LwG+OZJwHhS3CkhA7hiMTBo4rn1o6hUib0bccP89xkRScCgCc3PjaWuALNLXJcWi4GxoUJcTv3QTls1YmjRRgHaSNdj13P3Y41e7AVTasV1y0XapgMUId7/d3bYxcJrUzVgrhYfyxSALlossHavQzgBIRH1PgwsPYC7d2X6uP7Ql24CNi4CKnaLL0b0AybMBzL/AMg5LX9ARCSLy4jJ4nNBEIflDCWA4SRQdwIwuJa6E+I2c7VYI9NQLi5dJVcCIa4eIpXrKq2Wz0N0Ym2Qubo5oJyt6LqlkFBXeIkS1+qI5iu+3FeBKVSe2xQhYviRydtZXOHKYXPVN1nbrnly2MTP08UAobGALta1jgFC48SesTODmiCI75fqkFw1SQq1+N9JHdb1891TNFnFYdDGWiAyTSw4Z1E4EQAGlqD7+WQdth6pgVIuw5/CCoF354svqPXApX8Bxt3FfxEHm0wGhMaIS/L5be9jM4vDVI2nxULixjrPxxb3c2OL4l/Xj29Ti8Jg9xVZziaxV8fayRAitVUu9qK4w4CzSfzxM9eKa8EpFisbTGLg6mkUKrHdMnmL89II4CwXM2r0QESKuOhTPB+HJTYPDapCxeMHu4dSuirvoOuKvEPN0xEYTnhelafUivMjRQ90rQe5Hg8UvyPDDJ1DGFiC7LX/ir0rfx5SA/1/F4sbx94m9qroooPWLvKSSgeo0oCoNN+PIQjisI7dLC42k7i0fNzyuTr8jF6KWLHXpL0fMadTDEDmWjE8uUOMtd6zB8TdM9LyKjCHTWyf4HT9oLZ4LC1C+z007u3yELENpprm3iF3D5HdLH5Oe/MGAa6eJ1cdknRlmkFcKvd0fI7P7LkK0Yk1T2edP0gvnmuHtcVVacYzrlBrAGyu8+iwif8dHTbX0tTisb25N649qnBAFwUYTomhrXJP299NoQYi+4tLVJrYI9PysS4m+OHMF06nOPSqCu18rRudExhYguh4jQn//qUMcajDPVV/F/81fN7vgWue653/R0NdI5O5JuRTifUu3U0ud9XX9ND7UtnMzSEGaFHf4y6U1opDUy1Z68UfdqNrOfNxQ0VzEAJ877nqbq1mlh7SfLWfe2Zph12cB6n2KFB7GKg9Ii41h4G642KAqjkoLm0JCRUDjErXPHQHmecwnvtxiLb1JI8ej/XifmebssBiEM9veKI4lK1PcQ2v9hPXZ04VYLeI38tdTO8urK85JP43A8Twpm+n9ywiRQxm3d0D7WgSawdrj4pTSZw+Jhb+15eLtWjhCWLPnXsdluB6nOB5JWGTzXVFpPsfGQ3i37jNJA7vt5x7Sh0hPlaquve7dMTpEM995R7xf2MRSeKUEaGxPbIEgRPHBdGCz3fj/W1HsE7/LIZbfwbihgO3F/atMXminsBhb7+3yj2HT8sf4bYeK9Wtr0qTHoeJP67uUKUIEXuZFCrxsTyk+bFGL/7QKrrw70VHk6uGqkQML3UlwOnjzY/ry7rv3HUXbbQYMnRRze1tb6hPJu/chJUyORCVLv5/Z9yw5nXsULGH5kyCIP63NJaJPXnuteFUczgxnBCDly80keJ3spl8O4ZC1fx3FRYPxI8Qp1iIGy6uu3KblCabeEVk2U9A2c/iumJ3czhsSaYQg2d4kivEuJaIZOC861v/w6ELvPn9ZmAJkpoGKy5a8g3y8Q7uUq4T/8/uzm/FidGIiLrCbhGLwQ0l4g9Vy6E7j+E8QfxXtt189rBmMYj7uYfM2uyFiRB/6OrLxR4KQ4ueLrup7XZq9EDsMM9JIWOHisNaTVbxir32es+Mp8S2tSeyPxA3QvyM+jJxMZa135aWFGqxDVHprmWA+MNtMQD1Fc1XDNaXNz929+K1dSyVa+gxRCc+djo8hxObGjtuEyCGvviRriAzQmybs6lFTVwbE2Ra6sRgUrFHnCjzTCGh4uSiTod4jhoq2g+LciUwv6pba6c4020v8PbW4/itcxvuUq0TN1y7nGGFiLpHiAaIHSwuwSYI4g+9O2iYa8S5i2KHileGtddjoAgRb88RN7T945qqgKp94nBS1T6gcp+4Nle7ep9K2n6vRi8OfYQnNl8V2DKceHt1liCIdWENla7bjrS4sq8zPWmOJrEGytrQPGO34aR4P7jKPeK69ohYc3Z8s7j4QhMJJGWKs3knjRbX0QM9h38cTYCp0tX75A56peLaYQtqoTcDSxCYbU3Y9P0WvBPymrjhoj8BI6cEt1FERP4gk7nmI4oEEkZ173HD4sVlwKWer5mqXSFmrzg80zKchCe2PVzU1bboon2/UEKhbF1fljrOcx+bWazxaRlijKfEocqWdV5n1n6pwsRhsqQssdepoyElhbI5xPUwDCxB8Nm2A3jG8SzC5Y0Q0i6GbOLiYDeJiKjvCHVdOZd+cbBb0n1UOnGG8946y3k34EX8AdbU5EDCpr9iqPwUzOo4yH7/ZteK74iIiM4BDCwBtvfL/0OuYzPsUEAx7S3xcjgiIiI6KwaWABKOb8WIn58GAHw/4AGoB/ah7koiIiI/YmAJlPoK2D6cBSUcWO/MQeb1jwS7RURERL0GA0ugbFwIdWMFDjhTUHz+44gKU3f8HiIiIgLAwBIY9eVw7v4EAPBw09245bJuvLSPiIjoHMDAEgg/rILcacdO51CkZlyC1Ghdx+8hIiIiCQOLvzVZgR9WAQBWN12FazKSgtwgIiKi3oeBxd92fwqYqlAqROMr51ic3z8y2C0iIiLqdRhY/EkQgO0rAADvNl2B2IgwJER0863QiYiIzgEMLP50YjtQVowmuRofOH6L0amRwW4RERFRr8TA4k+u3pXtYRNxGhHIYmAhIiLyCQOLvxhOAnu+BAC8ZrkCAJCVqg9mi4iIiHotBhZ/2bkSEBywpV6E/xoTIJMBmf0ig90qIiKiXomBxR/sjUDRagDAntSbAABD4sMQpuZdmYmIiHzBwOIPv6wFGmsBfX8UOscAALLYu0JEROQzBpbuJgjANrHYFuPuwI8n6wEAozn/ChERkc8YWLrbsc1A5a9AiA7O0bfgp5N1ANjDQkRE1BUMLN3NdSkzsm7EUXMI6i1NUCvlGJYYHtx2ERER9WIMLN3p9DFg/3rx8bi7UFxSBwDISNEjRMFTTURE5Cv+inannf8ABCcw8LdA/PDm4SBOGEdERNQlDCzdxWYCdr0tPs6+GwDw04k6AAwsREREXeVTYFm+fDnS09Oh0WiQnZ2NHTt2nHX/ZcuWYdiwYdBqtUhNTcWDDz4Ii8Uivb548WLIZDKPZfjw4b40LXh++hCwGICoAcCQK2GxO7CnzAgAGM2CWyIioi7xeiazNWvWID8/HytWrEB2djaWLVuGvLw87N+/H/Hx8a32f//99zF37lysWrUKF110EQ4cOIBbb70VMpkMS5culfYbNWoUvv766+aGKXvRJGuCAGx/TXycfRcgl2PvydOwOwREh6qQGq0NbvuIiIh6Oa97WJYuXYo77rgDs2fPxsiRI7FixQrodDqsWrWqzf2///57XHzxxbjpppuQnp6OK6+8EtOnT2/VK6NUKpGYmCgtsbGxvn2jYDjyLVC9H1CFAaNnAGgxHNRPD5lMFsTGERER9X5eBRabzYaioiLk5uY2H0AuR25uLrZu3drmey666CIUFRVJAeXIkSNYv349Jk2a5LHfwYMHkZycjIEDB2LGjBkoKSlptx1WqxVGo9FjCaod/xDXo2cAmggAwE8nDQBYv0JERNQdvBp3qa6uhsPhQEJCgsf2hIQE7Nu3r8333HTTTaiursb48eMhCAKamppw9913429/+5u0T3Z2NlavXo1hw4ahrKwMjz32GC655BLs3r0b4eGt5y8pKCjAY4895k3T/evENnGdNU3aVOzqYRnNwEJERNRlfr9K6LvvvsNTTz2FV155Bbt27cKnn36KdevW4fHHH5f2ufrqq3HDDTcgMzMTeXl5WL9+Perq6vDRRx+1ecx58+bBYDBIy4kTJ/z9NdpnqgHMNeLjOLFQuM5sw9FqEwDOcEtERNQdvOphiY2NhUKhQEVFhcf2iooKJCYmtvmeBQsW4JZbbsHtt98OAMjIyIDJZMKdd96JRx99FHJ568wUGRmJoUOH4tChQ20eU61WQ61We9N0/6neL671/QFVKADgZ9dwUFqMDlGhqmC1jIiIqM/wqodFpVJhzJgxKCwslLY5nU4UFhYiJyenzfeYzeZWoUShUAAABEFo8z0NDQ04fPgwkpKSvGlecFS5AkvcUGkTh4OIiIi6l9fXDufn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUAgMmTJ2Pp0qU4//zzkZ2djUOHDmHBggWYPHmyFFweeughTJ48GWlpaSgtLcWiRYugUCgwffr0bvyqflJ9QFzHDpM2NV8hFBn49hAREfVBXgeWadOmoaqqCgsXLkR5eTlGjx6NDRs2SIW4JSUlHj0q8+fPh0wmw/z583Hq1CnExcVh8uTJePLJJ6V9Tp48ienTp6OmpgZxcXEYP348tm3bhri4uG74in7mDiyuHhZBEDglPxERUTeTCe2Ny/QiRqMRer0eBoMBERERgf3w5zMAQwkwewOQloMTtWZc8sy3UMpl2P1YHjQhisC2h4iIqJfw5veb9xLqCptJDCsAECv2sLh7V0YkRTCsEBERdRMGlq6oPiiudTFAaAyAljc81AepUURERH0PA0tXtFFwW8yCWyIiom7HwNIVZ1zS3ORw4pdT4hws5/ePDFKjiIiI+h4Glq5wTxrn6mE5UNEAi92JMLUSA2PDgtgwIiKivoWBpSvcNSyuHhb3cFBmPz3kct6hmYiIqLswsPjK0QTUHBYfu3pYfuIMt0RERH7BwOKr00cBpx0I0QERKQDACeOIiIj8hIHFV+6C29ghgFwOk7UJByrqAbCHhYiIqLsxsPjqjILbX04Z4BSAJL0GCRGaIDaMiIio72Fg8VWV5z2EeMNDIiIi/2Fg8dUZPSysXyEiIvIfBhZfCEKLS5rFwFJcUgeA9StERET+wMDiC2MpYGsAZAogagAqjRaUGiyQyYCMfryHEBERUXdjYPGFezgoeiCgVOGnk+J0/EPiwxCmVgaxYURERH0TA4svpIJb13DQidMAWHBLRETkLwwsvpAKbt1XCIk9LKN5w0MiIiK/YGDxxRk9LKWGRgDAoDje8JCIiMgfGFh8cUYPi9nqAADWrxAREfkJA4u3zLWAqUp87AosJlsTAECrUgSrVURERH0aA4u33POvRKQA6jAIgoBGm9jDEqpiDwsREZE/MLB464zhIJvDiSanAIA9LERERP7CwOIt912aXQW37voVANAxsBAREfkFA4u3ql1XCLkLbu1iYFEp5QhR8HQSERH5A39hvdWqh0UsuGXvChERkf8wsHjD3gjUlYiPXXdpNrPgloiIyO8YWLxRfRCAAGijgNBYAM2XNLOHhYiIyH8YWLzRsn5FJgPQXHTLwEJEROQ/DCzeOKPgFmguutVxSIiIiMhvGFi8cUbBLdBcdBuqZg8LERGRvzCweEPqYWkOLCZX0a2WPSxERER+w8DSWY4moOaQ+DiueUio0VV0G8oaFiIiIr9hYOmsuuOAwwYotYC+v7S5uYeFgYWIiMhfGFg6y12/EjsYkDefNqmGhUNCREREfsPA0lln3PTQzT1xnI5Ft0RERH7jU2BZvnw50tPTodFokJ2djR07dpx1/2XLlmHYsGHQarVITU3Fgw8+CIvF0qVjBlz1QXHdouAWaBFYQhhYiIiI/MXrwLJmzRrk5+dj0aJF2LVrF7KyspCXl4fKyso293///fcxd+5cLFq0CHv37sXKlSuxZs0a/O1vf/P5mEEhXdJ8Zg+La6ZbNYeEiIiI/MXrwLJ06VLccccdmD17NkaOHIkVK1ZAp9Nh1apVbe7//fff4+KLL8ZNN92E9PR0XHnllZg+fbpHD4q3xww4QWjzkmagueiWNSxERET+41VgsdlsKCoqQm5ubvMB5HLk5uZi69atbb7noosuQlFRkRRQjhw5gvXr12PSpEk+H9NqtcJoNHosflVfDliNgEwOxAzyeMnMewkRERH5nVfdAtXV1XA4HEhISPDYnpCQgH379rX5nptuugnV1dUYP348BEFAU1MT7r77bmlIyJdjFhQU4LHHHvOm6V3jLriNGgAo1R4vSTUsDCxERER+4/erhL777js89dRTeOWVV7Br1y58+umnWLduHR5//HGfjzlv3jwYDAZpOXHiRDe2uA1VruGguGGtXnLf/DCUNSxERER+49WvbGxsLBQKBSoqKjy2V1RUIDExsc33LFiwALfccgtuv/12AEBGRgZMJhPuvPNOPProoz4dU61WQ61Wt/maX0iXNA9p9ZLJNSTEieOIiIj8x6seFpVKhTFjxqCwsFDa5nQ6UVhYiJycnDbfYzabIZd7foxCIf64C4Lg0zEDTpo0zrOHRRAENLLoloiIyO+8/pXNz8/HrFmzMHbsWIwbNw7Lli2DyWTC7NmzAQAzZ85ESkoKCgoKAACTJ0/G0qVLcf755yM7OxuHDh3CggULMHnyZCm4dHTMoHPPwXLGkJDN4USTUwDAieOIiIj8yevAMm3aNFRVVWHhwoUoLy/H6NGjsWHDBqlotqSkxKNHZf78+ZDJZJg/fz5OnTqFuLg4TJ48GU8++WSnjxlUFgPQUC4+PmNIyF2/AnDiOCIiIn+SCYIgBLsRXWU0GqHX62EwGBAREdG9Bz+xE1iZC4QnAX/xvGrpVF0jLl7yDVRKOQ48cXX3fi4REVEf583vN+8l1JF27iEENN/4kJc0ExER+RcDS0ekKflbX9LMWW6JiIgCg4GlI9KU/G30sHCWWyIiooBgYOlI1dmGhDjLLRERUSAwsJyN3QLUHRcftzXLrd0dWDgkRERE5E/8pT0buxnImg4YTgBhrS+xdhfdhnIOFiIiIr9iYDkbXTRw7SvtvuwuutWyh4WIiMivOCTUBY2uottQ1rAQERH5FQNLF7h7WFjDQkRE5F8MLF3AieOIiIgCg4GlC8zuHhYW3RIREfkVA0sXSIGFNz4kIiLyKwaWLjC5Z7pVs4aFiIjInxhYusDMewkREREFBANLF/BeQkRERIHBwNIFUg0LAwsREZFfMbB0gfvmh6GsYSEiIvIrBpYucBfdatnDQkRE5FcMLD4SBAGNLLolIiIKCAYWH9kcTjQ5BQCcOI6IiMjfGFh85K5fAThxHBERkb8xsPjIbBcDi0oph1LB00hERORP/KX1EW98SEREFDgMLD4yseCWiIgoYBhYfMRZbomIiAKHgcVH7qJbBhYiIiL/Y2DxkbvoVschISIiIr9jYPGRu+g2lHOwEBER+R0Di4/cRbda9rAQERH5HQOLjxpdRbehrGEhIiLyOwYWH7l7WFjDQkRE5H8MLD7ixHFERESBw8DiI7O7h4VFt0RERH7HwOIjM2e6JSIiChgGFh+ZXEW3Wg4JERER+Z1PgWX58uVIT0+HRqNBdnY2duzY0e6+l19+OWQyWavlmmuukfa59dZbW71+1VVX+dK0gGEPCxERUeB4/Wu7Zs0a5OfnY8WKFcjOzsayZcuQl5eH/fv3Iz4+vtX+n376KWw2m/S8pqYGWVlZuOGGGzz2u+qqq/Dmm29Kz9VqtbdNCyjeS4iIiChwvO5hWbp0Ke644w7Mnj0bI0eOxIoVK6DT6bBq1ao294+OjkZiYqK0bNy4ETqdrlVgUavVHvtFRUX59o0ChPcSIiIiChyvAovNZkNRURFyc3ObDyCXIzc3F1u3bu3UMVauXIkbb7wRoaGhHtu/++47xMfHY9iwYbjnnntQU1PT7jGsViuMRqPHEmjSkJCaQ0JERET+5lVgqa6uhsPhQEJCgsf2hIQElJeXd/j+HTt2YPfu3bj99ts9tl911VV4++23UVhYiKeffhqbNm3C1VdfDYfD0eZxCgoKoNfrpSU1NdWbr9EtWHRLREQUOAHtHli5ciUyMjIwbtw4j+033nij9DgjIwOZmZkYNGgQvvvuO0ycOLHVcebNm4f8/HzpudFoDGhoEQQBjSy6JSIiChivelhiY2OhUChQUVHhsb2iogKJiYlnfa/JZMKHH36I2267rcPPGThwIGJjY3Ho0KE2X1er1YiIiPBYAsnmcKLJKQDgxHFERESB4FVgUalUGDNmDAoLC6VtTqcThYWFyMnJOet7165dC6vViptvvrnDzzl58iRqamqQlJTkTfMCxl1wCwC6EAYWIiIif/P6KqH8/Hy88cYbeOutt7B3717cc889MJlMmD17NgBg5syZmDdvXqv3rVy5Etdeey1iYmI8tjc0NOCvf/0rtm3bhmPHjqGwsBBTpkzB4MGDkZeX5+PX8i+zXQwsKqUcSgXn3iMiIvI3rwswpk2bhqqqKixcuBDl5eUYPXo0NmzYIBXilpSUQC73/BHfv38/Nm/ejP/85z+tjqdQKPDzzz/jrbfeQl1dHZKTk3HllVfi8ccf77FzsbhvfBjKglsiIqKAkAmCIAS7EV1lNBqh1+thMBgCUs9SfKIO1y7fgpRILbbMneD3zyMiIuqLvPn95niGDzjLLRERUWAxsPiAs9wSEREFFgOLD0xSDwvnYCEiIgoEBhYfSJPGcQ4WIiKigGBg8YHJFVi07GEhIiIKCAYWHzTaeFkzERFRIDGw+MDdw8IaFiIiosBgYPGBe+I4XiVEREQUGAwsPjC7e1hYdEtERBQQDCw+cAeWUA4JERERBQQDiw/c87BoOSREREQUEAwsPmAPCxERUWAxsPiA9xIiIiIKLAYWH/BeQkRERIHFwOIDaUhIzSEhIiKiQGBg8QGLbomIiAKLgcVLgiA03/yQRbdEREQBwcDiJZvDiSanAIATxxEREQUKA4uX3AW3AKALYWAhIiIKBAYWL5ntYmBRKeVQKnj6iIiIAoG/uF5y3/gwlAW3REREAcPA4iWT+8aHLLglIiIKGAYWL3GWWyIiosBjYPESZ7klIiIKPAYWL5mkHhYOCREREQUKA4uXpEnjOAcLERFRwDCweMlddKtlDwsREVHAMLB4iZc1ExERBR4Di5fcE8exhoWIiChwGFi85O5h4VVCREREgcPA4iWze+I4Ft0SEREFDAOLl9yBJZRDQkRERAHDwOIl9zwsWg4JERERBQwDi5fYw0JERBR4DCxeku4lxBoWIiKigPEpsCxfvhzp6enQaDTIzs7Gjh072t338ssvh0wma7Vcc8010j6CIGDhwoVISkqCVqtFbm4uDh486EvT/E66l1AIAwsREVGgeB1Y1qxZg/z8fCxatAi7du1CVlYW8vLyUFlZ2eb+n376KcrKyqRl9+7dUCgUuOGGG6R9nnnmGbz44otYsWIFtm/fjtDQUOTl5cFisfj+zfxEGhJSc0iIiIgoULwOLEuXLsUdd9yB2bNnY+TIkVixYgV0Oh1WrVrV5v7R0dFITEyUlo0bN0Kn00mBRRAELFu2DPPnz8eUKVOQmZmJt99+G6Wlpfj888+79OX8gUW3REREgedVYLHZbCgqKkJubm7zAeRy5ObmYuvWrZ06xsqVK3HjjTciNDQUAHD06FGUl5d7HFOv1yM7O7vdY1qtVhiNRo8lEARBYNEtERFREHgVWKqrq+FwOJCQkOCxPSEhAeXl5R2+f8eOHdi9ezduv/12aZv7fd4cs6CgAHq9XlpSU1O9+Ro+szmccDgFACy6JSIiCqSAXiW0cuVKZGRkYNy4cV06zrx582AwGKTlxIkT3dTCs3MX3AIsuiUiIgokrwJLbGwsFAoFKioqPLZXVFQgMTHxrO81mUz48MMPcdttt3lsd7/Pm2Oq1WpERER4LIHgvvGhSimHUsErwomIiALFq19dlUqFMWPGoLCwUNrmdDpRWFiInJycs7537dq1sFqtuPnmmz22DxgwAImJiR7HNBqN2L59e4fHDDT3jQ9DWXBLREQUUF5Xjubn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUe71u5ciWuvfZaxMTEeGyXyWR44IEH8MQTT2DIkCEYMGAAFixYgOTkZFx77bW+fzM/MLlvfMiCWyIiooDy+pd32rRpqKqqwsKFC1FeXo7Ro0djw4YNUtFsSUkJ5HLPjpv9+/dj8+bN+M9//tPmMR9++GGYTCbceeedqKurw/jx47FhwwZoNBofvpL/SLPcsoeFiIgooGSCIAjBbkRXGY1G6PV6GAwGv9azfL2nAre//QOyUiPxxZyL/fY5RERE5wJvfr9ZOeoF96RxvEKIiIgosBhYvNAoTcvPwEJERBRIDCxecBfdall0S0REFFAMLF7gZc1ERETBwcDiBffEcbysmYiIKLAYWLzg7mHhZc1ERESBxcDiBfedmnnjQyIiosBiYPGCO7CEckiIiIgooBhYvOCeh0XLISEiIqKAYmDxAntYiIiIgoOBxQvSvYRYw0JERBRQDCxeMFtdRbecmp+IiCigGFi8IA0JqTkkREREFEgMLF5g0S0REVFwMLB0kiAILLolIiIKEgaWTrI5nHA4BQAsuiUiIgo0BpZOchfcAiy6JSIiCjQGlk5y3/hQpZRDqeBpIyIiCiT+8naS+8aHoSy4JSIiCjgGlk4yuW98yIJbIiKigGNg6SRpllv2sBAREQUcA0snSbPcctI4IiKigGNg6ST3pHG8QoiIiCjwGFg6qVGalp+BhYiIKNAYWDqJRbdERETBw8DSSe7Lmll0S0REFHgMLJ3knjiOPSxERESBx8DSSexhISIiCh4Glk6SalhYdEtERBRwDCydJF0lxCEhIiKigGNg6ST3PCxaDgkREREFHANLJ5nZw0JERBQ0DCydJN1LiDUsREREAcfA0knSvYQ4NT8REVHAMbB0kjQkxJsfEhERBZxPgWX58uVIT0+HRqNBdnY2duzYcdb96+rqMGfOHCQlJUGtVmPo0KFYv3699PrixYshk8k8luHDh/vSNL+Rbn7IolsiIqKA87q7YM2aNcjPz8eKFSuQnZ2NZcuWIS8vD/v370d8fHyr/W02G6644grEx8fj448/RkpKCo4fP47IyEiP/UaNGoWvv/66uWHKntOTIQiC1MPCmW6JiIgCz+tf36VLl+KOO+7A7NmzAQArVqzAunXrsGrVKsydO7fV/qtWrUJtbS2+//57hISEAADS09NbN0SpRGJiorfNCQibwwmHUwDAolsiIqJg8GpIyGazoaioCLm5uc0HkMuRm5uLrVu3tvmeL7/8Ejk5OZgzZw4SEhJw3nnn4amnnoLD4fDY7+DBg0hOTsbAgQMxY8YMlJSUtNsOq9UKo9HosfiTu+AWYNEtERFRMHgVWKqrq+FwOJCQkOCxPSEhAeXl5W2+58iRI/j444/hcDiwfv16LFiwAM899xyeeOIJaZ/s7GysXr0aGzZswKuvvoqjR4/ikksuQX19fZvHLCgogF6vl5bU1FRvvobX3PUrKqUcSgXrlImIiALN7wUZTqcT8fHxeP3116FQKDBmzBicOnUKzz77LBYtWgQAuPrqq6X9MzMzkZ2djbS0NHz00Ue47bbbWh1z3rx5yM/Pl54bjUa/hpbmafnZu0JERBQMXgWW2NhYKBQKVFRUeGyvqKhot/4kKSkJISEhUCiaf+xHjBiB8vJy2Gw2qFSqVu+JjIzE0KFDcejQoTaPqVaroVarvWl6l5hYcEtERBRUXo1vqFQqjBkzBoWFhdI2p9OJwsJC5OTktPmeiy++GIcOHYLT6ZS2HThwAElJSW2GFQBoaGjA4cOHkZSU5E3z/MbMS5qJiIiCyuuCjPz8fLzxxht46623sHfvXtxzzz0wmUzSVUMzZ87EvHnzpP3vuece1NbW4v7778eBAwewbt06PPXUU5gzZ460z0MPPYRNmzbh2LFj+P777zF16lQoFApMnz69G75i10mz3HLSOCIioqDw+hd42rRpqKqqwsKFC1FeXo7Ro0djw4YNUiFuSUkJ5PLmHJSamoqvvvoKDz74IDIzM5GSkoL7778fjzzyiLTPyZMnMX36dNTU1CAuLg7jx4/Htm3bEBcX1w1fseukSeN4hRARkQeHwwG73R7sZlAPdmZZiK9kgiAI3dCeoDIajdDr9TAYDIiIiOj243+4owRzP/0FuSPi8Y9ZF3b78YmIehtBEFBeXo66urpgN4V6gcjISCQmJkImk3ls9+b3m2McncCiWyIiT+6wEh8fD51O1+qHiAhwzRRvNqOyshIAulSbyl/gTjBbWXRLROTmcDiksBITExPs5lAPp9VqAQCVlZWIj4/3eXiIs6B1gtnOHhYiIjd3zYpOpwtyS6i3cP+tdKXeiYGlE9jDQkTUGoeBqLO642+FgaUTpBoW3viQiIgoKBhYOqF5an4OCREREQUDA0snuOdh0XJIiIiIKCgYWDrBzB4WIiLyA06613kMLJ0g3UuINSxERL3ahg0bMH78eERGRiImJga/+93vcPjwYel198zr0dHRCA0NxdixY7F9+3bp9X/+85+48MILodFoEBsbi6lTp0qvyWQyfP755x6fFxkZidWrVwMAjh07BplMhjVr1uCyyy6DRqPBe++9h5qaGkyfPh0pKSnQ6XTIyMjABx984HEcp9OJZ555BoMHD4ZarUb//v3x5JNPAgAmTJiA++67z2P/qqoqqFQqj3v/9XbsMugE6V5CnJqfiKgVQRDQ6Jr+IdC0IQqvrkAxmUzIz89HZmYmGhoasHDhQkydOhXFxcUwm8247LLLkJKSgi+//BKJiYnYtWuXdPPedevWYerUqXj00Ufx9ttvw2azYf369V63ee7cuXjuuedw/vnnQ6PRwGKxYMyYMXjkkUcQERGBdevW4ZZbbsGgQYMwbtw4AMC8efPwxhtv4Pnnn8f48eNRVlaGffv2AQBuv/123HfffXjuueegVqsBAO+++y5SUlIwYcIEr9vXUzGwdII0JMSbHxIRtdJod2Dkwq+C8tl7/p7n1RxZ119/vcfzVatWIS4uDnv27MH333+Pqqoq7Ny5E9HR0QCAwYMHS/s++eSTuPHGG/HYY49J27Kysrxu8wMPPIDrrrvOY9tDDz0kPf7Tn/6Er776Ch999BHGjRuH+vp6vPDCC3j55Zcxa9YsAMCgQYMwfvx4AMB1112H++67D1988QX+8Ic/AABWr16NW2+9tU9des4hoU6Qbn7Iolsiol7t4MGDmD59OgYOHIiIiAikp6cDEG/cW1xcjPPPP18KK2cqLi7GxIkTu9yGsWPHejx3OBx4/PHHkZGRgejoaISFheGrr75CSUkJAGDv3r2wWq3tfrZGo8Ett9yCVatWAQB27dqF3bt349Zbb+1yW3sSdhl0QBAEqYeFM90SEbWmDVFgz9/zgvbZ3pg8eTLS0tLwxhtvIDk5GU6nE+eddx5sNps0hXy7n9XB6zKZDGfeT7itotrQ0FCP588++yxeeOEFLFu2DBkZGQgNDcUDDzwAm83Wqc8FxGGh0aNH4+TJk3jzzTcxYcIEpKWldfi+3oQ9LB2wOZxwOMU/QBbdEhG1JpPJoFMpg7J4M+RRU1OD/fv3Y/78+Zg4cSJGjBiB06dPS69nZmaiuLgYtbW1bb4/MzPzrEWscXFxKCsrk54fPHgQZrO5w3Zt2bIFU6ZMwc0334ysrCwMHDgQBw4ckF4fMmQItFrtWT87IyMDY8eOxRtvvIH3338ff/zjHzv83N6GgaUD7oJbgEW3RES9WVRUFGJiYvD666/j0KFD+Oabb5Cfny+9Pn36dCQmJuLaa6/Fli1bcOTIEXzyySfYunUrAGDRokX44IMPsGjRIuzduxe//PILnn76aen9EyZMwMsvv4wff/wRP/zwA+6++26EhIR02K4hQ4Zg48aN+P7777F3717cddddqKiokF7XaDR45JFH8PDDD+Ptt9/G4cOHsW3bNqxcudLjOLfffjuWLFkCQRA8rl7qKxhYOuCuX1Ep5VAqeLqIiHoruVyODz/8EEVFRTjvvPPw4IMP4tlnn5VeV6lU+M9//oP4+HhMmjQJGRkZWLJkiXR34csvvxxr167Fl19+idGjR2PChAnYsWOH9P7nnnsOqampuOSSS3DTTTfhoYce6tQNIufPn48LLrgAeXl5uPzyy6XQ1NKCBQvwl7/8BQsXLsSIESMwbdo0VFZWeuwzffp0KJVKTJ8+HRqNpgtnqmeSCWcOuPVCRqMRer0eBoMBERER3XrsgxX1uOL5/yJKF4IfF17ZrccmIuqNLBYLjh49igEDBvTJH8be6tixYxg0aBB27tyJCy64INjN8dDe34w3v9+sIu2AiQW3RETUg9ntdtTU1GD+/Pn4zW9+0+PCSnfhGEcHzFZe0kxERD3Xli1bkJSUhJ07d2LFihXBbo7fsNugA9IlzZw0joiIeqDLL7+81eXUfRF7WDogTRrHK4SIiIiChoGlA43StPwMLERERMHCwNIBFt0SEREFHwNLB1h0S0REFHwMLB0w29nDQkREFGwMLB1w97CwhoWIiCh4GFg64K5h0XJIiIjonJeeno5ly5YFuxnnJAaWDkhXCXFIiIiIKGgYWDrgnoeFPSxERNSbORwOOJ3OYDfDZwwsHTBb2cNCRNQXvP7660hOTm71oz1lyhT88Y9/xOHDhzFlyhQkJCQgLCwMF154Ib7++mufP2/p0qXIyMhAaGgoUlNTce+996KhocFjny1btuDyyy+HTqdDVFQU8vLycPr0aQCA0+nEM888g8GDB0OtVqN///548sknAQDfffcdZDIZ6urqpGMVFxdDJpPh2LFjAIDVq1cjMjISX375JUaOHAm1Wo2SkhLs3LkTV1xxBWJjY6HX63HZZZdh165dHu2qq6vDXXfdhYSEBGg0Gpx33nn417/+BZPJhIiICHz88cce+3/++ecIDQ1FfX29z+erIwwsHTDbXZc1s+iWiKhtggDYTMFZvJiS/oYbbkBNTQ2+/fZbaVttbS02bNiAGTNmoKGhAZMmTUJhYSF+/PFHXHXVVZg8eTJKSkp8Oi1yuRwvvvgifv31V7z11lv45ptv8PDDD0uvFxcXY+LEiRg5ciS2bt2KzZs3Y/LkyXA4xH8oz5s3D0uWLMGCBQuwZ88evP/++0hISPCqDWazGU8//TT+8Y9/4Ndff0V8fDzq6+sxa9YsbN68Gdu2bcOQIUMwadIkKWw4nU5cffXV2LJlC959913s2bMHS5YsgUKhQGhoKG688Ua8+eabHp/z5ptv4ve//z3Cw8N9OledwW6DDrh7WDg1PxFRO+xm4Knk4Hz230oBVWindo2KisLVV1+N999/HxMnTgQAfPzxx4iNjcVvf/tbyOVyZGVlSfs//vjj+Oyzz/Dll1/ivvvu87ppDzzwgPQ4PT0dTzzxBO6++2688sorAIBnnnkGY8eOlZ4DwKhRowAA9fX1eOGFF/Dyyy9j1qxZAIBBgwZh/PjxXrXBbrfjlVde8fheEyZM8Njn9ddfR2RkJDZt2oTf/e53+Prrr7Fjxw7s3bsXQ4cOBQAMHDhQ2v/222/HRRddhLKyMiQlJaGyshLr16/vUm9UZ7CHpQNmaWp+Zjsiot5uxowZ+OSTT2C1WgEA7733Hm688UbI5XI0NDTgoYcewogRIxAZGYmwsDDs3bvX5x6Wr7/+GhMnTkRKSgrCw8Nxyy23oKamBmazGUBzD0tb9u7dC6vV2u7rnaVSqZCZmemxraKiAnfccQeGDBkCvV6PiIgINDQ0SN+zuLgY/fr1k8LKmcaNG4dRo0bhrbfeAgC8++67SEtLw6WXXtqltnaEv8IdkG5+yKJbIqK2hejEno5gfbYXJk+eDEEQsG7dOlx44YX43//+h+effx4A8NBDD2Hjxo34v//7PwwePBharRa///3vYbPZvG7WsWPH8Lvf/Q733HMPnnzySURHR2Pz5s247bbbYLPZoNPpoNVq233/2V4DxOEmAB53abbb7W0eRyaTeWybNWsWampq8MILLyAtLQ1qtRo5OTnS9+zoswGxl2X58uWYO3cu3nzzTcyePbvV53Q3n3pYli9fjvT0dGg0GmRnZ2PHjh1n3b+urg5z5sxBUlIS1Go1hg4divXr13fpmIEgCILUw8KZbomI2iGTicMywVi8/JHUaDS47rrr8N577+GDDz7AsGHDcMEFFwAQC2BvvfVWTJ06FRkZGUhMTJQKWL1VVFQEp9OJ5557Dr/5zW8wdOhQlJZ6hrrMzEwUFha2+f4hQ4ZAq9W2+3pcXBwAoKysTNpWXFzcqbZt2bIFf/7znzFp0iSMGjUKarUa1dXVHu06efIkDhw40O4xbr75Zhw/fhwvvvgi9uzZIw1b+ZPXgWXNmjXIz8/HokWLsGvXLmRlZSEvLw+VlZVt7m+z2XDFFVfg2LFj+Pjjj7F//3688cYbSElJ8fmYgWJzOOFwiumVRbdERH3DjBkzsG7dOqxatQozZsyQtg8ZMgSffvopiouL8dNPP+Gmm27y+TLgwYMHw26346WXXsKRI0fwzjvvYMWKFR77zJs3Dzt37sS9996Ln3/+Gfv27cOrr76K6upqaDQaPPLII3j44Yfx9ttv4/Dhw9i2bRtWrlwpHT81NRWLFy/GwYMHsW7dOjz33HOdatuQIUPwzjvvYO/evdi+fTtmzJjh0aty2WWX4dJLL8X111+PjRs34ujRo/j3v/+NDRs2SPtERUXhuuuuw1//+ldceeWV6Nevn0/nySuCl8aNGyfMmTNHeu5wOITk5GShoKCgzf1fffVVYeDAgYLNZuu2Y57JYDAIAASDwdDJb9E5jbYm4fmN+4Un1+0R7E2Obj02EVFv1djYKOzZs0dobGwMdlN84nA4hKSkJAGAcPjwYWn70aNHhd/+9reCVqsVUlNThZdfflm47LLLhPvvv1/aJy0tTXj++ec79TlLly4VkpKSBK1WK+Tl5Qlvv/22AEA4ffq0tM93330nXHTRRYJarRYiIyOFvLw86XWHwyE88cQTQlpamhASEiL0799feOqpp6T3bt68WcjIyBA0Go1wySWXCGvXrhUACEePHhUEQRDefPNNQa/Xt2rXrl27hLFjxwoajUYYMmSIsHbt2lbfq6amRpg9e7YQExMjaDQa4bzzzhP+9a9/eRynsLBQACB89NFHHZ6L9v5mvPn9lglC568Jc4+7ffzxx7j22mul7bNmzUJdXR2++OKLVu+ZNGkSoqOjodPp8MUXXyAuLg433XQTHnnkESgUCp+OeSaj0Qi9Xg+DwYCIiIjOfh0iIvKBxWLB0aNHMWDAAGg0mmA3h4LknXfewYMPPojS0lKoVKqz7tve34w3v99eFWZUV1fD4XC0ug48ISEB+/bta/M9R44cwTfffIMZM2Zg/fr1OHToEO69917Y7XYsWrTIp2NarVapwhsQvzARERH5n9lsRllZGZYsWYK77rqrw7DSXfx+WbPT6UR8fDxef/11jBkzBtOmTcOjjz7aaizPGwUFBdDr9dKSmprajS0mIiI6u/feew9hYWFtLu65VPqqZ555BsOHD0diYiLmzZsXsM/1qoclNjYWCoUCFRUVHtsrKiqQmJjY5nuSkpIQEhIChaK5aHXEiBEoLy+HzWbz6Zjz5s1Dfn6+9NxoNDK0EBFRwPy///f/kJ2d3eZrISEhAW5NYC1evBiLFy8O+Od61cOiUqkwZswYj8usnE4nCgsLkZOT0+Z7Lr74Yhw6dMij0vrAgQNISkqCSqXy6ZhqtRoREREeCxERUaCEh4dj8ODBbS5paWnBbl6f5PWQUH5+Pt544w289dZb2Lt3L+655x6YTCbMnj0bADBz5kyPLqJ77rkHtbW1uP/++3HgwAGsW7cOTz31FObMmdPpYxIREdG5zevZ0KZNm4aqqiosXLgQ5eXlGD16NDZs2CAVzZaUlEgz8AFAamoqvvrqKzz44IPIzMxESkoK7r//fjzyyCOdPiYREfU8vs5RQuee7vhb8eqy5p6KlzUTEQWO0+nEwYMHoVAoEBcXB5VK5fdp2al3EgQBNpsNVVVVcDgcGDJkiEenht8uayYiIpLL5RgwYADKyspaTTdP1BadTof+/ft7hBVvMbAQEZHXVCoV+vfvj6amJjgcjmA3h3owhUIBpVLZ5V44BhYiIvKJTCZDSEhIn7+Ml3oGv08cR0RERNRVDCxERETU4zGwEBERUY/XJ2pY3Fdm8yaIREREvYf7d7szM6z0icBSX18PALyfEBERUS9UX18PvV5/1n36xMRxTqcTpaWlCA8P7/bJi9w3Vjxx4gQnpQsAnu/A4vkOLJ7vwOL5DixfzrcgCKivr0dycnKHc7T0iR4WuVyOfv36+fUzeJPFwOL5Diye78Di+Q4snu/A8vZ8d9Sz4saiWyIiIurxGFiIiIiox2Ng6YBarcaiRYugVquD3ZRzAs93YPF8BxbPd2DxfAeWv893nyi6JSIior6NPSxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9XgMLB1Yvnw50tPTodFokJ2djR07dgS7SX3Cf//7X0yePBnJycmQyWT4/PPPPV4XBAELFy5EUlIStFotcnNzcfDgweA0tpcrKCjAhRdeiPDwcMTHx+Paa6/F/v37PfaxWCyYM2cOYmJiEBYWhuuvvx4VFRVBanHv9uqrryIzM1OaPCsnJwf//ve/pdd5rv1ryZIlkMlkeOCBB6RtPOfdZ/HixZDJZB7L8OHDpdf9ea4ZWM5izZo1yM/Px6JFi7Br1y5kZWUhLy8PlZWVwW5ar2cymZCVlYXly5e3+fozzzyDF198EStWrMD27dsRGhqKvLw8WCyWALe099u0aRPmzJmDbdu2YePGjbDb7bjyyithMpmkfR588EH885//xNq1a7Fp0yaUlpbiuuuuC2Kre69+/fphyZIlKCoqwg8//IAJEyZgypQp+PXXXwHwXPvTzp078dprryEzM9NjO8959xo1ahTKysqkZfPmzdJrfj3XArVr3Lhxwpw5c6TnDodDSE5OFgoKCoLYqr4HgPDZZ59Jz51Op5CYmCg8++yz0ra6ujpBrVYLH3zwQRBa2LdUVlYKAIRNmzYJgiCe25CQEGHt2rXSPnv37hUACFu3bg1WM/uUqKgo4R//+AfPtR/V19cLQ4YMETZu3Chcdtllwv333y8IAv++u9uiRYuErKysNl/z97lmD0s7bDYbioqKkJubK22Ty+XIzc3F1q1bg9iyvu/o0aMoLy/3OPd6vR7Z2dk8993AYDAAAKKjowEARUVFsNvtHud7+PDh6N+/P893FzkcDnz44YcwmUzIycnhufajOXPm4JprrvE4twD/vv3h4MGDSE5OxsCBAzFjxgyUlJQA8P+57hM3P/SH6upqOBwOJCQkeGxPSEjAvn37gtSqc0N5eTkAtHnu3a+Rb5xOJx544AFcfPHFOO+88wCI51ulUiEyMtJjX55v3/3yyy/IycmBxWJBWFgYPvvsM4wcORLFxcU8137w4YcfYteuXdi5c2er1/j33b2ys7OxevVqDBs2DGVlZXjsscdwySWXYPfu3X4/1wwsROeQOXPmYPfu3R5jztT9hg0bhuLiYhgMBnz88ceYNWsWNm3aFOxm9UknTpzA/fffj40bN0Kj0QS7OX3e1VdfLT3OzMxEdnY20tLS8NFHH0Gr1fr1szkk1I7Y2FgoFIpW1c0VFRVITEwMUqvODe7zy3Pfve677z7861//wrfffot+/fpJ2xMTE2Gz2VBXV+exP8+371QqFQYPHowxY8agoKAAWVlZeOGFF3iu/aCoqAiVlZW44IILoFQqoVQqsWnTJrz44otQKpVISEjgOfejyMhIDB06FIcOHfL73zcDSztUKhXGjBmDwsJCaZvT6URhYSFycnKC2LK+b8CAAUhMTPQ490ajEdu3b+e594EgCLjvvvvw2Wef4ZtvvsGAAQM8Xh8zZgxCQkI8zvf+/ftRUlLC891NnE4nrFYrz7UfTJw4Eb/88guKi4ulZezYsZgxY4b0mOfcfxoaGnD48GEkJSX5/++7y2W7fdiHH34oqNVqYfXq1cKePXuEO++8U4iMjBTKy8uD3bRer76+Xvjxxx+FH3/8UQAgLF26VPjxxx+F48ePC4IgCEuWLBEiIyOFL774Qvj555+FKVOmCAMGDBAaGxuD3PLe55577hH0er3w3XffCWVlZdJiNpulfe6++26hf//+wjfffCP88MMPQk5OjpCTkxPEVvdec+fOFTZt2iQcPXpU+Pnnn4W5c+cKMplM+M9//iMIAs91ILS8SkgQeM6701/+8hfhu+++E44ePSps2bJFyM3NFWJjY4XKykpBEPx7rhlYOvDSSy8J/fv3F1QqlTBu3Dhh27ZtwW5Sn/Dtt98KAFots2bNEgRBvLR5wYIFQkJCgqBWq4WJEycK+/fvD26je6m2zjMA4c0335T2aWxsFO69914hKipK0Ol0wtSpU4WysrLgNboX++Mf/yikpaUJKpVKiIuLEyZOnCiFFUHguQ6EMwMLz3n3mTZtmpCUlCSoVCohJSVFmDZtmnDo0CHpdX+ea5kgCELX+2mIiIiI/Ic1LERERNTjMbAQERFRj8fAQkRERD0eAwsRERH1eAwsRERE1OMxsBAREVGPx8BCREREPR4DCxEREfV4DCxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9Xj/HwN7ZhH5PrzQAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABTvklEQVR4nO3deXwTdf4/8FeO5uqR3iel5b5si4J0q3gsVKu4/BBdFxEFWW9xV+26CiuX61HUr4gHirog3iLeu7C4WJVdkMtiVeQ+C/RuadImzdFkfn9MMm1oS5u0Sdryej4e85hkMpl8MnY3Lz6f93xGJgiCACIiIqIeTB7sBhARERF1hIGFiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHUwa7Ad3B6XSitLQU4eHhkMlkwW4OERERdYIgCKivr0dycjLk8rP3ofSJwFJaWorU1NRgN4OIiIh8cOLECfTr1++s+/SJwBIeHg5A/MIRERFBbg0RERF1htFoRGpqqvQ7fjZ9IrC4h4EiIiIYWIiIiHqZzpRzsOiWiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHY2AhIiKiHo+BhYiIiHo8BhYiIiLq8RhYiIiIqMdjYCEiIqIer0/c/JCIiIi6RhAEmG0O1JpsqDHZcNq1rjVZUWOyockhYMHvRgatfQwsREREfZQgCKgz21HdYEVVgxVV9VZUN9hQ3WBFdb1VXDfYUNMghhJrk7PdY6kUcsy/ZkSn7qzsDwwsREREvUyDtQlV9dYWiwXVDTbxcUPz9hqTFXaH4NWx1Uo5YkJViA5TITpULT52LQ6nAKWCgYWIiOic5HQKqLc2wdhoh6HRjlqTGD4q662orLegst6KKmPzY7PN4dXx9doQxIapEBumRly4WlrHhakRG+4ZTHQqRdB6Uc6GgYWIiMgPBEFAVYMVp0434uTpRpyqa8TJ02bUmmwwuIKJsbEJhkY76i12OL3rCIFOpUB8uCt4uMNHWIvnrmASE6aCWqnwz5cMIAYWIiIiLwiC2BtS0yAWpIo1IGIdSKnBFU5cAeVsNSFtUSvl0GtDEKkLQXy4RgwkEWrpcXy4GvER4uNQ9bn1E35ufVsiIqIWHE4BNQ1W1Ll6POrMdtSZm3tA6szi+rTZJl490yCubY7OBRG5DEiM0CAlSot+UTqkRGoRF66GXhsCvTYEEVqlax2CCE0INCG9vyfEXxhYiIioz3I6BVTWW3HytBknTptxslbsATlZZ8aJ2kaU1jWiyduxGJdQlQIxriGXGFcNSFKkBimRWqREaZEapUOiXoMQBac86w4MLERE1GsIggCjpQnVDVbUmmwdLlX11g57Q+QySD0eep1KHJJxDctI27UhUj1ITJgYTtgbElgMLEREFFROp4C6RrvrqhiLa64QK2oabNKcITUmq6tOpPPDMW4KuQxJeg1So3To5xqa6RelRWq0uE6I0EAh73lXxZAnBhYiIupW7l6QOrMNp81i/Ued2YbTJrE+pKrBikpjy4nMvJ8rJEytREyYClE6FWJCVYgKVUmX5bofR4WqEBemRpJeAyWHZXo9BhYiIuoUk7UJlfVWVBgtqDCKPSHi4+aekTqzHXWNdjh8qAuJdgWM2HBxHRPWfFmuew4RDsecuxhYiIjOcXaHE1X1VpQbLag0WlBusKDcaBUfu5ZKoxUN1iavjqtTKRClUyFSF+KxbjlvSHyE+DgmVA2Vkr0g1D4GFiKiPkIQBNSYbCg3WFBa14hyowXGRjvqrU1osDShwbVu+bzeIvaICJ3sEAlVKZAQoUG8a26QhAi167kGsWGuIRlXOOkLk5VRz8HAQkTUgwmCgAZrkzQfiHtda7KizCD2hpQaGlFmsKDMYIHNy4nK3JRyGRIimgNIQoQGiXoNEl3hxL0t7BybrIx6Dv7lEREFiDt8nDbZUWOy4rS5eSKyWrMNtQ02aYKyukY7DK5w4s08ITIZpELTRL0G0aEqhKqUCNMoEaZWIlyjRJg6RHoeplYi2lWkKueVMtSD+RRYli9fjmeffRbl5eXIysrCSy+9hHHjxrW5r91uR0FBAd566y2cOnUKw4YNw9NPP42rrrpK2mfx4sV47LHHPN43bNgw7Nu3z5fmERH5hSAIMNkcMDbaYbTYUW9pkh4bG8XhFeMZ28R183ZfJylTKeWI0oUgUquCXifOEyKGEi2SIzVI0muRpBd7QVgLQn2R14FlzZo1yM/Px4oVK5CdnY1ly5YhLy8P+/fvR3x8fKv958+fj3fffRdvvPEGhg8fjq+++gpTp07F999/j/PPP1/ab9SoUfj666+bG6Zk5w8R+YcgCGi0O6SaDrFXQxxmabU223HadbM6X25Q1xZtiALRZ16Cq1MhRqoBCUGkqw4kUiuueVUMnetkgtDZUitRdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33XcBiD0sn3/+OYqLi336EkajEXq9HgaDARERET4dg4h6J0EQUGuyocJoRUW9BRUGi/S4pkG8sqXB6oDJ2gSTK6CYbE1dCh4hChkiNO77vygRoQ1BuEbZapv4vOV2ccZUrYrhgwjw7vfbq24Mm82GoqIizJs3T9oml8uRm5uLrVu3tvkeq9UKjUbjsU2r1WLz5s0e2w4ePIjk5GRoNBrk5OSgoKAA/fv3b/eYVqtVem40Gr35GkTUw1mbHB43mmu51JjEO+SKc4BYOzX1entkMiBMpUTUGT0d0aEhiA5VS2uxxyNECh5qpRwyGes9iALJq8BSXV0Nh8OBhIQEj+0JCQnt1pvk5eVh6dKluPTSSzFo0CAUFhbi008/hcPhkPbJzs7G6tWrMWzYMJSVleGxxx7DJZdcgt27dyM8PLzVMQsKClrVvBBRz+Ce5dQ9g2nLdU2DDSZbEyx2BxrtDljsTjTaHLDYHdI293ZvxYapEB8uFpq6r3SJDVMjXKNEqEqJUFeBaaha4VoroVMpGDyIegm/F4q88MILuOOOOzB8+HDIZDIMGjQIs2fPxqpVq6R9rr76aulxZmYmsrOzkZaWho8++gi33XZbq2POmzcP+fn50nOj0YjU1FT/fhGic4ggCLA5nLA2OcUgYXOgzjXFuqFRrOmoc11iW2cWH582ifd9qWqw+nxpbUtKucyz1yOseer1mFBx1tMEV5FpXBgnHSPq67wKLLGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwWiwU1NTVITk7G3LlzMXDgwHY/JzIyEkOHDsWhQ4fafF2tVkOtVnvTdKJzliAIqDPbUWpoRGmdBWUe60bUme1SMLE2OWFtEtfeVbe1Fq5RuqZZF2c0jQtXIzZMhTC1EpoQBbQqBdRKca1RyqFVKaANUUATopBqP9j7QURuXgUWlUqFMWPGoLCwENdeey0Asei2sLAQ991331nfq9FokJKSArvdjk8++QR/+MMf2t23oaEBhw8fxi233OJN84j6PKdTQK3Zhqp6KwyNnpfLtryMtt4izt9RWW9FWZ0FjXZHxwc/C51KgUhtCPQ6lVTPEalTIVIrTrXuvsxWDCViOOFVLUTUnbweEsrPz8esWbMwduxYjBs3DsuWLYPJZMLs2bMBADNnzkRKSgoKCgoAANu3b8epU6cwevRonDp1CosXL4bT6cTDDz8sHfOhhx7C5MmTkZaWhtLSUixatAgKhQLTp0/vpq9J1LNZmxyoabBJtR6V9eLdbCvrLa7CUgsq68XXfJ3HIzZMhaQWc3a41zFh4o3k1Eo51EpxrQlRQB0ih1oph0rBAlMiCj6vA8u0adNQVVWFhQsXory8HKNHj8aGDRukQtySkhLI5c1jyRaLBfPnz8eRI0cQFhaGSZMm4Z133kFkZKS0z8mTJzF9+nTU1NQgLi4O48ePx7Zt2xAXF9f1b0gURE0OJ8qNFpw83YhTpxtRZmiU6jzcxajV9VYYLd7dVM49V4d4OW3bl9GGa5SIC1cjJVKLhAgNezyIqFfzeh6WnojzsFCwmKxN4t1sDRacqhNDycnTjTh52oyTp8Wbzzk62SOilMsQG6ZGbLh4tUt8uBrxEa6163FChDjkEqJggSkR9X5+m4eF6FxisTtw8nQjTpw2o6zOgnKDGEDKDBZUuNb1negZCVHIkBKpRb8oHZL0GqnOI9ZVhBrveq7XhnDohYioHQwsdM5yOAWUGy0oqTHjxGkzTtaaceJ0I0pqzThRa0ZlvbXjgwAIUyuRqNcgSa9Bvygd+kVpWyw6xIWpeVM5IqIuYmChPs1id+BErRnHa8w4XmtGSY3JtRaHbDqaITVUpUBqtE6sA9FrkBQhTkzmDigJERqEa0IC9G2IiM5dDCzUJzidAo7XmrGn1IhfSw3YU2bE/vJ6lBksZ31fiEIm9YqkRuuQGqVDarTWtdYhSsdhGiKinoCBhXoda5MDB8obsKfMgF9LjdhTasTeMiNMtrbnGglTK9E/Wof0WB36R4ciLUaHtGgd+sfokKTXQsHhGiKiHo+BhXo0u8OJgxUN+OVUHX46acAvJw3YV26E3dH6yhu1Uo7hieEYmRyBkcl6jEgMx4DYUESHqthLQkTUyzGwUI8hCAKO15ixq+Q0fj5pwM8n6/BrqRHWNu5LE6kLwajkCIxK1mNkUgRGJkdgYGwolLzcl4ioT2JgoaCqabBiy+EabDlYjc2HqnGqrrHVPuFqJTL66ZHRT4+sfpHISNGjX5SWvSZEROcQBhYKqEabAzuP1WLzoWpsPliNPWVGj9dDFDJk9YtEZr9IZKXqkZGiR3pMKC8LJiI6xzGwkN8drTahcG8FvtlXiR+OnW51KfGIpAiMHxyDiwfHYtyAaOhU/LMkIiJP/GWgbmd3OPHDsdP4Zl8FCvdW4ki1yeP1ZL0G44fE4uLBsbhoUCziwtVBaikREfUWDCzULU6bbNh0oApf763ApgNVHlPWhyhkyB4QgwnD43HZsDgMjA1l/QkREXmFgYV8Zmty4pt9Ffi46CS+3V/lcZO/6FAVLh8Wh9wRCbhkSCxngyUioi5hYCGv7Sk1Ym3RCXxRXIpak03aPjwxHBOGx2PiiASMTo3khGxERNRtGFioU06bbPii+BTWFp3Er6XNV/bEhatx3QUpuGFMPwyODw9iC4mIqC9jYKF2CYKAbUdq8c62Y/h6T6V0dU+IQobcEQm4YWw/XDokjpO1ERGR3zGwUCtNDif+vbscb/zvCH4+aZC2j0qOwO/H9MOU0SmIDlUFsYVERHSuYWAhidnWhI92nsDKLUdxolaccVatlOP6Mf0wI7s/RiXrg9xCIiI6VzGwEKrqrXjr+2N4Z9txGBrtAIAoXQhm5qRjZk4aYsI4TwoREQUXA8s57HiNCa9+dxif/ngKNtcNBtNidLj9koH4/QX9oFUpgtxCIiIiEQPLOajeYsfL3x7Cqs1HYXeIc6ec3z8Sd106EFeMTOTlyERE1OMwsJxDnE4BHxedxDNf7Ud1gxUAcOnQOPx5wmCMTY8OcuuIiIjax8ByjvjhWC0e++ce/HJKvOpnYGwoFvxuJH47PD7ILSMiIuoYA0sfV1rXiCX/3ocvfyoFAISrlbg/dwhm5qRDpeT8KURE1DswsPRRFrsDr206glc3HYLF7oRMBtx4YSr+cuUwxPKqHyIi6mUYWPqg/eX1uOudH3CsxgwAGJcejYWTR+K8FM6jQkREvRMDSx/z71/K8Je1P8FscyBJr8Gj14zANRlJkMl45Q8REfVeDCx9hNMpYOnGA3j520MAgIsHx+Dl6RcgilPoExFRH8DA0gcYGu14cE0xvtlXCQC4ffwAzL16OG9KSEREfQYDSy93qLIed75dhCPVJqiVciy5PgNTz+8X7GYRERF1KwaWXmzjngo8uKYYDdYmJOs1eO2Wscjox8JaIiLqexhYeiGnU8BL3xzC818fAACMGxCNV2ZcwMuViYioz2Jg6WWsTQ78+YMf8dWvFQCAWTlpmP+7kQhhvQoREfVhDCy9iCAIWPj5r/jq1wqoFHI8ce15+MOFqcFuFhERkd/59M/y5cuXIz09HRqNBtnZ2dixY0e7+9rtdvz973/HoEGDoNFokJWVhQ0bNnTpmOeqt74/hjU/nIBcBrw2cwzDChERnTO8Dixr1qxBfn4+Fi1ahF27diErKwt5eXmorKxsc//58+fjtddew0svvYQ9e/bg7rvvxtSpU/Hjjz/6fMxz0ZZD1Xh83V4AwNyrh+O3w3jTQiIiOnfIBEEQvHlDdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33Xd9OuaZjEYj9Ho9DAYDIiIivPk6vUJJjRn/b/lm1JntmHp+Cpb+IYsz1xIRUa/nze+3Vz0sNpsNRUVFyM3NbT6AXI7c3Fxs3bq1zfdYrVZoNBqPbVqtFps3b/b5mOeSBmsT7nj7B9SZ7cjqp0fBdRkMK0REdM7xKrBUV1fD4XAgISHBY3tCQgLKy8vbfE9eXh6WLl2KgwcPwul0YuPGjfj0009RVlbm8zGtViuMRqPH0hc5nQL+8lEx9lfUIy5cjdduGQtNiCLYzSIiIgo4v18L+8ILL2DIkCEYPnw4VCoV7rvvPsyePRtyue8fXVBQAL1eLy2pqX2z+PSFwoPSFUGv3TIGiXpNx28iIiLqg7xKDbGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwmkwnHjx/Hvn37EBYWhoEDB/p8zHnz5sFgMEjLiRMnvPkavcK/fynDC4UHAQBPTj0PF/SPCnKLiIiIgserwKJSqTBmzBgUFhZK25xOJwoLC5GTk3PW92o0GqSkpKCpqQmffPIJpkyZ4vMx1Wo1IiIiPJa+ZG+ZEX9Z+xMA4I8XD8ANY/3Qg2S3AKd2AYe+BmoOA46m7v8MIiKibuL1xHH5+fmYNWsWxo4di3HjxmHZsmUwmUyYPXs2AGDmzJlISUlBQUEBAGD79u04deoURo8ejVOnTmHx4sVwOp14+OGHO33Mc0mtyYY73v4BZpsD4wfH4m+Thnf9oKZqoPwXz6X6ACA4mveRhwDRA4CYwUDMINd6iLgOiwdY6EtEREHkdWCZNm0aqqqqsHDhQpSXl2P06NHYsGGDVDRbUlLiUZ9isVgwf/58HDlyBGFhYZg0aRLeeecdREZGdvqY5wq7w4l73yvCydONSIvR4eWbzoeys1PuCwJgrgGqDwI1h8Slcq8YTupL236PNhoISwBOHwOaGsUQU32g9X4hOkAVCijUgFINKDWAUuVaq5u3qyMATYRrrW/x2PVc7XquDhf3ZwgiIqJO8noelp6or8zDsmrzUfz9X3sQqlLgszkXY2hCeNs71hwGyn5qDibuxWJo/+DRA4HEDNeSKa7Dk8TQ4HQCxlMtjnUYqHEFn7oSQHB2/5eVKwFVmCvAhIkhRhUmPg6NB2KHAnFDxbW7nf7gdAJdKAAnIiLfefP7zXsJ9RB2hxP/+N8RAMDfrhnRdlg5fQz45gngl7XtHEUG6FObh3TihonhJGGkGAjaI5cDkaniMui3nq81WcUwY7cATRbxucMqrpssQJPNtbYAViNgMTavLYYzthkAW4N4XGcTYKkTl46owoDYIWJ4ca/DkwG7CbA2iMe01ouL9Ni13d7oWsxiG+1m13PXY6cdiBoApFwApIwBki8AkrIAla7jdhERUcAwsPQQ//q5FKUGC2LD1Lj+gn6eL5prgf89B+x4HXDYxG0pY8VAItWbDBZ7UUK03dswpVo8bndxOsUg0TJYWI2ez42nmoenao+Kr5X+KC7+cPqouOz+RHwuUwDxI4GU85tDTNww8VwQEVFQMLD0AIIg4LVNYu/K7IvTmyeHszcC218D/rcUsLqGewZcBlzxdyB5dHAa21VyuaumpZNDd002MUxU7XeFmIPi2lQl1tVIQ0nhzYv7uSpUXJQasQ4nxLVu+VymAKr2AqeKgFM/iuuGcqDiF3HZ9XZzW8ISxB6syFRA3w/Q9xfX7ueaSNblEBH5CQNLD7DpQBX2ldcjVKXAzdlpgNMB/LwG+OZJwHhS3CkhA7hiMTBo4rn1o6hUib0bccP89xkRScCgCc3PjaWuALNLXJcWi4GxoUJcTv3QTls1YmjRRgHaSNdj13P3Y41e7AVTasV1y0XapgMUId7/d3bYxcJrUzVgrhYfyxSALlossHavQzgBIRH1PgwsPYC7d2X6uP7Ql24CNi4CKnaLL0b0AybMBzL/AMg5LX9ARCSLy4jJ4nNBEIflDCWA4SRQdwIwuJa6E+I2c7VYI9NQLi5dJVcCIa4eIpXrKq2Wz0N0Ym2Qubo5oJyt6LqlkFBXeIkS1+qI5iu+3FeBKVSe2xQhYviRydtZXOHKYXPVN1nbrnly2MTP08UAobGALta1jgFC48SesTODmiCI75fqkFw1SQq1+N9JHdb1891TNFnFYdDGWiAyTSw4Z1E4EQAGlqD7+WQdth6pgVIuw5/CCoF354svqPXApX8Bxt3FfxEHm0wGhMaIS/L5be9jM4vDVI2nxULixjrPxxb3c2OL4l/Xj29Ti8Jg9xVZziaxV8fayRAitVUu9qK4w4CzSfzxM9eKa8EpFisbTGLg6mkUKrHdMnmL89II4CwXM2r0QESKuOhTPB+HJTYPDapCxeMHu4dSuirvoOuKvEPN0xEYTnhelafUivMjRQ90rQe5Hg8UvyPDDJ1DGFiC7LX/ir0rfx5SA/1/F4sbx94m9qroooPWLvKSSgeo0oCoNN+PIQjisI7dLC42k7i0fNzyuTr8jF6KWLHXpL0fMadTDEDmWjE8uUOMtd6zB8TdM9LyKjCHTWyf4HT9oLZ4LC1C+z007u3yELENpprm3iF3D5HdLH5Oe/MGAa6eJ1cdknRlmkFcKvd0fI7P7LkK0Yk1T2edP0gvnmuHtcVVacYzrlBrAGyu8+iwif8dHTbX0tTisb25N649qnBAFwUYTomhrXJP299NoQYi+4tLVJrYI9PysS4m+OHMF06nOPSqCu18rRudExhYguh4jQn//qUMcajDPVV/F/81fN7vgWue653/R0NdI5O5JuRTifUu3U0ud9XX9ND7UtnMzSEGaFHf4y6U1opDUy1Z68UfdqNrOfNxQ0VzEAJ877nqbq1mlh7SfLWfe2Zph12cB6n2KFB7GKg9Ii41h4G642KAqjkoLm0JCRUDjErXPHQHmecwnvtxiLb1JI8ej/XifmebssBiEM9veKI4lK1PcQ2v9hPXZ04VYLeI38tdTO8urK85JP43A8Twpm+n9ywiRQxm3d0D7WgSawdrj4pTSZw+Jhb+15eLtWjhCWLPnXsdluB6nOB5JWGTzXVFpPsfGQ3i37jNJA7vt5x7Sh0hPlaquve7dMTpEM995R7xf2MRSeKUEaGxPbIEgRPHBdGCz3fj/W1HsE7/LIZbfwbihgO3F/atMXminsBhb7+3yj2HT8sf4bYeK9Wtr0qTHoeJP67uUKUIEXuZFCrxsTyk+bFGL/7QKrrw70VHk6uGqkQML3UlwOnjzY/ry7rv3HUXbbQYMnRRze1tb6hPJu/chJUyORCVLv5/Z9yw5nXsULGH5kyCIP63NJaJPXnuteFUczgxnBCDly80keJ3spl8O4ZC1fx3FRYPxI8Qp1iIGy6uu3KblCabeEVk2U9A2c/iumJ3czhsSaYQg2d4kivEuJaIZOC861v/w6ELvPn9ZmAJkpoGKy5a8g3y8Q7uUq4T/8/uzm/FidGIiLrCbhGLwQ0l4g9Vy6E7j+E8QfxXtt189rBmMYj7uYfM2uyFiRB/6OrLxR4KQ4ueLrup7XZq9EDsMM9JIWOHisNaTVbxir32es+Mp8S2tSeyPxA3QvyM+jJxMZa135aWFGqxDVHprmWA+MNtMQD1Fc1XDNaXNz929+K1dSyVa+gxRCc+djo8hxObGjtuEyCGvviRriAzQmybs6lFTVwbE2Ra6sRgUrFHnCjzTCGh4uSiTod4jhoq2g+LciUwv6pba6c4020v8PbW4/itcxvuUq0TN1y7nGGFiLpHiAaIHSwuwSYI4g+9O2iYa8S5i2KHileGtddjoAgRb88RN7T945qqgKp94nBS1T6gcp+4Nle7ep9K2n6vRi8OfYQnNl8V2DKceHt1liCIdWENla7bjrS4sq8zPWmOJrEGytrQPGO34aR4P7jKPeK69ohYc3Z8s7j4QhMJJGWKs3knjRbX0QM9h38cTYCp0tX75A56peLaYQtqoTcDSxCYbU3Y9P0WvBPymrjhoj8BI6cEt1FERP4gk7nmI4oEEkZ173HD4sVlwKWer5mqXSFmrzg80zKchCe2PVzU1bboon2/UEKhbF1fljrOcx+bWazxaRlijKfEocqWdV5n1n6pwsRhsqQssdepoyElhbI5xPUwDCxB8Nm2A3jG8SzC5Y0Q0i6GbOLiYDeJiKjvCHVdOZd+cbBb0n1UOnGG8946y3k34EX8AdbU5EDCpr9iqPwUzOo4yH7/ZteK74iIiM4BDCwBtvfL/0OuYzPsUEAx7S3xcjgiIiI6KwaWABKOb8WIn58GAHw/4AGoB/ah7koiIiI/YmAJlPoK2D6cBSUcWO/MQeb1jwS7RURERL0GA0ugbFwIdWMFDjhTUHz+44gKU3f8HiIiIgLAwBIY9eVw7v4EAPBw09245bJuvLSPiIjoHMDAEgg/rILcacdO51CkZlyC1Ghdx+8hIiIiCQOLvzVZgR9WAQBWN12FazKSgtwgIiKi3oeBxd92fwqYqlAqROMr51ic3z8y2C0iIiLqdRhY/EkQgO0rAADvNl2B2IgwJER0863QiYiIzgEMLP50YjtQVowmuRofOH6L0amRwW4RERFRr8TA4k+u3pXtYRNxGhHIYmAhIiLyCQOLvxhOAnu+BAC8ZrkCAJCVqg9mi4iIiHotBhZ/2bkSEBywpV6E/xoTIJMBmf0ig90qIiKiXomBxR/sjUDRagDAntSbAABD4sMQpuZdmYmIiHzBwOIPv6wFGmsBfX8UOscAALLYu0JEROQzBpbuJgjANrHYFuPuwI8n6wEAozn/ChERkc8YWLrbsc1A5a9AiA7O0bfgp5N1ANjDQkRE1BUMLN3NdSkzsm7EUXMI6i1NUCvlGJYYHtx2ERER9WIMLN3p9DFg/3rx8bi7UFxSBwDISNEjRMFTTURE5Cv+inannf8ABCcw8LdA/PDm4SBOGEdERNQlDCzdxWYCdr0tPs6+GwDw04k6AAwsREREXeVTYFm+fDnS09Oh0WiQnZ2NHTt2nHX/ZcuWYdiwYdBqtUhNTcWDDz4Ii8Uivb548WLIZDKPZfjw4b40LXh++hCwGICoAcCQK2GxO7CnzAgAGM2CWyIioi7xeiazNWvWID8/HytWrEB2djaWLVuGvLw87N+/H/Hx8a32f//99zF37lysWrUKF110EQ4cOIBbb70VMpkMS5culfYbNWoUvv766+aGKXvRJGuCAGx/TXycfRcgl2PvydOwOwREh6qQGq0NbvuIiIh6Oa97WJYuXYo77rgDs2fPxsiRI7FixQrodDqsWrWqzf2///57XHzxxbjpppuQnp6OK6+8EtOnT2/VK6NUKpGYmCgtsbGxvn2jYDjyLVC9H1CFAaNnAGgxHNRPD5lMFsTGERER9X5eBRabzYaioiLk5uY2H0AuR25uLrZu3drmey666CIUFRVJAeXIkSNYv349Jk2a5LHfwYMHkZycjIEDB2LGjBkoKSlptx1WqxVGo9FjCaod/xDXo2cAmggAwE8nDQBYv0JERNQdvBp3qa6uhsPhQEJCgsf2hIQE7Nu3r8333HTTTaiursb48eMhCAKamppw9913429/+5u0T3Z2NlavXo1hw4ahrKwMjz32GC655BLs3r0b4eGt5y8pKCjAY4895k3T/evENnGdNU3aVOzqYRnNwEJERNRlfr9K6LvvvsNTTz2FV155Bbt27cKnn36KdevW4fHHH5f2ufrqq3HDDTcgMzMTeXl5WL9+Perq6vDRRx+1ecx58+bBYDBIy4kTJ/z9NdpnqgHMNeLjOLFQuM5sw9FqEwDOcEtERNQdvOphiY2NhUKhQEVFhcf2iooKJCYmtvmeBQsW4JZbbsHtt98OAMjIyIDJZMKdd96JRx99FHJ568wUGRmJoUOH4tChQ20eU61WQ61We9N0/6neL671/QFVKADgZ9dwUFqMDlGhqmC1jIiIqM/wqodFpVJhzJgxKCwslLY5nU4UFhYiJyenzfeYzeZWoUShUAAABEFo8z0NDQ04fPgwkpKSvGlecFS5AkvcUGkTh4OIiIi6l9fXDufn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUAgMmTJ2Pp0qU4//zzkZ2djUOHDmHBggWYPHmyFFweeughTJ48GWlpaSgtLcWiRYugUCgwffr0bvyqflJ9QFzHDpM2NV8hFBn49hAREfVBXgeWadOmoaqqCgsXLkR5eTlGjx6NDRs2SIW4JSUlHj0q8+fPh0wmw/z583Hq1CnExcVh8uTJePLJJ6V9Tp48ienTp6OmpgZxcXEYP348tm3bhri4uG74in7mDiyuHhZBEDglPxERUTeTCe2Ny/QiRqMRer0eBoMBERERgf3w5zMAQwkwewOQloMTtWZc8sy3UMpl2P1YHjQhisC2h4iIqJfw5veb9xLqCptJDCsAECv2sLh7V0YkRTCsEBERdRMGlq6oPiiudTFAaAyAljc81AepUURERH0PA0tXtFFwW8yCWyIiom7HwNIVZ1zS3ORw4pdT4hws5/ePDFKjiIiI+h4Glq5wTxrn6mE5UNEAi92JMLUSA2PDgtgwIiKivoWBpSvcNSyuHhb3cFBmPz3kct6hmYiIqLswsPjK0QTUHBYfu3pYfuIMt0RERH7BwOKr00cBpx0I0QERKQDACeOIiIj8hIHFV+6C29ghgFwOk7UJByrqAbCHhYiIqLsxsPjqjILbX04Z4BSAJL0GCRGaIDaMiIio72Fg8VWV5z2EeMNDIiIi/2Fg8dUZPSysXyEiIvIfBhZfCEKLS5rFwFJcUgeA9StERET+wMDiC2MpYGsAZAogagAqjRaUGiyQyYCMfryHEBERUXdjYPGFezgoeiCgVOGnk+J0/EPiwxCmVgaxYURERH0TA4svpIJb13DQidMAWHBLRETkLwwsvpAKbt1XCIk9LKN5w0MiIiK/YGDxxRk9LKWGRgDAoDje8JCIiMgfGFh8cUYPi9nqAADWrxAREfkJA4u3zLWAqUp87AosJlsTAECrUgSrVURERH0aA4u33POvRKQA6jAIgoBGm9jDEqpiDwsREZE/MLB464zhIJvDiSanAIA9LERERP7CwOIt912aXQW37voVANAxsBAREfkFA4u3ql1XCLkLbu1iYFEp5QhR8HQSERH5A39hvdWqh0UsuGXvChERkf8wsHjD3gjUlYiPXXdpNrPgloiIyO8YWLxRfRCAAGijgNBYAM2XNLOHhYiIyH8YWLzRsn5FJgPQXHTLwEJEROQ/DCzeOKPgFmguutVxSIiIiMhvGFi8cUbBLdBcdBuqZg8LERGRvzCweEPqYWkOLCZX0a2WPSxERER+w8DSWY4moOaQ+DiueUio0VV0G8oaFiIiIr9hYOmsuuOAwwYotYC+v7S5uYeFgYWIiMhfGFg6y12/EjsYkDefNqmGhUNCREREfsPA0lln3PTQzT1xnI5Ft0RERH7jU2BZvnw50tPTodFokJ2djR07dpx1/2XLlmHYsGHQarVITU3Fgw8+CIvF0qVjBlz1QXHdouAWaBFYQhhYiIiI/MXrwLJmzRrk5+dj0aJF2LVrF7KyspCXl4fKyso293///fcxd+5cLFq0CHv37sXKlSuxZs0a/O1vf/P5mEEhXdJ8Zg+La6ZbNYeEiIiI/MXrwLJ06VLccccdmD17NkaOHIkVK1ZAp9Nh1apVbe7//fff4+KLL8ZNN92E9PR0XHnllZg+fbpHD4q3xww4QWjzkmagueiWNSxERET+41VgsdlsKCoqQm5ubvMB5HLk5uZi69atbb7noosuQlFRkRRQjhw5gvXr12PSpEk+H9NqtcJoNHosflVfDliNgEwOxAzyeMnMewkRERH5nVfdAtXV1XA4HEhISPDYnpCQgH379rX5nptuugnV1dUYP348BEFAU1MT7r77bmlIyJdjFhQU4LHHHvOm6V3jLriNGgAo1R4vSTUsDCxERER+4/erhL777js89dRTeOWVV7Br1y58+umnWLduHR5//HGfjzlv3jwYDAZpOXHiRDe2uA1VruGguGGtXnLf/DCUNSxERER+49WvbGxsLBQKBSoqKjy2V1RUIDExsc33LFiwALfccgtuv/12AEBGRgZMJhPuvPNOPProoz4dU61WQ61Wt/maX0iXNA9p9ZLJNSTEieOIiIj8x6seFpVKhTFjxqCwsFDa5nQ6UVhYiJycnDbfYzabIZd7foxCIf64C4Lg0zEDTpo0zrOHRRAENLLoloiIyO+8/pXNz8/HrFmzMHbsWIwbNw7Lli2DyWTC7NmzAQAzZ85ESkoKCgoKAACTJ0/G0qVLcf755yM7OxuHDh3CggULMHnyZCm4dHTMoHPPwXLGkJDN4USTUwDAieOIiIj8yevAMm3aNFRVVWHhwoUoLy/H6NGjsWHDBqlotqSkxKNHZf78+ZDJZJg/fz5OnTqFuLg4TJ48GU8++WSnjxlUFgPQUC4+PmNIyF2/AnDiOCIiIn+SCYIgBLsRXWU0GqHX62EwGBAREdG9Bz+xE1iZC4QnAX/xvGrpVF0jLl7yDVRKOQ48cXX3fi4REVEf583vN+8l1JF27iEENN/4kJc0ExER+RcDS0ekKflbX9LMWW6JiIgCg4GlI9KU/G30sHCWWyIiooBgYOlI1dmGhDjLLRERUSAwsJyN3QLUHRcftzXLrd0dWDgkRERE5E/8pT0buxnImg4YTgBhrS+xdhfdhnIOFiIiIr9iYDkbXTRw7SvtvuwuutWyh4WIiMivOCTUBY2uottQ1rAQERH5FQNLF7h7WFjDQkRE5F8MLF3AieOIiIgCg4GlC8zuHhYW3RIREfkVA0sXSIGFNz4kIiLyKwaWLjC5Z7pVs4aFiIjInxhYusDMewkREREFBANLF/BeQkRERIHBwNIFUg0LAwsREZFfMbB0gfvmh6GsYSEiIvIrBpYucBfdatnDQkRE5FcMLD4SBAGNLLolIiIKCAYWH9kcTjQ5BQCcOI6IiMjfGFh85K5fAThxHBERkb8xsPjIbBcDi0oph1LB00hERORP/KX1EW98SEREFDgMLD4yseCWiIgoYBhYfMRZbomIiAKHgcVH7qJbBhYiIiL/Y2DxkbvoVschISIiIr9jYPGRu+g2lHOwEBER+R0Di4/cRbda9rAQERH5HQOLjxpdRbehrGEhIiLyOwYWH7l7WFjDQkRE5H8MLD7ixHFERESBw8DiI7O7h4VFt0RERH7HwOIjM2e6JSIiChgGFh+ZXEW3Wg4JERER+Z1PgWX58uVIT0+HRqNBdnY2duzY0e6+l19+OWQyWavlmmuukfa59dZbW71+1VVX+dK0gGEPCxERUeB4/Wu7Zs0a5OfnY8WKFcjOzsayZcuQl5eH/fv3Iz4+vtX+n376KWw2m/S8pqYGWVlZuOGGGzz2u+qqq/Dmm29Kz9VqtbdNCyjeS4iIiChwvO5hWbp0Ke644w7Mnj0bI0eOxIoVK6DT6bBq1ao294+OjkZiYqK0bNy4ETqdrlVgUavVHvtFRUX59o0ChPcSIiIiChyvAovNZkNRURFyc3ObDyCXIzc3F1u3bu3UMVauXIkbb7wRoaGhHtu/++47xMfHY9iwYbjnnntQU1PT7jGsViuMRqPHEmjSkJCaQ0JERET+5lVgqa6uhsPhQEJCgsf2hIQElJeXd/j+HTt2YPfu3bj99ts9tl911VV4++23UVhYiKeffhqbNm3C1VdfDYfD0eZxCgoKoNfrpSU1NdWbr9EtWHRLREQUOAHtHli5ciUyMjIwbtw4j+033nij9DgjIwOZmZkYNGgQvvvuO0ycOLHVcebNm4f8/HzpudFoDGhoEQQBjSy6JSIiChivelhiY2OhUChQUVHhsb2iogKJiYlnfa/JZMKHH36I2267rcPPGThwIGJjY3Ho0KE2X1er1YiIiPBYAsnmcKLJKQDgxHFERESB4FVgUalUGDNmDAoLC6VtTqcThYWFyMnJOet7165dC6vViptvvrnDzzl58iRqamqQlJTkTfMCxl1wCwC6EAYWIiIif/P6KqH8/Hy88cYbeOutt7B3717cc889MJlMmD17NgBg5syZmDdvXqv3rVy5Etdeey1iYmI8tjc0NOCvf/0rtm3bhmPHjqGwsBBTpkzB4MGDkZeX5+PX8i+zXQwsKqUcSgXn3iMiIvI3rwswpk2bhqqqKixcuBDl5eUYPXo0NmzYIBXilpSUQC73/BHfv38/Nm/ejP/85z+tjqdQKPDzzz/jrbfeQl1dHZKTk3HllVfi8ccf77FzsbhvfBjKglsiIqKAkAmCIAS7EV1lNBqh1+thMBgCUs9SfKIO1y7fgpRILbbMneD3zyMiIuqLvPn95niGDzjLLRERUWAxsPiAs9wSEREFFgOLD0xSDwvnYCEiIgoEBhYfSJPGcQ4WIiKigGBg8YHJFVi07GEhIiIKCAYWHzTaeFkzERFRIDGw+MDdw8IaFiIiosBgYPGBe+I4XiVEREQUGAwsPjC7e1hYdEtERBQQDCw+cAeWUA4JERERBQQDiw/c87BoOSREREQUEAwsPmAPCxERUWAxsPiA9xIiIiIKLAYWH/BeQkRERIHFwOIDaUhIzSEhIiKiQGBg8QGLbomIiAKLgcVLgiA03/yQRbdEREQBwcDiJZvDiSanAIATxxEREQUKA4uX3AW3AKALYWAhIiIKBAYWL5ntYmBRKeVQKnj6iIiIAoG/uF5y3/gwlAW3REREAcPA4iWT+8aHLLglIiIKGAYWL3GWWyIiosBjYPESZ7klIiIKPAYWL5mkHhYOCREREQUKA4uXpEnjOAcLERFRwDCweMlddKtlDwsREVHAMLB4iZc1ExERBR4Di5fcE8exhoWIiChwGFi85O5h4VVCREREgcPA4iWze+I4Ft0SEREFDAOLl9yBJZRDQkRERAHDwOIl9zwsWg4JERERBQwDi5fYw0JERBR4DCxeku4lxBoWIiKigPEpsCxfvhzp6enQaDTIzs7Gjh072t338ssvh0wma7Vcc8010j6CIGDhwoVISkqCVqtFbm4uDh486EvT/E66l1AIAwsREVGgeB1Y1qxZg/z8fCxatAi7du1CVlYW8vLyUFlZ2eb+n376KcrKyqRl9+7dUCgUuOGGG6R9nnnmGbz44otYsWIFtm/fjtDQUOTl5cFisfj+zfxEGhJSc0iIiIgoULwOLEuXLsUdd9yB2bNnY+TIkVixYgV0Oh1WrVrV5v7R0dFITEyUlo0bN0Kn00mBRRAELFu2DPPnz8eUKVOQmZmJt99+G6Wlpfj888+79OX8gUW3REREgedVYLHZbCgqKkJubm7zAeRy5ObmYuvWrZ06xsqVK3HjjTciNDQUAHD06FGUl5d7HFOv1yM7O7vdY1qtVhiNRo8lEARBYNEtERFREHgVWKqrq+FwOJCQkOCxPSEhAeXl5R2+f8eOHdi9ezduv/12aZv7fd4cs6CgAHq9XlpSU1O9+Ro+szmccDgFACy6JSIiCqSAXiW0cuVKZGRkYNy4cV06zrx582AwGKTlxIkT3dTCs3MX3AIsuiUiIgokrwJLbGwsFAoFKioqPLZXVFQgMTHxrO81mUz48MMPcdttt3lsd7/Pm2Oq1WpERER4LIHgvvGhSimHUsErwomIiALFq19dlUqFMWPGoLCwUNrmdDpRWFiInJycs7537dq1sFqtuPnmmz22DxgwAImJiR7HNBqN2L59e4fHDDT3jQ9DWXBLREQUUF5Xjubn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUe71u5ciWuvfZaxMTEeGyXyWR44IEH8MQTT2DIkCEYMGAAFixYgOTkZFx77bW+fzM/MLlvfMiCWyIiooDy+pd32rRpqKqqwsKFC1FeXo7Ro0djw4YNUtFsSUkJ5HLPjpv9+/dj8+bN+M9//tPmMR9++GGYTCbceeedqKurw/jx47FhwwZoNBofvpL/SLPcsoeFiIgooGSCIAjBbkRXGY1G6PV6GAwGv9azfL2nAre//QOyUiPxxZyL/fY5RERE5wJvfr9ZOeoF96RxvEKIiIgosBhYvNAoTcvPwEJERBRIDCxecBfdall0S0REFFAMLF7gZc1ERETBwcDiBffEcbysmYiIKLAYWLzg7mHhZc1ERESBxcDiBfedmnnjQyIiosBiYPGCO7CEckiIiIgooBhYvOCeh0XLISEiIqKAYmDxAntYiIiIgoOBxQvSvYRYw0JERBRQDCxeMFtdRbecmp+IiCigGFi8IA0JqTkkREREFEgMLF5g0S0REVFwMLB0kiAILLolIiIKEgaWTrI5nHA4BQAsuiUiIgo0BpZOchfcAiy6JSIiCjQGlk5y3/hQpZRDqeBpIyIiCiT+8naS+8aHoSy4JSIiCjgGlk4yuW98yIJbIiKigGNg6SRpllv2sBAREQUcA0snSbPcctI4IiKigGNg6ST3pHG8QoiIiCjwGFg6qVGalp+BhYiIKNAYWDqJRbdERETBw8DSSe7Lmll0S0REFHgMLJ3knjiOPSxERESBx8DSSexhISIiCh4Glk6SalhYdEtERBRwDCydJF0lxCEhIiKigGNg6ST3PCxaDgkREREFHANLJ5nZw0JERBQ0DCydJN1LiDUsREREAcfA0knSvYQ4NT8REVHAMbB0kjQkxJsfEhERBZxPgWX58uVIT0+HRqNBdnY2duzYcdb96+rqMGfOHCQlJUGtVmPo0KFYv3699PrixYshk8k8luHDh/vSNL+Rbn7IolsiIqKA87q7YM2aNcjPz8eKFSuQnZ2NZcuWIS8vD/v370d8fHyr/W02G6644grEx8fj448/RkpKCo4fP47IyEiP/UaNGoWvv/66uWHKntOTIQiC1MPCmW6JiIgCz+tf36VLl+KOO+7A7NmzAQArVqzAunXrsGrVKsydO7fV/qtWrUJtbS2+//57hISEAADS09NbN0SpRGJiorfNCQibwwmHUwDAolsiIqJg8GpIyGazoaioCLm5uc0HkMuRm5uLrVu3tvmeL7/8Ejk5OZgzZw4SEhJw3nnn4amnnoLD4fDY7+DBg0hOTsbAgQMxY8YMlJSUtNsOq9UKo9HosfiTu+AWYNEtERFRMHgVWKqrq+FwOJCQkOCxPSEhAeXl5W2+58iRI/j444/hcDiwfv16LFiwAM899xyeeOIJaZ/s7GysXr0aGzZswKuvvoqjR4/ikksuQX19fZvHLCgogF6vl5bU1FRvvobX3PUrKqUcSgXrlImIiALN7wUZTqcT8fHxeP3116FQKDBmzBicOnUKzz77LBYtWgQAuPrqq6X9MzMzkZ2djbS0NHz00Ue47bbbWh1z3rx5yM/Pl54bjUa/hpbmafnZu0JERBQMXgWW2NhYKBQKVFRUeGyvqKhot/4kKSkJISEhUCiaf+xHjBiB8vJy2Gw2qFSqVu+JjIzE0KFDcejQoTaPqVaroVarvWl6l5hYcEtERBRUXo1vqFQqjBkzBoWFhdI2p9OJwsJC5OTktPmeiy++GIcOHYLT6ZS2HThwAElJSW2GFQBoaGjA4cOHkZSU5E3z/MbMS5qJiIiCyuuCjPz8fLzxxht46623sHfvXtxzzz0wmUzSVUMzZ87EvHnzpP3vuece1NbW4v7778eBAwewbt06PPXUU5gzZ460z0MPPYRNmzbh2LFj+P777zF16lQoFApMnz69G75i10mz3HLSOCIioqDw+hd42rRpqKqqwsKFC1FeXo7Ro0djw4YNUiFuSUkJ5PLmHJSamoqvvvoKDz74IDIzM5GSkoL7778fjzzyiLTPyZMnMX36dNTU1CAuLg7jx4/Htm3bEBcX1w1fseukSeN4hRARkQeHwwG73R7sZlAPdmZZiK9kgiAI3dCeoDIajdDr9TAYDIiIiOj243+4owRzP/0FuSPi8Y9ZF3b78YmIehtBEFBeXo66urpgN4V6gcjISCQmJkImk3ls9+b3m2McncCiWyIiT+6wEh8fD51O1+qHiAhwzRRvNqOyshIAulSbyl/gTjBbWXRLROTmcDiksBITExPs5lAPp9VqAQCVlZWIj4/3eXiIs6B1gtnOHhYiIjd3zYpOpwtyS6i3cP+tdKXeiYGlE9jDQkTUGoeBqLO642+FgaUTpBoW3viQiIgoKBhYOqF5an4OCREREQUDA0snuOdh0XJIiIiIKCgYWDrBzB4WIiLyA06613kMLJ0g3UuINSxERL3ahg0bMH78eERGRiImJga/+93vcPjwYel198zr0dHRCA0NxdixY7F9+3bp9X/+85+48MILodFoEBsbi6lTp0qvyWQyfP755x6fFxkZidWrVwMAjh07BplMhjVr1uCyyy6DRqPBe++9h5qaGkyfPh0pKSnQ6XTIyMjABx984HEcp9OJZ555BoMHD4ZarUb//v3x5JNPAgAmTJiA++67z2P/qqoqqFQqj3v/9XbsMugE6V5CnJqfiKgVQRDQ6Jr+IdC0IQqvrkAxmUzIz89HZmYmGhoasHDhQkydOhXFxcUwm8247LLLkJKSgi+//BKJiYnYtWuXdPPedevWYerUqXj00Ufx9ttvw2azYf369V63ee7cuXjuuedw/vnnQ6PRwGKxYMyYMXjkkUcQERGBdevW4ZZbbsGgQYMwbtw4AMC8efPwxhtv4Pnnn8f48eNRVlaGffv2AQBuv/123HfffXjuueegVqsBAO+++y5SUlIwYcIEr9vXUzGwdII0JMSbHxIRtdJod2Dkwq+C8tl7/p7n1RxZ119/vcfzVatWIS4uDnv27MH333+Pqqoq7Ny5E9HR0QCAwYMHS/s++eSTuPHGG/HYY49J27Kysrxu8wMPPIDrrrvOY9tDDz0kPf7Tn/6Er776Ch999BHGjRuH+vp6vPDCC3j55Zcxa9YsAMCgQYMwfvx4AMB1112H++67D1988QX+8Ic/AABWr16NW2+9tU9des4hoU6Qbn7Iolsiol7t4MGDmD59OgYOHIiIiAikp6cDEG/cW1xcjPPPP18KK2cqLi7GxIkTu9yGsWPHejx3OBx4/PHHkZGRgejoaISFheGrr75CSUkJAGDv3r2wWq3tfrZGo8Ett9yCVatWAQB27dqF3bt349Zbb+1yW3sSdhl0QBAEqYeFM90SEbWmDVFgz9/zgvbZ3pg8eTLS0tLwxhtvIDk5GU6nE+eddx5sNps0hXy7n9XB6zKZDGfeT7itotrQ0FCP588++yxeeOEFLFu2DBkZGQgNDcUDDzwAm83Wqc8FxGGh0aNH4+TJk3jzzTcxYcIEpKWldfi+3oQ9LB2wOZxwOMU/QBbdEhG1JpPJoFMpg7J4M+RRU1OD/fv3Y/78+Zg4cSJGjBiB06dPS69nZmaiuLgYtbW1bb4/MzPzrEWscXFxKCsrk54fPHgQZrO5w3Zt2bIFU6ZMwc0334ysrCwMHDgQBw4ckF4fMmQItFrtWT87IyMDY8eOxRtvvIH3338ff/zjHzv83N6GgaUD7oJbgEW3RES9WVRUFGJiYvD666/j0KFD+Oabb5Cfny+9Pn36dCQmJuLaa6/Fli1bcOTIEXzyySfYunUrAGDRokX44IMPsGjRIuzduxe//PILnn76aen9EyZMwMsvv4wff/wRP/zwA+6++26EhIR02K4hQ4Zg48aN+P7777F3717cddddqKiokF7XaDR45JFH8PDDD+Ptt9/G4cOHsW3bNqxcudLjOLfffjuWLFkCQRA8rl7qKxhYOuCuX1Ep5VAqeLqIiHoruVyODz/8EEVFRTjvvPPw4IMP4tlnn5VeV6lU+M9//oP4+HhMmjQJGRkZWLJkiXR34csvvxxr167Fl19+idGjR2PChAnYsWOH9P7nnnsOqampuOSSS3DTTTfhoYce6tQNIufPn48LLrgAeXl5uPzyy6XQ1NKCBQvwl7/8BQsXLsSIESMwbdo0VFZWeuwzffp0KJVKTJ8+HRqNpgtnqmeSCWcOuPVCRqMRer0eBoMBERER3XrsgxX1uOL5/yJKF4IfF17ZrccmIuqNLBYLjh49igEDBvTJH8be6tixYxg0aBB27tyJCy64INjN8dDe34w3v9+sIu2AiQW3RETUg9ntdtTU1GD+/Pn4zW9+0+PCSnfhGEcHzFZe0kxERD3Xli1bkJSUhJ07d2LFihXBbo7fsNugA9IlzZw0joiIeqDLL7+81eXUfRF7WDogTRrHK4SIiIiChoGlA43StPwMLERERMHCwNIBFt0SEREFHwNLB1h0S0REFHwMLB0w29nDQkREFGwMLB1w97CwhoWIiCh4GFg64K5h0XJIiIjonJeeno5ly5YFuxnnJAaWDkhXCXFIiIiIKGgYWDrgnoeFPSxERNSbORwOOJ3OYDfDZwwsHTBb2cNCRNQXvP7660hOTm71oz1lyhT88Y9/xOHDhzFlyhQkJCQgLCwMF154Ib7++mufP2/p0qXIyMhAaGgoUlNTce+996KhocFjny1btuDyyy+HTqdDVFQU8vLycPr0aQCA0+nEM888g8GDB0OtVqN///548sknAQDfffcdZDIZ6urqpGMVFxdDJpPh2LFjAIDVq1cjMjISX375JUaOHAm1Wo2SkhLs3LkTV1xxBWJjY6HX63HZZZdh165dHu2qq6vDXXfdhYSEBGg0Gpx33nn417/+BZPJhIiICHz88cce+3/++ecIDQ1FfX29z+erIwwsHTDbXZc1s+iWiKhtggDYTMFZvJiS/oYbbkBNTQ2+/fZbaVttbS02bNiAGTNmoKGhAZMmTUJhYSF+/PFHXHXVVZg8eTJKSkp8Oi1yuRwvvvgifv31V7z11lv45ptv8PDDD0uvFxcXY+LEiRg5ciS2bt2KzZs3Y/LkyXA4xH8oz5s3D0uWLMGCBQuwZ88evP/++0hISPCqDWazGU8//TT+8Y9/4Ndff0V8fDzq6+sxa9YsbN68Gdu2bcOQIUMwadIkKWw4nU5cffXV2LJlC959913s2bMHS5YsgUKhQGhoKG688Ua8+eabHp/z5ptv4ve//z3Cw8N9OledwW6DDrh7WDg1PxFRO+xm4Knk4Hz230oBVWindo2KisLVV1+N999/HxMnTgQAfPzxx4iNjcVvf/tbyOVyZGVlSfs//vjj+Oyzz/Dll1/ivvvu87ppDzzwgPQ4PT0dTzzxBO6++2688sorAIBnnnkGY8eOlZ4DwKhRowAA9fX1eOGFF/Dyyy9j1qxZAIBBgwZh/PjxXrXBbrfjlVde8fheEyZM8Njn9ddfR2RkJDZt2oTf/e53+Prrr7Fjxw7s3bsXQ4cOBQAMHDhQ2v/222/HRRddhLKyMiQlJaGyshLr16/vUm9UZ7CHpQNmaWp+Zjsiot5uxowZ+OSTT2C1WgEA7733Hm688UbI5XI0NDTgoYcewogRIxAZGYmwsDDs3bvX5x6Wr7/+GhMnTkRKSgrCw8Nxyy23oKamBmazGUBzD0tb9u7dC6vV2u7rnaVSqZCZmemxraKiAnfccQeGDBkCvV6PiIgINDQ0SN+zuLgY/fr1k8LKmcaNG4dRo0bhrbfeAgC8++67SEtLw6WXXtqltnaEv8IdkG5+yKJbIqK2hejEno5gfbYXJk+eDEEQsG7dOlx44YX43//+h+effx4A8NBDD2Hjxo34v//7PwwePBharRa///3vYbPZvG7WsWPH8Lvf/Q733HMPnnzySURHR2Pz5s247bbbYLPZoNPpoNVq233/2V4DxOEmAB53abbb7W0eRyaTeWybNWsWampq8MILLyAtLQ1qtRo5OTnS9+zoswGxl2X58uWYO3cu3nzzTcyePbvV53Q3n3pYli9fjvT0dGg0GmRnZ2PHjh1n3b+urg5z5sxBUlIS1Go1hg4divXr13fpmIEgCILUw8KZbomI2iGTicMywVi8/JHUaDS47rrr8N577+GDDz7AsGHDcMEFFwAQC2BvvfVWTJ06FRkZGUhMTJQKWL1VVFQEp9OJ5557Dr/5zW8wdOhQlJZ6hrrMzEwUFha2+f4hQ4ZAq9W2+3pcXBwAoKysTNpWXFzcqbZt2bIFf/7znzFp0iSMGjUKarUa1dXVHu06efIkDhw40O4xbr75Zhw/fhwvvvgi9uzZIw1b+ZPXgWXNmjXIz8/HokWLsGvXLmRlZSEvLw+VlZVt7m+z2XDFFVfg2LFj+Pjjj7F//3688cYbSElJ8fmYgWJzOOFwiumVRbdERH3DjBkzsG7dOqxatQozZsyQtg8ZMgSffvopiouL8dNPP+Gmm27y+TLgwYMHw26346WXXsKRI0fwzjvvYMWKFR77zJs3Dzt37sS9996Ln3/+Gfv27cOrr76K6upqaDQaPPLII3j44Yfx9ttv4/Dhw9i2bRtWrlwpHT81NRWLFy/GwYMHsW7dOjz33HOdatuQIUPwzjvvYO/evdi+fTtmzJjh0aty2WWX4dJLL8X111+PjRs34ujRo/j3v/+NDRs2SPtERUXhuuuuw1//+ldceeWV6Nevn0/nySuCl8aNGyfMmTNHeu5wOITk5GShoKCgzf1fffVVYeDAgYLNZuu2Y57JYDAIAASDwdDJb9E5jbYm4fmN+4Un1+0R7E2Obj02EVFv1djYKOzZs0dobGwMdlN84nA4hKSkJAGAcPjwYWn70aNHhd/+9reCVqsVUlNThZdfflm47LLLhPvvv1/aJy0tTXj++ec79TlLly4VkpKSBK1WK+Tl5Qlvv/22AEA4ffq0tM93330nXHTRRYJarRYiIyOFvLw86XWHwyE88cQTQlpamhASEiL0799feOqpp6T3bt68WcjIyBA0Go1wySWXCGvXrhUACEePHhUEQRDefPNNQa/Xt2rXrl27hLFjxwoajUYYMmSIsHbt2lbfq6amRpg9e7YQExMjaDQa4bzzzhP+9a9/eRynsLBQACB89NFHHZ6L9v5mvPn9lglC568Jc4+7ffzxx7j22mul7bNmzUJdXR2++OKLVu+ZNGkSoqOjodPp8MUXXyAuLg433XQTHnnkESgUCp+OeSaj0Qi9Xg+DwYCIiIjOfh0iIvKBxWLB0aNHMWDAAGg0mmA3h4LknXfewYMPPojS0lKoVKqz7tve34w3v99eFWZUV1fD4XC0ug48ISEB+/bta/M9R44cwTfffIMZM2Zg/fr1OHToEO69917Y7XYsWrTIp2NarVapwhsQvzARERH5n9lsRllZGZYsWYK77rqrw7DSXfx+WbPT6UR8fDxef/11jBkzBtOmTcOjjz7aaizPGwUFBdDr9dKSmprajS0mIiI6u/feew9hYWFtLu65VPqqZ555BsOHD0diYiLmzZsXsM/1qoclNjYWCoUCFRUVHtsrKiqQmJjY5nuSkpIQEhIChaK5aHXEiBEoLy+HzWbz6Zjz5s1Dfn6+9NxoNDK0EBFRwPy///f/kJ2d3eZrISEhAW5NYC1evBiLFy8O+Od61cOiUqkwZswYj8usnE4nCgsLkZOT0+Z7Lr74Yhw6dMij0vrAgQNISkqCSqXy6ZhqtRoREREeCxERUaCEh4dj8ODBbS5paWnBbl6f5PWQUH5+Pt544w289dZb2Lt3L+655x6YTCbMnj0bADBz5kyPLqJ77rkHtbW1uP/++3HgwAGsW7cOTz31FObMmdPpYxIREdG5zevZ0KZNm4aqqiosXLgQ5eXlGD16NDZs2CAVzZaUlEgz8AFAamoqvvrqKzz44IPIzMxESkoK7r//fjzyyCOdPiYREfU8vs5RQuee7vhb8eqy5p6KlzUTEQWO0+nEwYMHoVAoEBcXB5VK5fdp2al3EgQBNpsNVVVVcDgcGDJkiEenht8uayYiIpLL5RgwYADKyspaTTdP1BadTof+/ft7hBVvMbAQEZHXVCoV+vfvj6amJjgcjmA3h3owhUIBpVLZ5V44BhYiIvKJTCZDSEhIn7+Ml3oGv08cR0RERNRVDCxERETU4zGwEBERUY/XJ2pY3Fdm8yaIREREvYf7d7szM6z0icBSX18PALyfEBERUS9UX18PvV5/1n36xMRxTqcTpaWlCA8P7/bJi9w3Vjxx4gQnpQsAnu/A4vkOLJ7vwOL5DixfzrcgCKivr0dycnKHc7T0iR4WuVyOfv36+fUzeJPFwOL5Diye78Di+Q4snu/A8vZ8d9Sz4saiWyIiIurxGFiIiIiox2Ng6YBarcaiRYugVquD3ZRzAs93YPF8BxbPd2DxfAeWv893nyi6JSIior6NPSxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9XgMLB1Yvnw50tPTodFokJ2djR07dgS7SX3Cf//7X0yePBnJycmQyWT4/PPPPV4XBAELFy5EUlIStFotcnNzcfDgweA0tpcrKCjAhRdeiPDwcMTHx+Paa6/F/v37PfaxWCyYM2cOYmJiEBYWhuuvvx4VFRVBanHv9uqrryIzM1OaPCsnJwf//ve/pdd5rv1ryZIlkMlkeOCBB6RtPOfdZ/HixZDJZB7L8OHDpdf9ea4ZWM5izZo1yM/Px6JFi7Br1y5kZWUhLy8PlZWVwW5ar2cymZCVlYXly5e3+fozzzyDF198EStWrMD27dsRGhqKvLw8WCyWALe099u0aRPmzJmDbdu2YePGjbDb7bjyyithMpmkfR588EH885//xNq1a7Fp0yaUlpbiuuuuC2Kre69+/fphyZIlKCoqwg8//IAJEyZgypQp+PXXXwHwXPvTzp078dprryEzM9NjO8959xo1ahTKysqkZfPmzdJrfj3XArVr3Lhxwpw5c6TnDodDSE5OFgoKCoLYqr4HgPDZZ59Jz51Op5CYmCg8++yz0ra6ujpBrVYLH3zwQRBa2LdUVlYKAIRNmzYJgiCe25CQEGHt2rXSPnv37hUACFu3bg1WM/uUqKgo4R//+AfPtR/V19cLQ4YMETZu3Chcdtllwv333y8IAv++u9uiRYuErKysNl/z97lmD0s7bDYbioqKkJubK22Ty+XIzc3F1q1bg9iyvu/o0aMoLy/3OPd6vR7Z2dk8993AYDAAAKKjowEARUVFsNvtHud7+PDh6N+/P893FzkcDnz44YcwmUzIycnhufajOXPm4JprrvE4twD/vv3h4MGDSE5OxsCBAzFjxgyUlJQA8P+57hM3P/SH6upqOBwOJCQkeGxPSEjAvn37gtSqc0N5eTkAtHnu3a+Rb5xOJx544AFcfPHFOO+88wCI51ulUiEyMtJjX55v3/3yyy/IycmBxWJBWFgYPvvsM4wcORLFxcU8137w4YcfYteuXdi5c2er1/j33b2ys7OxevVqDBs2DGVlZXjsscdwySWXYPfu3X4/1wwsROeQOXPmYPfu3R5jztT9hg0bhuLiYhgMBnz88ceYNWsWNm3aFOxm9UknTpzA/fffj40bN0Kj0QS7OX3e1VdfLT3OzMxEdnY20tLS8NFHH0Gr1fr1szkk1I7Y2FgoFIpW1c0VFRVITEwMUqvODe7zy3Pfve677z7861//wrfffot+/fpJ2xMTE2Gz2VBXV+exP8+371QqFQYPHowxY8agoKAAWVlZeOGFF3iu/aCoqAiVlZW44IILoFQqoVQqsWnTJrz44otQKpVISEjgOfejyMhIDB06FIcOHfL73zcDSztUKhXGjBmDwsJCaZvT6URhYSFycnKC2LK+b8CAAUhMTPQ490ajEdu3b+e594EgCLjvvvvw2Wef4ZtvvsGAAQM8Xh8zZgxCQkI8zvf+/ftRUlLC891NnE4nrFYrz7UfTJw4Eb/88guKi4ulZezYsZgxY4b0mOfcfxoaGnD48GEkJSX5/++7y2W7fdiHH34oqNVqYfXq1cKePXuEO++8U4iMjBTKy8uD3bRer76+Xvjxxx+FH3/8UQAgLF26VPjxxx+F48ePC4IgCEuWLBEiIyOFL774Qvj555+FKVOmCAMGDBAaGxuD3PLe55577hH0er3w3XffCWVlZdJiNpulfe6++26hf//+wjfffCP88MMPQk5OjpCTkxPEVvdec+fOFTZt2iQcPXpU+Pnnn4W5c+cKMplM+M9//iMIAs91ILS8SkgQeM6701/+8hfhu+++E44ePSps2bJFyM3NFWJjY4XKykpBEPx7rhlYOvDSSy8J/fv3F1QqlTBu3Dhh27ZtwW5Sn/Dtt98KAFots2bNEgRBvLR5wYIFQkJCgqBWq4WJEycK+/fvD26je6m2zjMA4c0335T2aWxsFO69914hKipK0Ol0wtSpU4WysrLgNboX++Mf/yikpaUJKpVKiIuLEyZOnCiFFUHguQ6EMwMLz3n3mTZtmpCUlCSoVCohJSVFmDZtmnDo0CHpdX+ea5kgCELX+2mIiIiI/Ic1LERERNTjMbAQERFRj8fAQkRERD0eAwsRERH1eAwsRERE1OMxsBAREVGPx8BCREREPR4DCxEREfV4DCxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9Xj/HwN7ZhH5PrzQAAAAAElFTkSuQmCC"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "history = nnlm_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Training Swivel"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "swivel_model = build_model(swivel_module, name='swivel')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {},
+   "source": [
+    "swivel_history = train_and_evaluate(data, val_data, swivel_model)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:35:28.659782: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:35:28.659830: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n",
@@ -1623,16 +1623,16 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Epoch 1/50\n",
       " 6/51 [==>...........................] - ETA: 1s - loss: 1.3236 - accuracy: 0.2742"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:35:29.196649: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:35:29.196700: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n",
@@ -1654,8 +1654,8 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "51/51 [==============================] - 2s 29ms/step - loss: 1.0789 - accuracy: 0.4533 - val_loss: 0.8935 - val_accuracy: 0.6139\n",
       "Epoch 2/50\n",
@@ -1759,326 +1759,77 @@
      ]
     }
    ],
-   "source": [
-    "swivel_history = train_and_evaluate(data, val_data, swivel_model)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {},
+   "source": [
+    "history = swivel_history\n",
+    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
+    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 41,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 41
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABM1UlEQVR4nO3deXhU9aH/8fcsmckeyM4SVlkVAqKk0bZuUYqWi8v10moFsdLWQqumva20KtVepf31lmItFqUi1WqltYJWKepF0aooyqLsgiBhy8aSPTPJzPn9MUsmIYFMksnJ8nk9z3nOzJlzznznGJnPfLdjMQzDQERERMQkVrMLICIiIr2bwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFTKYyIiIiIqRRGRERExFQKIyIiImIqu9kFaA2v18vRo0dJSEjAYrGYXRwRERFpBcMwqKiooH///litLdd/dIswcvToUbKysswuhoiIiLTBoUOHGDhwYIuvd4swkpCQAPg+TGJiosmlERERkdYoLy8nKysr+D3ekm4RRgJNM4mJiQojIiIi3czZulioA6uIiIiYKuww8s477zBt2jT69++PxWJh9erVZ9z/2LFj3HTTTYwcORKr1cpdd93VxqKKiIhITxR2GKmqqiI7O5slS5a0an+Xy0VaWhr33nsv2dnZYRdQREREeraw+4xMnTqVqVOntnr/IUOG8MgjjwCwfPnycN9OREQEAI/HQ11dndnFkBA2mw273d7uaTe6ZAdWl8uFy+UKPi8vLzexNCIiYrbKykoOHz6MYRhmF0WaiI2NpV+/fjgcjjafo0uGkYULF/LAAw+YXQwREekCPB4Phw8fJjY2lrS0NE1+2UUYhoHb7aakpIQDBw4wYsSIM05sdiZdMozMnz+f/Pz84PPAOGUREel96urqMAyDtLQ0YmJizC6OhIiJiSEqKoqDBw/idruJjo5u03m6ZBhxOp04nU6ziyEiIl2IakS6prbWhjQ6RweUQ0RERKTNwq4ZqaysZN++fcHnBw4cYOvWrSQnJzNo0CDmz5/PkSNHePrpp4P7bN26NXhsSUkJW7duxeFwMHbs2PZ/AhEREenWwg4jH3/8MZdddlnweaBvx6xZs1ixYgXHjh2joKCg0TETJ04MPt60aRPPPfccgwcP5osvvmhjsUVERLq2Sy+9lAkTJrB48WKzi9LlhR1GLr300jMOrVqxYsVp2zQUS0RERFrSJTuwdpZVWw6zpeAUXx/fn8lDk80ujoiISK/Uqzuwvrm7hKc3HGTbkTKziyIiIq1kGAbV7npTlrbW9J88eZKZM2fSt29fYmNjmTp1Knv37g2+fvDgQaZNm0bfvn2Ji4vj3HPPZc2aNcFjb7755uDQ5hEjRvDUU091yLXsKnp1zUhKnG+2uOOVrrPsKSIiXUVNnYex979mynvvfHAKsY7wvzpvvfVW9u7dy8svv0xiYiI//elPufrqq9m5cydRUVHMnTsXt9vNO++8Q1xcHDt37iQ+Ph6A++67j507d/Kvf/2L1NRU9u3bR01NTUd/NFMpjAAnqtwml0RERHqqQAh57733uOiiiwB49tlnycrKYvXq1dx4440UFBRwww03MG7cOACGDRsWPL6goICJEydywQUXAL57vvU0vTqMJMf7a0YURkREuo2YKBs7H5xi2nuHa9euXdjtdnJycoLbUlJSGDVqFLt27QLghz/8IXfccQevv/46eXl53HDDDYwfPx6AO+64gxtuuIHNmzdz1VVXce211wZDTU/Rq/uMqJlGRKT7sVgsxDrspiyRmgX29ttvZ//+/dxyyy1s27aNCy64gEcffRSAqVOncvDgQe6++26OHj3KFVdcwY9//OOIlMMsvTuMxPumnFczjYiIRMqYMWOor6/nww8/DG47fvw4e/bsaTT5Z1ZWFt/73vd48cUX+dGPfsSyZcuCr6WlpTFr1iz+8pe/sHjxYp544olO/QyR1rubaYI1IwojIiISGSNGjGD69OnMmTOHxx9/nISEBO655x4GDBjA9OnTAbjrrruYOnUqI0eO5OTJk7z11luMGTMGgPvvv59JkyZx7rnn4nK5eOWVV4Kv9RS9umYkNc5XM1LhqsdV7zG5NCIi0lM99dRTTJo0ia9//evk5uZiGAZr1qwhKioKAI/Hw9y5cxkzZgxf+9rXGDlyJI899hgADoeD+fPnM378eL761a9is9l4/vnnzfw4Hc5idIPpUcvLy0lKSqKsrIzExMQOO69hGIz4+b+o9xp8MP8KMpPadutjERGJnNraWg4cOMDQoUPbfIt6iZwz/fdp7fd3r64ZsVgs9PU31ZSqE6uIiIgpenUYAc01IiIiYjaFkXiFERERETP1+jCS7O/EqmYaERERc/T6MKJmGhEREXMpjGiuEREREVMpjPhnYdX9aURERMzR68NIcrCZRn1GREREzNDrw0iK7twrIiJiKoWRQM2I+oyIiEgXMmTIEBYvXtyqfS0WC6tXr45oeSJJYUT3pxERETFVrw8jiTF27FYLoOG9IiIiZuj1YcRisQQ7sWp4r4hIN2AY4K4yZ2nlvWWfeOIJ+vfvj9frbbR9+vTp3HbbbXz++edMnz6djIwM4uPjufDCC/m///u/DrtE27Zt4/LLLycmJoaUlBS+853vUFlZGXx9/fr1TJ48mbi4OPr06cPFF1/MwYMHAfjkk0+47LLLSEhIIDExkUmTJvHxxx93WNmaY4/o2buJ5DgHxRUudWIVEekO6qrh4f7mvPfPjoIj7qy73XjjjfzgBz/grbfe4oorrgDgxIkTrF27ljVr1lBZWcnVV1/NQw89hNPp5Omnn2batGns2bOHQYMGtauIVVVVTJkyhdzcXD766COKi4u5/fbbmTdvHitWrKC+vp5rr72WOXPm8Ne//hW3283GjRuxWHytBDfffDMTJ07kj3/8Izabja1btxIVFdWuMp2Nwgih96fR8F4REWm/vn37MnXqVJ577rlgGHnhhRdITU3lsssuw2q1kp2dHdz/l7/8JatWreLll19m3rx57Xrv5557jtraWp5++mni4nzB6Q9/+APTpk3j17/+NVFRUZSVlfH1r3+d4cOHAzBmzJjg8QUFBfz3f/83o0ePBmDEiBHtKk9rKIzQ0IlVzTQiIt1AVKyvhsKs926lm2++mTlz5vDYY4/hdDp59tln+cY3voHVaqWyspJf/OIXvPrqqxw7doz6+npqamooKChodxF37dpFdnZ2MIgAXHzxxXi9Xvbs2cNXv/pVbr31VqZMmcKVV15JXl4e//Vf/0W/fv0AyM/P5/bbb+eZZ54hLy+PG2+8MRhaIqXX9xmBhonP1EwjItINWCy+phIzFn9TRmtMmzYNwzB49dVXOXToEP/+97+5+eabAfjxj3/MqlWrePjhh/n3v//N1q1bGTduHG5353wPPfXUU2zYsIGLLrqIlStXMnLkSD744AMAfvGLX7Bjxw6uueYa3nzzTcaOHcuqVasiWh6FESA1XnONiIhIx4qOjub666/n2Wef5a9//SujRo3i/PPPB+C9997j1ltv5brrrmPcuHFkZmbyxRdfdMj7jhkzhk8++YSqqqrgtvfeew+r1cqoUaOC2yZOnMj8+fN5//33Oe+883juueeCr40cOZK7776b119/neuvv56nnnqqQ8rWEoURIDnQTKM+IyIi0oFuvvlmXn31VZYvXx6sFQFfP4wXX3yRrVu38sknn3DTTTedNvKmPe8ZHR3NrFmz2L59O2+99RY/+MEPuOWWW8jIyODAgQPMnz+fDRs2cPDgQV5//XX27t3LmDFjqKmpYd68eaxfv56DBw/y3nvv8dFHHzXqUxIJ6jOCmmlERCQyLr/8cpKTk9mzZw833XRTcPuiRYu47bbbuOiii0hNTeWnP/0p5eXlHfKesbGxvPbaa9x5551ceOGFxMbGcsMNN7Bo0aLg67t37+bPf/4zx48fp1+/fsydO5fvfve71NfXc/z4cWbOnElRURGpqalcf/31PPDAAx1StpZYDKOVg6b93nnnHX7zm9+wadMmjh07xqpVq7j22mvPeMz69evJz89nx44dZGVlce+993Lrrbe2+j3Ly8tJSkqirKyMxMTEcIrbKh9/cYL/XLqBwSmxvP3fl3X4+UVEpO1qa2s5cOAAQ4cOJTo62uziSBNn+u/T2u/vsJtpqqqqyM7OZsmSJa3a/8CBA1xzzTVcdtllbN26lbvuuovbb7+d1157Ldy3jhhNeiYiImKesJtppk6dytSpU1u9/9KlSxk6dCi//e1vAV/HmnfffZff/e53TJkyJdy3j4jA0N5K//1pnHabySUSERHxefbZZ/nud7/b7GuDBw9mx44dnVyijhfxPiMbNmwgLy+v0bYpU6Zw1113tXiMy+XC5WroTNpR7WgtCdyfpt5rcKLKTb+kmIi+n4iISGv9x3/8Bzk5Oc2+FumZUTtLxMNIYWEhGRkZjbZlZGRQXl5OTU0NMTGnf/EvXLgw4p1lQgXuT1Nc4eJ4pcKIiIh0HQkJCSQkJJhdjIjqkkN758+fT1lZWXA5dOhQxN8zJT4wvFf9RkREuqIwx1tIJ+mI/y4RrxnJzMykqKio0baioiISExObrRUBcDqdOJ3OSBetkZRgJ1bNNSIi0pXYbL5+fG63u8XvDTFPdXU10L4mo4iHkdzcXNasWdNo2xtvvEFubm6k3zosgRE1J1QzIiLSpdjtdmJjYykpKSEqKgqrtUtW6vc6hmFQXV1NcXExffr0CYbGtgg7jFRWVrJv377g8wMHDrB161aSk5MZNGgQ8+fP58iRIzz99NMAfO973+MPf/gDP/nJT7jtttt48803+dvf/sarr77a5kJHQuDOvWqmERHpWiwWC/369ePAgQMcPHjQ7OJIE3369CEzM7Nd5wg7jHz88cdcdlnDxGD5+fkAzJo1ixUrVnDs2LFGdx0cOnQor776KnfffTePPPIIAwcO5E9/+lOXGdYboGYaEZGuy+FwMGLEiE67kZy0TlRUVLtqRALCDiOXXnrpGTurrFixotljtmzZEu5bdarA/WnUTCMi0jVZrVbNwNpDqeHNT800IiIi5lAY8UvRlPAiIiKmUBjxC8wzomYaERGRzqUw4hcY2lvpqqe2zmNyaURERHoPhRG/xGg7UTYLoNoRERGRzqQw4he4Pw0ojIiIiHQmhZEQgeG9pZprREREpNMojIRIUc2IiIhIp1MYCRGYa0RhREREpPMojIQI9Bkp1VwjIiIinUZhJERDM436jIiIiHQWhZEQgYnPNAuriIhI51EYCRFoptH9aURERDqPwkiIVHVgFRER6XQKIyEC84wc1zwjIiIinUZhJESgmabK7dH9aURERDqJwkgI3Z9GRESk8ymMhAi9P41G1IiIiHQOhZEmgv1GNNeIiIhIp1AYaSIwokY1IyIiIp1DYaSJZN0sT0REpFMpjDSREmymURgRERHpDAojTaQEm2nUZ0RERKQzKIw0oWYaERGRzqUw0kSK7k8jIiLSqRRGmgg202hor4iISKdQGGkiMM/ICQ3tFRER6RQKI00EakZ0fxoREZHOoTDSRIKz4f406jciIiISeQojTVgsluBcI2qqERERiTyFkWYEhveWqhOriIhIxLUpjCxZsoQhQ4YQHR1NTk4OGzdubHHfuro6HnzwQYYPH050dDTZ2dmsXbu2zQXuDIF+I6oZERERibyww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcXGz+9977708/vjjPProo+zcuZPvfe97XHfddWzZsqXdhY+UFE18JiIi0mnCDiOLFi1izpw5zJ49m7Fjx7J06VJiY2NZvnx5s/s/88wz/OxnP+Pqq69m2LBh3HHHHVx99dX89re/bXfhIyUwvFfNNCIiIpEXVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3G5XERHRzfaFhMTw7vvvtvi+7hcLsrLyxstnUnNNCIiIp0nrDBSWlqKx+MhIyOj0faMjAwKCwubPWbKlCksWrSIvXv34vV6eeONN3jxxRc5duxYi++zcOFCkpKSgktWVlY4xWw3TQkvIiLSeSI+muaRRx5hxIgRjB49GofDwbx585g9ezZWa8tvPX/+fMrKyoLLoUOHIlO4A+/Au4uhaEejzckKIyIiIp3GHs7Oqamp2Gw2ioqKGm0vKioiMzOz2WPS0tJYvXo1tbW1HD9+nP79+3PPPfcwbNiwFt/H6XTidDrDKVrbbHwCdv0T7NGQcW5wc7CZRn1GREREIi6smhGHw8GkSZNYt25dcJvX62XdunXk5uae8djo6GgGDBhAfX09//jHP5g+fXrbStyRkv2B6MTnjTYHJj07rj4jIiIiERdWzQhAfn4+s2bN4oILLmDy5MksXryYqqoqZs+eDcDMmTMZMGAACxcuBODDDz/kyJEjTJgwgSNHjvCLX/wCr9fLT37yk479JG2RPNy3PrG/8WZ/zUi1//400VG2zi6ZiIhIrxF2GJkxYwYlJSXcf//9FBYWMmHCBNauXRvs1FpQUNCoP0htbS333nsv+/fvJz4+nquvvppnnnmGPn36dNiHaLMUfxg53rhmJMFpx2Gz4vZ4OV7lZkCfGBMKJyIi0jtYDMMwzC7E2ZSXl5OUlERZWRmJiYkdeOKjsGgMWGxwbxHYooIvfenhdRSW1/LyvIsZP7BPx72niIhIL9Ha7+/efW+ahH4QFQuGB04VNHpJI2pEREQ6R+8OIxZLQyfWJk01gRE16sQqIiISWb07jAAkD/WtTxtRo+G9IiIinUFhpKURNYHhvWqmERERiSiFETXTiIiImEphJDC8t8VmGoURERGRSFIYCTTTnCqA+obgkRKvZhoREZHOoDCSkOkf3uttNLw3OLS3Uh1YRUREIklhJHR4b0hTjZppREREOofCCISEkYYRNSkh96epcXvMKJWIiEivoDACzY6oifffnwbguOYaERERiRiFEWh2RI3FYgn2G1FTjYiISOQojECLE59prhEREZHIUxiBhmaaJsN7dbM8ERGRyFMYAf/w3rjThvfq/jQiIiKRpzACLQ/vDUx8pmYaERGRiFEYCQjcvTdkRI2aaURERCJPYSQg5fROrKnxmoVVREQk0hRGApJPH96bHOdrptHQXhERkchRGAloZuIzNdOIiIhEnsJIQKCZpuxQcHhvquYZERERiTiFkYD4jJDhvQeBhpqRmjrdn0ZERCRSFEYCQof3+ptqdH8aERGRyFMYCZXS+O69FotFU8KLiIhEmMJIqGZH1OhmeSIiIpGkMBKqmRE1gVlYSzXXiIiISEQojIRqZuKzFNWMiIiIRJTCSKjk04f3qplGREQkshRGQsWngyPeN7z35BcAwQ6sJRVqphEREYkEhZFQFkvDDfP8TTWDk+MA2F9aZVapREREerQ2hZElS5YwZMgQoqOjycnJYePGjWfcf/HixYwaNYqYmBiysrK4++67qa2tbVOBI67JiJoRGfEA7CuuxDAMs0olIiLSY4UdRlauXEl+fj4LFixg8+bNZGdnM2XKFIqLi5vd/7nnnuOee+5hwYIF7Nq1iyeffJKVK1fys5/9rN2Fj4gmI2qGpMRhs1qodNVTWN5FA5SIiEg3FnYYWbRoEXPmzGH27NmMHTuWpUuXEhsby/Lly5vd//333+fiiy/mpptuYsiQIVx11VV885vfPGttimmajKhx2K0MSYkFYG9RpVmlEhER6bHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDsMRdddBGbNm0Kho/9+/ezZs0arr766hbfx+VyUV5e3mjpNM1MfDYiPQGAvcUKIyIiIh0trDBSWlqKx+MhIyOj0faMjAwKCwubPeamm27iwQcf5Mtf/jJRUVEMHz6cSy+99IzNNAsXLiQpKSm4ZGVlhVPM9gk005QdhnrfCJrQfiMiIiLSsSI+mmb9+vU8/PDDPPbYY2zevJkXX3yRV199lV/+8pctHjN//nzKysqCy6FDhyJdzAaNhvf67t57TnogjFR0XjlERER6CXs4O6empmKz2SgqKmq0vaioiMzMzGaPue+++7jlllu4/fbbARg3bhxVVVV85zvf4ec//zlW6+l5yOl04nQ6wylaxwncvbfwU19TTdrIYBj5rMg3osZisZhTNhERkR4orJoRh8PBpEmTWLduXXCb1+tl3bp15ObmNntMdXX1aYHDZrMBdN2hsk1G1AxPi8digbKaOkp1914REZEOFVbNCEB+fj6zZs3iggsuYPLkySxevJiqqipmz54NwMyZMxkwYAALFy4EYNq0aSxatIiJEyeSk5PDvn37uO+++5g2bVowlHQ5TUbUREfZGJQcy8Hj1ewtriAtwaRaGxERkR4o7DAyY8YMSkpKuP/++yksLGTChAmsXbs22Km1oKCgUU3Ivffei8Vi4d577+XIkSOkpaUxbdo0HnrooY77FB2t2RE18Rw8Xs3nxZVcNDzVpIKJiIj0PBajy7aVNCgvLycpKYmysjISExMj/4YHN8BTX4OkQXD3NgB+9a/dLH37c2bmDubB6edFvgwiIiLdXGu/v3VvmuakhN691ze8N9CJVROfiYiIdCyFkebEpYEjATCCd+8dEQgjmmtERESkQymMNKeZu/cO94eR0koXp6o1okZERKSjKIy0JNBU4x/eG++0M6BPDKCZWEVERDqSwkhLmhlRc46aakRERDqcwkhLAhOf+ZtpIKTfiDqxioiIdBiFkZYEm2kawkhDzYjuUSMiItJRFEZakhwyvLeuFtDde0VERCJBYaQlcakNw3tP+e/em5YAwLGyWipq60wsnIiISM+hMNISiwVSGt8wLyk2inT/fWk+L6kyq2QiIiI9isLImTR3j5qMQCdW9RsRERHpCAojZ9LsiBpfU436jYiIiHQMhZEzaTLxGTTMxKq5RkRERDqGwsiZBJtpmplrRMN7RUREOoTCyJkEmmnKDjcM7/WHkcMna6hxe8wqmYiISI+hMHImcangTCT07r0p8U6S4xwYBnxeoqYaERGR9lIYOROLJaQT6+n3qFEnVhERkfZTGDmbZkbUaFp4ERGRjqMwcjbBETX7gpt0wzwREZGOozByNmmjfeviXcFNmmtERESk4yiMnE3mON+6cDt4vUDDLKwHT1TjqteIGhERkfZQGDmb5OFgj4a6Kjh5AID0BCcJ0XY8XoMvSqtNLqCIiEj3pjByNjY7pI/1PS7cBoDFYtHkZyIiIh1EYaQ1gk0124KbzlEnVhERkQ6hMNIazYQRdWIVERHpGAojrREII0Xbg5vOydDEZyIiIh1BYaQ1Ms71rcuPQNVxoGGukf2lldR7vGaVTEREpNtTGGkNZwL0Hep7XORrqumfFEOsw0adx+DgCY2oERERaSuFkdYKnW8EsFot6sQqIiLSARRGWitzvG8dOqImLdBvRMN7RURE2kphpLUyz/OtQ8OIOrGKiIi0W5vCyJIlSxgyZAjR0dHk5OSwcePGFve99NJLsVgspy3XXHNNmwttikAzTekeqHcBDcN79yqMiIiItFnYYWTlypXk5+ezYMECNm/eTHZ2NlOmTKG4uLjZ/V988UWOHTsWXLZv347NZuPGG29sd+E7VeIAiOkL3noo2Q00jKjZV1yJx2uYWToREZFuK+wwsmjRIubMmcPs2bMZO3YsS5cuJTY2luXLlze7f3JyMpmZmcHljTfeIDY2tvuFEYsFMgJNNb5OrFnJsTjsVlz1Xo6crDGxcCIiIt1XWGHE7XazadMm8vLyGk5gtZKXl8eGDRtadY4nn3ySb3zjG8TFxbW4j8vlory8vNHSJTTpxGqzWhiepnvUiIiItEdYYaS0tBSPx0NGRkaj7RkZGRQWFp71+I0bN7J9+3Zuv/32M+63cOFCkpKSgktWVlY4xYycM92jRv1GRERE2qRTR9M8+eSTjBs3jsmTJ59xv/nz51NWVhZcDh061EklPIvAiJqibWD4+oiE9hsRERGR8NnD2Tk1NRWbzUZRUVGj7UVFRWRmZp7x2KqqKp5//nkefPDBs76P0+nE6XSGU7TOkToKrFFQWwZlh6DPoGAYUc2IiIhI24RVM+JwOJg0aRLr1q0LbvN6vaxbt47c3NwzHvv3v/8dl8vFt771rbaVtCuwOyB9tO+xv6lmRGCukaIKDEMjakRERMIVdjNNfn4+y5Yt489//jO7du3ijjvuoKqqitmzZwMwc+ZM5s+ff9pxTz75JNdeey0pKSntL7WZMhpPCz84JQ671UKV28OxsloTCyYiItI9hdVMAzBjxgxKSkq4//77KSwsZMKECaxduzbYqbWgoACrtXHG2bNnD++++y6vv/56x5TaTJnj4BOg8FMAomxWhqbGsbe4kr3FlfTvE2Nu+URERLqZsMMIwLx585g3b16zr61fv/60baNGjeo5TRjNTQufHs/e4kr2FVdyycg0kwomIiLSPeneNOEKTHx26qCvIyuhI2o014iIiEi4FEbCFZsMSf55T4p2AHBOhu8eNZ8VaUSNiIhIuBRG2iKjcVPN6ExfGNl1rFz3qBEREQmTwkhbNJmJdXhaPLEOG9VuD5+XqHZEREQkHAojbdEkjNisFsYNSAJg66FTJhVKRESke1IYaYvAiJriXeCpByA7qw8Anx4+ZU6ZREREuimFkbboMwQcCeBxwfG9AGQP7APAJ4fKzCuXiIhIN6Qw0hZW62nzjYwf6Gum2V1YjqveY1bJREREuh2FkbZqMqJmYN8YUuIc1HkMdh3TfCMiIiKtpTDSVk06sVoslmDtyCfqxCoiItJqCiNtFRpG/FPdjw/0G1EnVhERkVZTGGmr9DFgsUJ1KVQWATDBP6JGNSMiIiKtpzDSVlExkDrS97hJJ9b9pVWU19aZVTIREZFuRWGkPYJNNZ8CkBLvZGDfGAwDth/WEF8REZHWUBhpj+CImu3BTcH5RhRGREREWkVhpD2ajKiBhqYazcQqIiLSOgoj7REII8f3gbsKaJgWXp1YRUREWkdhpD3i0yE+AzB896kBzhuQhMUCR8tqKa6oNbd8IiIi3YDCSHs16cQa77QzIj0egE91nxoREZGzUhhpr2b7jfQB1G9ERESkNRRG2qu5ETWBfiMaUSMiInJWCiPtlTnety7aAV7f3XqzA/eoOXwKwz9VvIiIiDRPYaS9UoaDPQbqquDEAQBGZybisFk5VV3HoRM1JhdQRESka1MYaS+rDTLG+h4X+fqNOOxWxvRPBGCr+o2IiIickcJIR2imE2ugqeZTzTciIiJyRgojHaHZMNIH8PUbERERkZYpjHSEzGzf+vDH4PUCkJ3lqxnZfqSceo/XrJKJiIh0eQojHaH/BHDEQ80JKPIN8R2WGk+8005NnYd9JZXmlk9ERKQLUxjpCLYoGHyR7/GBtwGwWi2MG+Af4qt+IyIiIi1SGOkoQy/xrfe/Hdw0Pisw34gmPxMREWmJwkhHGeYPIwffh3o3ABMCnVhVMyIiItKiNoWRJUuWMGTIEKKjo8nJyWHjxo1n3P/UqVPMnTuXfv364XQ6GTlyJGvWrGlTgbus9HMhNsU3+dmRTQCM908Lv6ewgto6j4mFExER6brCDiMrV64kPz+fBQsWsHnzZrKzs5kyZQrFxcXN7u92u7nyyiv54osveOGFF9izZw/Lli1jwIAB7S58l2K1wtCv+h77+430T4omNd5Jvddgx9FyEwsnIiLSdYUdRhYtWsScOXOYPXs2Y8eOZenSpcTGxrJ8+fJm91++fDknTpxg9erVXHzxxQwZMoRLLrmE7Ozsdhe+y2nSb8RisTRMfqb5RkRERJoVVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3n55ZfJzc1l7ty5ZGRkcN555/Hwww/j8bTcbOFyuSgvL2+0dAuBfiOHPwJ3FQDj/f1GPlUnVhERkWaFFUZKS0vxeDxkZGQ02p6RkUFhYWGzx+zfv58XXngBj8fDmjVruO+++/jtb3/L//zP/7T4PgsXLiQpKSm4ZGVlhVNM8/QdCkmDwFsHB33hLDD5mTqxioiINC/io2m8Xi/p6ek88cQTTJo0iRkzZvDzn/+cpUuXtnjM/PnzKSsrCy6HDh2KdDE7hsUCwwL9RtYDDTUj+0urKKupM6dcIiIiXVhYYSQ1NRWbzUZRUVGj7UVFRWRmZjZ7TL9+/Rg5ciQ2my24bcyYMRQWFuJ2u5s9xul0kpiY2GjpNoZe6lv7+40kxzkYlBwLwDY11YiIiJwmrDDicDiYNGkS69atC27zer2sW7eO3NzcZo+5+OKL2bdvH15vw/1ZPvvsM/r164fD4WhjsbuwwIiawm1QfQKA8QMDk5+dMqlQIiIiXVfYzTT5+fksW7aMP//5z+zatYs77riDqqoqZs+eDcDMmTOZP39+cP877riDEydOcOedd/LZZ5/x6quv8vDDDzN37tyO+xRdSUIGpI0BDDjwDtBwB1+NqBERETmdPdwDZsyYQUlJCffffz+FhYVMmDCBtWvXBju1FhQUYLU2ZJysrCxee+017r77bsaPH8+AAQO48847+elPf9pxn6KrGXYJlOzyzTdy7rVk+yc/++SQmmlERESashiGYZhdiLMpLy8nKSmJsrKy7tF/ZPcaeP6bkDwcfriZanc95y14Da8BH/7sCjISo80uoYiISMS19vtb96aJhCEXg8UKJz6HssPEOuyMzEgANMRXRESkKYWRSIhOgv7n+x77R9WMD87EqqYaERGRUAojkRKYjdV/n5pgvxF1YhUREWlEYSRSQu9TYxjBETWfHDqF19vlu+mIiIh0GoWRSMnKAXs0VBZC6WeMykwgzmGjvLaebUfUVCMiIhKgMBIpUdG+QAKw/22ibFYuHZUOwOs7m7+Pj4iISG+kMBJJTfqNXHWuby6WN3YWtXSEiIhIr6MwEklDL/Wtv/g3eD1cOiodu9XCZ0WVfFFaZWbJREREugyFkUjqPwGcSVBbBsc+ISkmii8NSwFUOyIiIhKgMBJJVhsM+bLvsb+p5sqxvqYa9RsRERHxURiJtGEhQ3xpCCObDp6ktNJlVqlERES6DIWRSAvMN1LwAdS76N8nhvMGJOI14M1dxeaWTUREpAtQGIm0tFEQnwn1NXBoIwBXjc0E1FQjIiICCiORZ7HA0K/6HjfpN/LvvaVUu+vNKpmIiEiXoDDSGQJhxN9vZHRmAlnJMbjqvbzzWamJBRMRETGfwkhnCHRiPbIJasuxWCxcOcbXVKMhviIi0tspjHSGPoOg71AwPHDwfaBhNtZ1u4uo93jNLJ2IiIipFEY6S5Op4S8Y3Jc+sVGcqq7j44MnTSyYiIiIuRRGOsvQxvON2G1WrhjtnwBth5pqRESk91IY6SxDLwEsULwDSvcBDaNq3thViGEYJhZORETEPAojnSUuBUZc5Xv88ZMAfHVkKk67lUMnathdWGFi4URERMyjMNKZJn/Ht97yLLiriHXY+cqIVECjakREpPdSGOlMwy+H5GHgKoNP/wZoNlYRERGFkc5ktcKFt/seb1wGhsHlY9KxWGD7kXKOnqoxt3wiIiImUBjpbBNuAnuMryNrwQZS451cMLgvoKYaERHpnRRGOltMXxj/X77HG5cBDU01CiMiItIbKYyYYfIc33rXy1BRGBzi+8H+45TV1JlYMBERkc6nMGKGzHGQ9SXw1sOmFQxJjWNkRjz1XoP1e4rNLp2IiEinUhgxS6B25OOnwFMXrB3RbKwiItLbKIyYZcx/QFw6VBbCrn8G+42s31OMq95jcuFEREQ6T5vCyJIlSxgyZAjR0dHk5OSwcePGFvddsWIFFoul0RIdHd3mAvcYdgdcMNv3+KM/MW5AEhmJTqrcHt7//Li5ZRMREelEYYeRlStXkp+fz4IFC9i8eTPZ2dlMmTKF4uKW+zokJiZy7Nix4HLw4MF2FbrHmHQrWGxw8D2sJTsb7lWjUTUiItKLhB1GFi1axJw5c5g9ezZjx45l6dKlxMbGsnz58haPsVgsZGZmBpeMjIx2FbrHSOwPY6b5Hm9cxpUhQ3y9Xt04T0REeoewwojb7WbTpk3k5eU1nMBqJS8vjw0bNrR4XGVlJYMHDyYrK4vp06ezY8eOM76Py+WivLy80dJjBTqyfrqS3P52Epx2SipcfLBfTTUiItI7hBVGSktL8Xg8p9VsZGRkUFjY/L1VRo0axfLly3nppZf4y1/+gtfr5aKLLuLw4cMtvs/ChQtJSkoKLllZWeEUs3sZfDGkjYG6ahzbn2f6xP4ALFm/z+SCiYiIdI6Ij6bJzc1l5syZTJgwgUsuuYQXX3yRtLQ0Hn/88RaPmT9/PmVlZcHl0KFDkS6meSyWhtqRjcv43leHYrdaeG/fcTYdPGlu2URERDpBWGEkNTUVm81GUVHjDpZFRUVkZma26hxRUVFMnDiRffta/uXvdDpJTExstPRo42eAMxFOfM7AEx9y/fkDAHj0zb0mF0xERCTywgojDoeDSZMmsW7duuA2r9fLunXryM3NbdU5PB4P27Zto1+/fuGVtCdzxvtuoAfw0Z/4/qXnYLXA+j0lfHr4lKlFExERibSwm2ny8/NZtmwZf/7zn9m1axd33HEHVVVVzJ7tmzNj5syZzJ8/P7j/gw8+yOuvv87+/fvZvHkz3/rWtzh48CC33357x32KnuBC//XY8y+G2EqZPiFQO6K+IyIi0rPZwz1gxowZlJSUcP/991NYWMiECRNYu3ZtsFNrQUEBVmtDxjl58iRz5syhsLCQvn37MmnSJN5//33Gjh3bcZ+iJ0gdAcMug/1vwcfLmXvZf7N66xHe2FnErmPljOnXw5uqRESk17IYhtHlJ7QoLy8nKSmJsrKynt1/ZPer8PxNEJMM+TuZ+/ddvPrpMa4Z148lN59vdulERETC0trvb92bpisZ+TVIGgQ1J+Cd/+UHl58DwJrtx9hXXGFy4URERCJDYaQrsdrgql/6Hr/7O0Z793PV2AwMA/6gviMiItJDKYx0NedeC2OvBcMDq7/PDy8ZDMDLnxzlQGmVqUUTERGJBIWRrujq/4XYFCjewXn7/8Rlo9LwGvDYW6odERGRnkdhpCuKT4Orf+N7/O//5ScT3ACs2nKEQyeqTSyYiIhIx1MY6arOvd53R19vPWM+vIdLhveh3mvwx7c/N7tkIiIiHUphpKuyWOCaRRDTFwq38T9pbwDwwseHOVZWY3LhREREOo7CSFcWnw5Tfc01WZ/+gf8cWIbb4+Xxt/ebXDAREZGOozDS1Y37Txh1DXjr+IX3D9ip568bCyiuqDW7ZCIiIh1CYaSrs1jg64sgug/xJ3bwQMo6XPVelr2j2hEREekZFEa6g4RMmPprAL5Z8xwjLIf5ywcFHK90mVwwERGR9lMY6S7Gz4CRX8PqrWNJ3J9w17l5aM0us0slIiLSbgoj3YXFAl//HTiTGFn/GXPsa3hx8xFe2nrE7JKJiIi0i8JId5LYH762EIAfR/2D0ZYC7l21XROhiYhIt6Yw0t1MuAnOuRK74eavMb8m1X2Iu1Zupd7jNbtkIiIibaIw0t1YLHD9E5Axjr7ekzzveIjigt08qrv6iohIN6Uw0h3FJsPM1ZA2mgzLCZ6Leph/vLmBj784YXbJREREwqYw0l3FpcLMlyB5OFnWEp6Jeohf/vVNymrqzC6ZiIhIWBRGurOETJj1T7x9BjPUWsRva+7jVy/8G8MwzC6ZiIhIqymMdHdJA7DO+ifuuP6cYz3KzL0/5JUPdphdKhERkVZTGOkJ+g7GcdsrVDlSGWM9xNC1t1Bw5KjZpRIREWkVhZGeImU40d9+hTJrEudZ9lP91HXUVZeZXSoREZGzUhjpQWwZY3B9cxWniGd0/W4K//gf4K4yu1giIiJnpDDSw6SPmMSOy1dQbsSQVbGVyj/mQanmIBERka5LYaQHuvirV/LMOb/jhBFP/MmdeJZ+BT553uxiiYiINEthpIf69jf+i3szH+cD7xhs9dWw6ruw6g5wVZpdNBERkUYURnqo6Cgbv7nta/yu329YVPefeLDAJ8/BE5fAsU/NLp6IiEiQwkgPFue08+Rtufx7wG3c5LqXIpLh+D74Ux5sXAaaHE1ERLoAhZEeLt5pZ8XsydQM+BJfq32YdyyTwOOCNT+Gld+Cat3PRkREzKUw0gskxUTx9G2T6ddvIDNr8vmtdTaGNQp2vwJLvwIH3jG7iCIi0ospjPQSfWId/OX2HEZlJPJo9ZXMtj1MXdIQKD8Mf54Gf/0mlOwxu5giItILtSmMLFmyhCFDhhAdHU1OTg4bN25s1XHPP/88FouFa6+9ti1vK+2UHOfg2Tk5nJMez/qKAVxd+xCV42aCxQZ71sBjX4J/3gkVhWYXVUREepGww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcfEZj/viiy/48Y9/zFe+8pU2F1baLzXeyXO35zA0NY69ZRau/vx6imeuh9FfB8MLm1bA7yfCmw+Bq8Ls4oqISC8QdhhZtGgRc+bMYfbs2YwdO5alS5cSGxvL8uXLWzzG4/Fw880388ADDzBs2LB2FVjaLz0xmufm5DAoOZaCE9Vct7KUbV9+DGavhYEXQl01vPP/fKFk4zLw1JldZBER6cHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDicQ8++CDp6el8+9vfbtX7uFwuysvLGy3SsfolxfDcHF8NyZFTNdyw9H3+XjIQvv0G/NczkDwcqkp8o26W5MC2FxRKREQkIsIKI6WlpXg8HjIyMhptz8jIoLCw+X4G7777Lk8++STLli1r9fssXLiQpKSk4JKVlRVOMaWVBvaNZfXci8kbk4673st/v/Ap9760HffIr8PcD+Hq/4W4NDjxOfzj2/C7c2HdL+FUgdlFFxGRHiSio2kqKiq45ZZbWLZsGampqa0+bv78+ZSVlQWXQ4cORbCUvVtSTBRP3HIB+VeOxGKBv3xQwDee2EBRlQcmz4EfboFLfwbxGVBZBP/+X1g8Hp69Efb8C7wesz+CiIh0cxbDaP00nG63m9jYWF544YVGI2JmzZrFqVOneOmllxrtv3XrViZOnIjNZgtu83q9gK95Z8+ePQwfPvys71teXk5SUhJlZWUkJia2trgSprd2F3Pn81sor60nLcHJYzefz4VDkn0veup8I24+Xg771zcclDgQJs2CibdAYj9Tyi0iIl1Ta7+/wwojADk5OUyePJlHH30U8IWLQYMGMW/ePO65555G+9bW1rJvX+Pb1997771UVFTwyCOPMHLkSBwOR4d9GGm/L0qr+N5fNrG7sAK71cJ9Xx/LzNzBWCyWhp2Ofw6bnoItz0KNfwZXiw1Gfg3Ou963dsab8wFERKTLiFgYWblyJbNmzeLxxx9n8uTJLF68mL/97W/s3r2bjIwMZs6cyYABA1i4cGGzx996662cOnWK1atXd/iHkY5R7a7np//Yxj8/OQrA9RMH8NB144hx2BrvWFcLu/7pqy0peL9huz0azsmDsdfCyCkQrf9mIiK9UWu/v+3hnnjGjBmUlJRw//33U1hYyIQJE1i7dm2wU2tBQQFWqyZ27c5iHXZ+/40JZA9MYuG/dvPiliPsPFbOr24Yz4SsPg07RkXD+Bt9S/Eu+PRvsHM1nNjvm2p+9ytgc8DwK+Dca2HUVIhOMulTiYhIVxV2zYgZVDNing2fH2fec5s5XuXGYoFbvjSYH08ZRWJ0VPMHGAYUbYedL8GO1XB8b8Nr1igYfhkMuxQGXwQZ48AWdh4WEZFuImLNNGZQGDFXaaWLh1/dxYtbjgCQnuBkwbRzuXpcZuO+JE0Zhq/GZOdqXzgp2d34dUcCDMrxBZPBF0P/iWB3Ru6DiIhIp1IYkQ73/r5Sfr56OwdKqwC4bFQaD04/j6zk2NadoHg3fLYWDr4PBR+Aq6zx6/Zo3wywgy+CftmQNhr6DgGrrdnTiYhI16YwIhFRW+fhsfWfs3T957g9XqKjrNyVN5Jvf3koUbYw+gp5PVC0wxdMDr7nW1eXnr6fPQbSRkL6WEgfA2ljfOukgXCmWhkRETGdwohE1L7iSn6+ahsfHvAN7R2dmcBD153HpMHJbTuhYUDpXl8wKfgAindCyR7wuJrf35EAqSMgZTiknONbkof5nquTrIh0dYbhm7/J4/YvIY+99Q3bvB7f8+DS5Hm9C+proK7Gd1+xulr/ugbq/Y/r/ec0PCHn8Jz+/MoH4JwrOvRjKoxIxBmGwT82H+GhV3dystp335qrxmZw95UjGdOvA/47eT1w4gCU7PL1PQksx/f6/gdqSVy6P6QMhz5DID7dN4NsQoZvHZcGthY64IqIObxe/5doNbgrfV+yQZaQmlD/OvC86Zeq4Q157P+SDX5h1/q+oOtr/V/WIds9Lt+Xtsfl2x4IBsFtbt/5LDawWsFi9T+2+dYWq287Fv9xrpB14Nzuhm3eLnivrxuehHH/2aGnVBiRTnOiys2v/rWLv286TOCv6Zrx/bjrihGMyEjo+Desd/vul3N8X8iy37euKm7dOWJTID7TF1Ti0iA2GWKS/eu+viV0myNezULSM3g9/i9kV8Ov5/rahl/U9SG/rOtCfnHX1/p/qTfz6zz0eSAAGIbvseFtCAmGf3u9C9xVUFflW7urfY97NYtvKgSbw/djyRble2y1gdUesoQ8t9h8nf6jYn1TLUTF+B7bo/3bYnyLzdHkeH+ACj2fxQoZ5/l+tHUghRHpdHuLKli8bi+vfnoM8H13T8/uz515IxmaGtc5hagt9wcVf1gpOwyVxVBZ6F8X+/5BDJfVDs5EcCaErP1LdMhzRzw44vxLC4+jYv3/8yvcdFmhX9iBL+vAL+PgL25vk+f+taeu8S/r4K/rkOr4wJcyRstrr/9c3rqQavy6xtX4ZwsG3nrw1Id8lpoz1yp2FVFxvi9Zi6XhegDBXzvB5zTz5Wpt/EUb/MKO8a3tMb4vbrt/CW6P9n1p252N16GPrbaQ2peQgBX6N4HRzHmcYHeErP2PA4EjcO4e+G+CwoiYZtexchb/32e8tqMIAJvVwnUTB/DDy0cwKKWVI28ixev1TWFfUei78V9lsa82peYkVJ/wvVZ90rcObGup30p7WKwt/KMYeO7wzcsS+IUUeGy1hzy3+9ahv3hsUaf/gmr2y47Tn7eq3BYaVZk3fW4Yjb+EA1+eoV/Ghqf5f4yD/0j7f8UF29CbqeIOfRwMDCFrT8hjwxtSxhbWhrfxObrDF3ZHsEb5/96cIb+kQ35V22Mafl0Hf2GHfvE3+aUe/JVtCWnCsIY0Y/jXtqiGkB4VGxLa43zvqYkzewyFETHd9iNl/O6Nz1i329d0YrdauPGCgXz7y8M4J72b3LvGMHxV1DUnwVXhX8pDHocstWX+KueqhnbvwHN3Jbgq21YrI+ay2v2/mqMaqsaDX8hN+g1Ybc2Hq9Bt1ij/cPWzBCSrzR86Hb7gaWsSUBtVvTdXjR+ybhp8AzUBGjYvEaYwIl3GloKT/O7/9vLOZyXBbRefk8ItXxpC3ph07OEMCe7OAm3lZ+tIF/iF7q1raKMPVtfXh2wP6WnfbFu+//UWazKarltR/uaaE4Kv+QWrt6P8tR+OxjUgFkvDKIBGowjqfDUaHrfvc9qi/Ofynyf0ceCLPfSL1dbkeaCGyWJtpuzekMf+6xJaXR84j82pWYJF2kFhRLqcj744weNv7+fN3UV4/X91/ZOiuSlnEDMuHERagmZfFRHpSRRGpMs6fLKa5z4sYOVHhzhe5QYgymZh6nn9mJk7mEmD+555mnkREekWFEaky3PVe1iz7RjPbDjI5oJTwe1j+iVy46SBfD27H+kJ0eYVUERE2kVhRLqV7UfKeGbDQV765Ai1dV4ArBa4aHgq/zGhP1POzSQpRhOViYh0Jwoj0i2VVdexeusRXtp6pFFticNm5bLRaUyfMIDLR6cTHaVRACIiXZ3CiHR7Bcer+eenR1m95Qh7iyuD2+Oddq46N4Orz+vHxeekEuNQMBER6YoURqTHMAyD3YUVvPzJUV7eepQjp2qCrznsVnKHpXD56HQuH51OVrLJk6qJiEiQwoj0SF6vweaCk/zzk6P8367iRsEE4Jz0eC4fnc5lo9K5YEhfonrLHCYiIl2Qwoj0eIZhsLe4kjd3F/Pm7mI2HTyJx9vw55wQbefL56SSOzyF3GEpnJMeryHDIiKdSGFEep2y6jre2VvCW7uLWf9ZCSf8c5gEpMY7g8Ekd3gKQ1JiFU5ERCJIYUR6NY/X4JPDp3h/Xykb9h/n4y9O4qr3NtonMzGa3OEp5AxN5vzBfRmeFo/NqnAiItJRFEZEQrjqPWwtOMWG/cfZ8PlxthScwu1pHE7inXbGD0xi4qA+TMjqy4SsPpqiXkSkHRRGRM6gts7DpoMn2fD5cT4+eIJPD5dR7T79jroD+sT4w0kfzhuQxNj+iSRGa/I1EZHWUBgRCYPHa/BZUQVbD51ia8Epthw6yd7iSpr7v2NQciznDUjk3P6+cHJu/0RNWy8i0gyFEZF2qqitY9vhMrYcOsUnh06x42j5aUOJA9ITnJzbP5FRmYmMyoxnRHoC56THa6ZYEenVFEZEIuBklZudx8rZcbSM7Ud86/2lVc3WoFgtMCQljhEZ8YzKSGBERgKjMhMYkhKHw675T0Sk51MYEekk1e56dh2rYOfRMvYUVfBZUSWfFVVwqrqu2f2tFshKjmVoahxDU+MYlhrH0NR4hqbF0S8xGqtG9IhID6EwImIiwzAoqXDxWVEle4oq2FtU4V9XUumqb/E4p93K0NQ4BqfEMijZt2T51wP6xuC0q9lHRLoPhRGRLigQUvaXVnHAv+wvqeJAaSUFJ6qp87T8v6PF4psbJRBOsvrGkpUcw0D/Oj0hWvOkiEiXojAi0s3Ue7wcOVXD/pIqCk5UB5dD/nVzQ49DRdksDOjTEE4G9o1lYN8Y+iXF0C8pmozEaPVVEZFO1drvb3tbTr5kyRJ+85vfUFhYSHZ2No8++iiTJ09udt8XX3yRhx9+mH379lFXV8eIESP40Y9+xC233NKWtxbpsew2K4NT4hicEnfaa4ZhcLzKHQwngYBy+GQNh05Wc/RULXUegy+OV/PF8epmz2+x+KbE75cU7V98ISXTH1QyEqNJT3AS52zTPwsiIm0W9r86K1euJD8/n6VLl5KTk8PixYuZMmUKe/bsIT09/bT9k5OT+fnPf87o0aNxOBy88sorzJ49m/T0dKZMmdIhH0Kkp7NYLKTGO0mNd3L+oL6nvV7v8VJYXsvhkzW+gOIPKodPVnOsrJbCslrcHi8lFS5KKlx8erisxfeKd9pJT3SSnuAMBpSMxGjSEpykJfi2pyVEkxht1719RKRDhN1Mk5OTw4UXXsgf/vAHALxeL1lZWfzgBz/gnnvuadU5zj//fK655hp++ctftmp/NdOItE+gZqWwrJajp2ooLK/l6KlaCstqOFpWS0mFi6Ly2rM2BYVy2K2kxYcGFKc/MDlIjnOSEu8gJc5BSryTPjFRGiUk0gtFpJnG7XazadMm5s+fH9xmtVrJy8tjw4YNZz3eMAzefPNN9uzZw69//etw3lpE2iG0ZuW8AUkt7lfpqqeovJai8oaAUlzuoqjCRUmFb1txhYuK2nrc9b4+Li1NBBfKaoHkOAfJcQ5S4pwk+4OK77kvvCTHOUiJ923rG+tQZ1yRXiSsMFJaWorH4yEjI6PR9oyMDHbv3t3icWVlZQwYMACXy4XNZuOxxx7jyiuvbHF/l8uFy+UKPi8vLw+nmCLSRvFOO/Fp8QxPiz/jfrV1nmAwKalwUVLpoqS8lpJKNyeqXJyocnO80s3xKjdlNXV4DSitdFNa6QYqz1oOiwWSYqJIjnXQJzaKvrEO+sY56Bsb5V/7lj6xUb4lxkFSTBTRUVY1HYl0Q53SUy0hIYGtW7dSWVnJunXryM/PZ9iwYVx66aXN7r9w4UIeeOCBziiaiLRBdJSNLP8cKGdT5/FyssoXTHwBxRdWTlT5wkkwvPi3naquwzDgVHVdixPHtcRht9InJoqkGF9ISfKHFN/jhnVScB/f64nRduw2jTQSMUtYfUbcbjexsbG88MILXHvttcHts2bN4tSpU7z00kutOs/tt9/OoUOHeO2115p9vbmakaysLPUZEekF6jxeTlb7QsnJKjcnq92crK7zBxXf45NVbk5U+2pdyqrrOFVTh8fbvlkKYh024p12EqLtJERH+dd2EpxRwW1JMXaSYqNIjG4cahJjonQfIpFmRKTPiMPhYNKkSaxbty4YRrxeL+vWrWPevHmtPo/X620UNppyOp04nc5wiiYiPUSUzUp6QnRYd0I2DINKVz1lNb7alMD6VE1DYCmrqWv0emAJzIhb7fZQ7fZQXNHyv01n4rBbSYqJIsEfaOL9QSY+GGp8gSbwPDT4BB7HOezq6Cu9UtjNNPn5+cyaNYsLLriAyZMns3jxYqqqqpg9ezYAM2fOZMCAASxcuBDwNblccMEFDB8+HJfLxZo1a3jmmWf44x//2LGfRER6LYvF4q/NiGLg6SOfz6jO46Wytp6K2nrKa+uoqK2notYXUgKPfa/VU+4PMOW1DWGm3N8nxl3fMHS67Z8D4h2+IBPvbFgHwkuc0xdqfNujiHPaiHP4tsc5bb61w06sf7s6AUt3EXYYmTFjBiUlJdx///0UFhYyYcIE1q5dG+zUWlBQgNXa0PZaVVXF97//fQ4fPkxMTAyjR4/mL3/5CzNmzOi4TyEi0kZRNquvU2yco03Hh9bKlNXUUVlb3zjI+B9XhgSbCpf/uasuGITqvQaGgW//M9y/KBzRUVZfqAkJNvH+ZqemYSfWYSfOYSPW6V87fAEnsI6JsqlzsESMpoMXETGZYRi46r2NamKqXA2hpcrtDzQu3/ZKf6CpctVT5fZQ5aqn2uV/3e1pd/+Z5lgsEBvlCyvxTjuxjkBNTEONTJx/e6zT5tvXYSfGYSPWYfOv/a/7++fEOuy6RUEPF9Hp4EVEpONYLBaio2xER9lIS2hff7lAsKn2h5RAgAkEm8qQMON7Xuffx0O1O2Tt9lDtDze+8+ILPm5Pu5qimnLYrI2amJo2N8U6fE1OMaFrp42YqIaam/hAM5U/ECngdD8KIyIiPUhosEluY9NTKK/XoLbeQ6WrnmqXhyp/YPGtfdsqXfVUu+updHmocdcHOwNX+x/X1Pme17gbgo673guA2+PFXe3lZJjDuM8kymZpFG5Ca2Ri/M1RgRqbWIedmKjTa2+io2whx9j8+6gfTqQojIiISIusVov/C9oOCR133jqP1xdk/KGmyl87E6jJCQSZKrcv4FT5w0yVq56aOn/TlDskHLnqcfkDTp3HaNM8Na3htFuDISY2JNDE+vvbxEb5w4vD1uhxIPBER51+rK/Wx9ar57pRGBERkU4XZbOSFGslKTaqw84ZCDiBWptAf5pAgAnU2ISGm2DtTeC1Ov/juvpG2wK9K131Xlz1HVuTE+CwWRv627TQkbhpR+PGNT1NApL/XN0h5CiMiIhIjxCJgAON++FUhzZD+WtnqutCHrsbgk9tSPNUMOQEm60azhPocBxosjpFxwYdh782J65JWGnchGXnuokDGDew5XtXRZLCiIiIyBl0dD+cUIZh4PZ4fU1QgVobf+1OYFugI3FwHdI0VV3XcEww5Lh8ASkYcuq9uOu9Z222mjioj8KIiIhIb2OxWHDabTjtNvqc/VZPrRYIOdUhwSbQxyYQVkJDTnWdh5EZHdgpKEwKIyIiIj1MaMhp64R+nanr92oRERGRHk1hREREREylMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRUCiMiIiJiKoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIipusVdew3DAKC8vNzkkoiIiEhrBb63A9/jLekWYaSiogKArKwsk0siIiIi4aqoqCApKanF1y3G2eJKF+D1ejl69CgJCQlYLJYOO295eTlZWVkcOnSIxMTEDjuvNE/Xu3PpencuXe/Opevd+dpyzQ3DoKKigv79+2O1ttwzpFvUjFitVgYOHBix8ycmJuqPuRPpencuXe/OpevduXS9O1+41/xMNSIB6sAqIiIiplIYEREREVP16jDidDpZsGABTqfT7KL0CrrenUvXu3PpencuXe/OF8lr3i06sIqIiEjP1atrRkRERMR8CiMiIiJiKoURERERMZXCiIiIiJiqV4eRJUuWMGTIEKKjo8nJyWHjxo1mF6lHeOedd5g2bRr9+/fHYrGwevXqRq8bhsH9999Pv379iImJIS8vj71795pT2B5g4cKFXHjhhSQkJJCens61117Lnj17Gu1TW1vL3LlzSUlJIT4+nhtuuIGioiKTSty9/fGPf2T8+PHBiZ9yc3P517/+FXxd1zpyfvWrX2GxWLjrrruC23S9O9YvfvELLBZLo2X06NHB1yN1vXttGFm5ciX5+fksWLCAzZs3k52dzZQpUyguLja7aN1eVVUV2dnZLFmypNnX/9//+3/8/ve/Z+nSpXz44YfExcUxZcoUamtrO7mkPcPbb7/N3Llz+eCDD3jjjTeoq6vjqquuoqqqKrjP3XffzT//+U/+/ve/8/bbb3P06FGuv/56E0vdfQ0cOJBf/epXbNq0iY8//pjLL7+c6dOns2PHDkDXOlI++ugjHn/8ccaPH99ou653xzv33HM5duxYcHn33XeDr0Xsehu91OTJk425c+cGn3s8HqN///7GwoULTSxVzwMYq1atCj73er1GZmam8Zvf/Ca47dSpU4bT6TT++te/mlDCnqe4uNgAjLffftswDN/1jYqKMv7+978H99m1a5cBGBs2bDCrmD1K3759jT/96U+61hFSUVFhjBgxwnjjjTeMSy65xLjzzjsNw9DfdiQsWLDAyM7Obva1SF7vXlkz4na72bRpE3l5ecFtVquVvLw8NmzYYGLJer4DBw5QWFjY6NonJSWRk5Oja99BysrKAEhOTgZg06ZN1NXVNbrmo0ePZtCgQbrm7eTxeHj++eepqqoiNzdX1zpC5s6dyzXXXNPouoL+tiNl79699O/fn2HDhnHzzTdTUFAARPZ6d4sb5XW00tJSPB4PGRkZjbZnZGSwe/duk0rVOxQWFgI0e+0Dr0nbeb1e7rrrLi6++GLOO+88wHfNHQ4Hffr0abSvrnnbbdu2jdzcXGpra4mPj2fVqlWMHTuWrVu36lp3sOeff57Nmzfz0Ucfnfaa/rY7Xk5ODitWrGDUqFEcO3aMBx54gK985Sts3749ote7V4YRkZ5q7ty5bN++vVEbr3S8UaNGsXXrVsrKynjhhReYNWsWb7/9ttnF6nEOHTrEnXfeyRtvvEF0dLTZxekVpk6dGnw8fvx4cnJyGDx4MH/729+IiYmJ2Pv2ymaa1NRUbDbbaT2Ai4qKyMzMNKlUvUPg+urad7x58+bxyiuv8NZbbzFw4MDg9szMTNxuN6dOnWq0v6552zkcDs455xwmTZrEwoULyc7O5pFHHtG17mCbNm2iuLiY888/H7vdjt1u5+233+b3v/89drudjIwMXe8I69OnDyNHjmTfvn0R/fvulWHE4XAwadIk1q1bF9zm9XpZt24dubm5Jpas5xs6dCiZmZmNrn15eTkffvihrn0bGYbBvHnzWLVqFW+++SZDhw5t9PqkSZOIiopqdM337NlDQUGBrnkH8Xq9uFwuXesOdsUVV7Bt2za2bt0aXC644AJuvvnm4GNd78iqrKzk888/p1+/fpH9+25X99du7PnnnzecTqexYsUKY+fOncZ3vvMdo0+fPkZhYaHZRev2KioqjC1bthhbtmwxAGPRokXGli1bjIMHDxqGYRi/+tWvjD59+hgvvfSS8emnnxrTp083hg4datTU1Jhc8u7pjjvuMJKSkoz169cbx44dCy7V1dXBfb73ve8ZgwYNMt58803j448/NnJzc43c3FwTS9193XPPPcbbb79tHDhwwPj000+Ne+65x7BYLMbrr79uGIaudaSFjqYxDF3vjvajH/3IWL9+vXHgwAHjvffeM/Ly8ozU1FSjuLjYMIzIXe9eG0YMwzAeffRRY9CgQYbD4TAmT55sfPDBB2YXqUd46623DOC0ZdasWYZh+Ib33nfffUZGRobhdDqNK664wtizZ4+5he7GmrvWgPHUU08F96mpqTG+//3vG3379jViY2ON6667zjh27Jh5he7GbrvtNmPw4MGGw+Ew0tLSjCuuuCIYRAxD1zrSmoYRXe+ONWPGDKNfv36Gw+EwBgwYYMyYMcPYt29f8PVIXW+LYRhG++pWRERERNquV/YZERERka5DYURERERMpTAiIiIiplIYEREREVMpjIiIiIipFEZERETEVAojIiIiYiqFERERETGVwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFT/X+aPmnAN4NmKQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABM1UlEQVR4nO3deXhU9aH/8fcsmckeyM4SVlkVAqKk0bZuUYqWi8v10moFsdLWQqumva20KtVepf31lmItFqUi1WqltYJWKepF0aooyqLsgiBhy8aSPTPJzPn9MUsmIYFMksnJ8nk9z3nOzJlzznznGJnPfLdjMQzDQERERMQkVrMLICIiIr2bwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFTKYyIiIiIqRRGRERExFQKIyIiImIqu9kFaA2v18vRo0dJSEjAYrGYXRwRERFpBcMwqKiooH///litLdd/dIswcvToUbKysswuhoiIiLTBoUOHGDhwYIuvd4swkpCQAPg+TGJiosmlERERkdYoLy8nKysr+D3ekm4RRgJNM4mJiQojIiIi3czZulioA6uIiIiYKuww8s477zBt2jT69++PxWJh9erVZ9z/2LFj3HTTTYwcORKr1cpdd93VxqKKiIhITxR2GKmqqiI7O5slS5a0an+Xy0VaWhr33nsv2dnZYRdQREREeraw+4xMnTqVqVOntnr/IUOG8MgjjwCwfPnycN9OREQEAI/HQ11dndnFkBA2mw273d7uaTe6ZAdWl8uFy+UKPi8vLzexNCIiYrbKykoOHz6MYRhmF0WaiI2NpV+/fjgcjjafo0uGkYULF/LAAw+YXQwREekCPB4Phw8fJjY2lrS0NE1+2UUYhoHb7aakpIQDBw4wYsSIM05sdiZdMozMnz+f/Pz84PPAOGUREel96urqMAyDtLQ0YmJizC6OhIiJiSEqKoqDBw/idruJjo5u03m6ZBhxOp04nU6ziyEiIl2IakS6prbWhjQ6RweUQ0RERKTNwq4ZqaysZN++fcHnBw4cYOvWrSQnJzNo0CDmz5/PkSNHePrpp4P7bN26NXhsSUkJW7duxeFwMHbs2PZ/AhEREenWwg4jH3/8MZdddlnweaBvx6xZs1ixYgXHjh2joKCg0TETJ04MPt60aRPPPfccgwcP5osvvmhjsUVERLq2Sy+9lAkTJrB48WKzi9LlhR1GLr300jMOrVqxYsVp2zQUS0RERFrSJTuwdpZVWw6zpeAUXx/fn8lDk80ujoiISK/Uqzuwvrm7hKc3HGTbkTKziyIiIq1kGAbV7npTlrbW9J88eZKZM2fSt29fYmNjmTp1Knv37g2+fvDgQaZNm0bfvn2Ji4vj3HPPZc2aNcFjb7755uDQ5hEjRvDUU091yLXsKnp1zUhKnG+2uOOVrrPsKSIiXUVNnYex979mynvvfHAKsY7wvzpvvfVW9u7dy8svv0xiYiI//elPufrqq9m5cydRUVHMnTsXt9vNO++8Q1xcHDt37iQ+Ph6A++67j507d/Kvf/2L1NRU9u3bR01NTUd/NFMpjAAnqtwml0RERHqqQAh57733uOiiiwB49tlnycrKYvXq1dx4440UFBRwww03MG7cOACGDRsWPL6goICJEydywQUXAL57vvU0vTqMJMf7a0YURkREuo2YKBs7H5xi2nuHa9euXdjtdnJycoLbUlJSGDVqFLt27QLghz/8IXfccQevv/46eXl53HDDDYwfPx6AO+64gxtuuIHNmzdz1VVXce211wZDTU/Rq/uMqJlGRKT7sVgsxDrspiyRmgX29ttvZ//+/dxyyy1s27aNCy64gEcffRSAqVOncvDgQe6++26OHj3KFVdcwY9//OOIlMMsvTuMxPumnFczjYiIRMqYMWOor6/nww8/DG47fvw4e/bsaTT5Z1ZWFt/73vd48cUX+dGPfsSyZcuCr6WlpTFr1iz+8pe/sHjxYp544olO/QyR1rubaYI1IwojIiISGSNGjGD69OnMmTOHxx9/nISEBO655x4GDBjA9OnTAbjrrruYOnUqI0eO5OTJk7z11luMGTMGgPvvv59JkyZx7rnn4nK5eOWVV4Kv9RS9umYkNc5XM1LhqsdV7zG5NCIi0lM99dRTTJo0ia9//evk5uZiGAZr1qwhKioKAI/Hw9y5cxkzZgxf+9rXGDlyJI899hgADoeD+fPnM378eL761a9is9l4/vnnzfw4Hc5idIPpUcvLy0lKSqKsrIzExMQOO69hGIz4+b+o9xp8MP8KMpPadutjERGJnNraWg4cOMDQoUPbfIt6iZwz/fdp7fd3r64ZsVgs9PU31ZSqE6uIiIgpenUYAc01IiIiYjaFkXiFERERETP1+jCS7O/EqmYaERERc/T6MKJmGhEREXMpjGiuEREREVMpjPhnYdX9aURERMzR68NIcrCZRn1GREREzNDrw0iK7twrIiJiKoWRQM2I+oyIiEgXMmTIEBYvXtyqfS0WC6tXr45oeSJJYUT3pxERETFVrw8jiTF27FYLoOG9IiIiZuj1YcRisQQ7sWp4r4hIN2AY4K4yZ2nlvWWfeOIJ+vfvj9frbbR9+vTp3HbbbXz++edMnz6djIwM4uPjufDCC/m///u/DrtE27Zt4/LLLycmJoaUlBS+853vUFlZGXx9/fr1TJ48mbi4OPr06cPFF1/MwYMHAfjkk0+47LLLSEhIIDExkUmTJvHxxx93WNmaY4/o2buJ5DgHxRUudWIVEekO6qrh4f7mvPfPjoIj7qy73XjjjfzgBz/grbfe4oorrgDgxIkTrF27ljVr1lBZWcnVV1/NQw89hNPp5Omnn2batGns2bOHQYMGtauIVVVVTJkyhdzcXD766COKi4u5/fbbmTdvHitWrKC+vp5rr72WOXPm8Ne//hW3283GjRuxWHytBDfffDMTJ07kj3/8Izabja1btxIVFdWuMp2Nwgih96fR8F4REWm/vn37MnXqVJ577rlgGHnhhRdITU3lsssuw2q1kp2dHdz/l7/8JatWreLll19m3rx57Xrv5557jtraWp5++mni4nzB6Q9/+APTpk3j17/+NVFRUZSVlfH1r3+d4cOHAzBmzJjg8QUFBfz3f/83o0ePBmDEiBHtKk9rKIzQ0IlVzTQiIt1AVKyvhsKs926lm2++mTlz5vDYY4/hdDp59tln+cY3voHVaqWyspJf/OIXvPrqqxw7doz6+npqamooKChodxF37dpFdnZ2MIgAXHzxxXi9Xvbs2cNXv/pVbr31VqZMmcKVV15JXl4e//Vf/0W/fv0AyM/P5/bbb+eZZ54hLy+PG2+8MRhaIqXX9xmBhonP1EwjItINWCy+phIzFn9TRmtMmzYNwzB49dVXOXToEP/+97+5+eabAfjxj3/MqlWrePjhh/n3v//N1q1bGTduHG5353wPPfXUU2zYsIGLLrqIlStXMnLkSD744AMAfvGLX7Bjxw6uueYa3nzzTcaOHcuqVasiWh6FESA1XnONiIhIx4qOjub666/n2Wef5a9//SujRo3i/PPPB+C9997j1ltv5brrrmPcuHFkZmbyxRdfdMj7jhkzhk8++YSqqqrgtvfeew+r1cqoUaOC2yZOnMj8+fN5//33Oe+883juueeCr40cOZK7776b119/neuvv56nnnqqQ8rWEoURIDnQTKM+IyIi0oFuvvlmXn31VZYvXx6sFQFfP4wXX3yRrVu38sknn3DTTTedNvKmPe8ZHR3NrFmz2L59O2+99RY/+MEPuOWWW8jIyODAgQPMnz+fDRs2cPDgQV5//XX27t3LmDFjqKmpYd68eaxfv56DBw/y3nvv8dFHHzXqUxIJ6jOCmmlERCQyLr/8cpKTk9mzZw833XRTcPuiRYu47bbbuOiii0hNTeWnP/0p5eXlHfKesbGxvPbaa9x5551ceOGFxMbGcsMNN7Bo0aLg67t37+bPf/4zx48fp1+/fsydO5fvfve71NfXc/z4cWbOnElRURGpqalcf/31PPDAAx1StpZYDKOVg6b93nnnHX7zm9+wadMmjh07xqpVq7j22mvPeMz69evJz89nx44dZGVlce+993Lrrbe2+j3Ly8tJSkqirKyMxMTEcIrbKh9/cYL/XLqBwSmxvP3fl3X4+UVEpO1qa2s5cOAAQ4cOJTo62uziSBNn+u/T2u/vsJtpqqqqyM7OZsmSJa3a/8CBA1xzzTVcdtllbN26lbvuuovbb7+d1157Ldy3jhhNeiYiImKesJtppk6dytSpU1u9/9KlSxk6dCi//e1vAV/HmnfffZff/e53TJkyJdy3j4jA0N5K//1pnHabySUSERHxefbZZ/nud7/b7GuDBw9mx44dnVyijhfxPiMbNmwgLy+v0bYpU6Zw1113tXiMy+XC5WroTNpR7WgtCdyfpt5rcKLKTb+kmIi+n4iISGv9x3/8Bzk5Oc2+FumZUTtLxMNIYWEhGRkZjbZlZGRQXl5OTU0NMTGnf/EvXLgw4p1lQgXuT1Nc4eJ4pcKIiIh0HQkJCSQkJJhdjIjqkkN758+fT1lZWXA5dOhQxN8zJT4wvFf9RkREuqIwx1tIJ+mI/y4RrxnJzMykqKio0baioiISExObrRUBcDqdOJ3OSBetkZRgJ1bNNSIi0pXYbL5+fG63u8XvDTFPdXU10L4mo4iHkdzcXNasWdNo2xtvvEFubm6k3zosgRE1J1QzIiLSpdjtdmJjYykpKSEqKgqrtUtW6vc6hmFQXV1NcXExffr0CYbGtgg7jFRWVrJv377g8wMHDrB161aSk5MZNGgQ8+fP58iRIzz99NMAfO973+MPf/gDP/nJT7jtttt48803+dvf/sarr77a5kJHQuDOvWqmERHpWiwWC/369ePAgQMcPHjQ7OJIE3369CEzM7Nd5wg7jHz88cdcdlnDxGD5+fkAzJo1ixUrVnDs2LFGdx0cOnQor776KnfffTePPPIIAwcO5E9/+lOXGdYboGYaEZGuy+FwMGLEiE67kZy0TlRUVLtqRALCDiOXXnrpGTurrFixotljtmzZEu5bdarA/WnUTCMi0jVZrVbNwNpDqeHNT800IiIi5lAY8UvRlPAiIiKmUBjxC8wzomYaERGRzqUw4hcY2lvpqqe2zmNyaURERHoPhRG/xGg7UTYLoNoRERGRzqQw4he4Pw0ojIiIiHQmhZEQgeG9pZprREREpNMojIRIUc2IiIhIp1MYCRGYa0RhREREpPMojIQI9Bkp1VwjIiIinUZhJERDM436jIiIiHQWhZEQgYnPNAuriIhI51EYCRFoptH9aURERDqPwkiIVHVgFRER6XQKIyEC84wc1zwjIiIinUZhJESgmabK7dH9aURERDqJwkgI3Z9GRESk8ymMhAi9P41G1IiIiHQOhZEmgv1GNNeIiIhIp1AYaSIwokY1IyIiIp1DYaSJZN0sT0REpFMpjDSREmymURgRERHpDAojTaQEm2nUZ0RERKQzKIw0oWYaERGRzqUw0kSK7k8jIiLSqRRGmgg202hor4iISKdQGGkiMM/ICQ3tFRER6RQKI00EakZ0fxoREZHOoTDSRIKz4f406jciIiISeQojTVgsluBcI2qqERERiTyFkWYEhveWqhOriIhIxLUpjCxZsoQhQ4YQHR1NTk4OGzdubHHfuro6HnzwQYYPH050dDTZ2dmsXbu2zQXuDIF+I6oZERERibyww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcXGz+9977708/vjjPProo+zcuZPvfe97XHfddWzZsqXdhY+UFE18JiIi0mnCDiOLFi1izpw5zJ49m7Fjx7J06VJiY2NZvnx5s/s/88wz/OxnP+Pqq69m2LBh3HHHHVx99dX89re/bXfhIyUwvFfNNCIiIpEXVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3G5XERHRzfaFhMTw7vvvtvi+7hcLsrLyxstnUnNNCIiIp0nrDBSWlqKx+MhIyOj0faMjAwKCwubPWbKlCksWrSIvXv34vV6eeONN3jxxRc5duxYi++zcOFCkpKSgktWVlY4xWw3TQkvIiLSeSI+muaRRx5hxIgRjB49GofDwbx585g9ezZWa8tvPX/+fMrKyoLLoUOHIlO4A+/Au4uhaEejzckKIyIiIp3GHs7Oqamp2Gw2ioqKGm0vKioiMzOz2WPS0tJYvXo1tbW1HD9+nP79+3PPPfcwbNiwFt/H6XTidDrDKVrbbHwCdv0T7NGQcW5wc7CZRn1GREREIi6smhGHw8GkSZNYt25dcJvX62XdunXk5uae8djo6GgGDBhAfX09//jHP5g+fXrbStyRkv2B6MTnjTYHJj07rj4jIiIiERdWzQhAfn4+s2bN4oILLmDy5MksXryYqqoqZs+eDcDMmTMZMGAACxcuBODDDz/kyJEjTJgwgSNHjvCLX/wCr9fLT37yk479JG2RPNy3PrG/8WZ/zUi1//400VG2zi6ZiIhIrxF2GJkxYwYlJSXcf//9FBYWMmHCBNauXRvs1FpQUNCoP0htbS333nsv+/fvJz4+nquvvppnnnmGPn36dNiHaLMUfxg53rhmJMFpx2Gz4vZ4OV7lZkCfGBMKJyIi0jtYDMMwzC7E2ZSXl5OUlERZWRmJiYkdeOKjsGgMWGxwbxHYooIvfenhdRSW1/LyvIsZP7BPx72niIhIL9Ha7+/efW+ahH4QFQuGB04VNHpJI2pEREQ6R+8OIxZLQyfWJk01gRE16sQqIiISWb07jAAkD/WtTxtRo+G9IiIinUFhpKURNYHhvWqmERERiSiFETXTiIiImEphJDC8t8VmGoURERGRSFIYCTTTnCqA+obgkRKvZhoREZHOoDCSkOkf3uttNLw3OLS3Uh1YRUREIklhJHR4b0hTjZppREREOofCCISEkYYRNSkh96epcXvMKJWIiEivoDACzY6oifffnwbguOYaERERiRiFEWh2RI3FYgn2G1FTjYiISOQojECLE59prhEREZHIUxiBhmaaJsN7dbM8ERGRyFMYAf/w3rjThvfq/jQiIiKRpzACLQ/vDUx8pmYaERGRiFEYCQjcvTdkRI2aaURERCJPYSQg5fROrKnxmoVVREQk0hRGApJPH96bHOdrptHQXhERkchRGAloZuIzNdOIiIhEnsJIQKCZpuxQcHhvquYZERERiTiFkYD4jJDhvQeBhpqRmjrdn0ZERCRSFEYCQof3+ptqdH8aERGRyFMYCZXS+O69FotFU8KLiIhEmMJIqGZH1OhmeSIiIpGkMBKqmRE1gVlYSzXXiIiISEQojIRqZuKzFNWMiIiIRJTCSKjk04f3qplGREQkshRGQsWngyPeN7z35BcAwQ6sJRVqphEREYkEhZFQFkvDDfP8TTWDk+MA2F9aZVapREREerQ2hZElS5YwZMgQoqOjycnJYePGjWfcf/HixYwaNYqYmBiysrK4++67qa2tbVOBI67JiJoRGfEA7CuuxDAMs0olIiLSY4UdRlauXEl+fj4LFixg8+bNZGdnM2XKFIqLi5vd/7nnnuOee+5hwYIF7Nq1iyeffJKVK1fys5/9rN2Fj4gmI2qGpMRhs1qodNVTWN5FA5SIiEg3FnYYWbRoEXPmzGH27NmMHTuWpUuXEhsby/Lly5vd//333+fiiy/mpptuYsiQIVx11VV885vfPGttimmajKhx2K0MSYkFYG9RpVmlEhER6bHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDsMRdddBGbNm0Kho/9+/ezZs0arr766hbfx+VyUV5e3mjpNM1MfDYiPQGAvcUKIyIiIh0trDBSWlqKx+MhIyOj0faMjAwKCwubPeamm27iwQcf5Mtf/jJRUVEMHz6cSy+99IzNNAsXLiQpKSm4ZGVlhVPM9gk005QdhnrfCJrQfiMiIiLSsSI+mmb9+vU8/PDDPPbYY2zevJkXX3yRV199lV/+8pctHjN//nzKysqCy6FDhyJdzAaNhvf67t57TnogjFR0XjlERER6CXs4O6empmKz2SgqKmq0vaioiMzMzGaPue+++7jlllu4/fbbARg3bhxVVVV85zvf4ec//zlW6+l5yOl04nQ6wylaxwncvbfwU19TTdrIYBj5rMg3osZisZhTNhERkR4orJoRh8PBpEmTWLduXXCb1+tl3bp15ObmNntMdXX1aYHDZrMBdN2hsk1G1AxPi8digbKaOkp1914REZEOFVbNCEB+fj6zZs3iggsuYPLkySxevJiqqipmz54NwMyZMxkwYAALFy4EYNq0aSxatIiJEyeSk5PDvn37uO+++5g2bVowlHQ5TUbUREfZGJQcy8Hj1ewtriAtwaRaGxERkR4o7DAyY8YMSkpKuP/++yksLGTChAmsXbs22Km1oKCgUU3Ivffei8Vi4d577+XIkSOkpaUxbdo0HnrooY77FB2t2RE18Rw8Xs3nxZVcNDzVpIKJiIj0PBajy7aVNCgvLycpKYmysjISExMj/4YHN8BTX4OkQXD3NgB+9a/dLH37c2bmDubB6edFvgwiIiLdXGu/v3VvmuakhN691ze8N9CJVROfiYiIdCyFkebEpYEjATCCd+8dEQgjmmtERESkQymMNKeZu/cO94eR0koXp6o1okZERKSjKIy0JNBU4x/eG++0M6BPDKCZWEVERDqSwkhLmhlRc46aakRERDqcwkhLAhOf+ZtpIKTfiDqxioiIdBiFkZYEm2kawkhDzYjuUSMiItJRFEZakhwyvLeuFtDde0VERCJBYaQlcakNw3tP+e/em5YAwLGyWipq60wsnIiISM+hMNISiwVSGt8wLyk2inT/fWk+L6kyq2QiIiI9isLImTR3j5qMQCdW9RsRERHpCAojZ9LsiBpfU436jYiIiHQMhZEzaTLxGTTMxKq5RkRERDqGwsiZBJtpmplrRMN7RUREOoTCyJkEmmnKDjcM7/WHkcMna6hxe8wqmYiISI+hMHImcangTCT07r0p8U6S4xwYBnxeoqYaERGR9lIYOROLJaQT6+n3qFEnVhERkfZTGDmbZkbUaFp4ERGRjqMwcjbBETX7gpt0wzwREZGOozByNmmjfeviXcFNmmtERESk4yiMnE3mON+6cDt4vUDDLKwHT1TjqteIGhERkfZQGDmb5OFgj4a6Kjh5AID0BCcJ0XY8XoMvSqtNLqCIiEj3pjByNjY7pI/1PS7cBoDFYtHkZyIiIh1EYaQ1gk0124KbzlEnVhERkQ6hMNIazYQRdWIVERHpGAojrREII0Xbg5vOydDEZyIiIh1BYaQ1Ms71rcuPQNVxoGGukf2lldR7vGaVTEREpNtTGGkNZwL0Hep7XORrqumfFEOsw0adx+DgCY2oERERaSuFkdYKnW8EsFot6sQqIiLSARRGWitzvG8dOqImLdBvRMN7RURE2kphpLUyz/OtQ8OIOrGKiIi0W5vCyJIlSxgyZAjR0dHk5OSwcePGFve99NJLsVgspy3XXHNNmwttikAzTekeqHcBDcN79yqMiIiItFnYYWTlypXk5+ezYMECNm/eTHZ2NlOmTKG4uLjZ/V988UWOHTsWXLZv347NZuPGG29sd+E7VeIAiOkL3noo2Q00jKjZV1yJx2uYWToREZFuK+wwsmjRIubMmcPs2bMZO3YsS5cuJTY2luXLlze7f3JyMpmZmcHljTfeIDY2tvuFEYsFMgJNNb5OrFnJsTjsVlz1Xo6crDGxcCIiIt1XWGHE7XazadMm8vLyGk5gtZKXl8eGDRtadY4nn3ySb3zjG8TFxbW4j8vlory8vNHSJTTpxGqzWhiepnvUiIiItEdYYaS0tBSPx0NGRkaj7RkZGRQWFp71+I0bN7J9+3Zuv/32M+63cOFCkpKSgktWVlY4xYycM92jRv1GRERE2qRTR9M8+eSTjBs3jsmTJ59xv/nz51NWVhZcDh061EklPIvAiJqibWD4+oiE9hsRERGR8NnD2Tk1NRWbzUZRUVGj7UVFRWRmZp7x2KqqKp5//nkefPDBs76P0+nE6XSGU7TOkToKrFFQWwZlh6DPoGAYUc2IiIhI24RVM+JwOJg0aRLr1q0LbvN6vaxbt47c3NwzHvv3v/8dl8vFt771rbaVtCuwOyB9tO+xv6lmRGCukaIKDEMjakRERMIVdjNNfn4+y5Yt489//jO7du3ijjvuoKqqitmzZwMwc+ZM5s+ff9pxTz75JNdeey0pKSntL7WZMhpPCz84JQ671UKV28OxsloTCyYiItI9hdVMAzBjxgxKSkq4//77KSwsZMKECaxduzbYqbWgoACrtXHG2bNnD++++y6vv/56x5TaTJnj4BOg8FMAomxWhqbGsbe4kr3FlfTvE2Nu+URERLqZsMMIwLx585g3b16zr61fv/60baNGjeo5TRjNTQufHs/e4kr2FVdyycg0kwomIiLSPeneNOEKTHx26qCvIyuhI2o014iIiEi4FEbCFZsMSf55T4p2AHBOhu8eNZ8VaUSNiIhIuBRG2iKjcVPN6ExfGNl1rFz3qBEREQmTwkhbNJmJdXhaPLEOG9VuD5+XqHZEREQkHAojbdEkjNisFsYNSAJg66FTJhVKRESke1IYaYvAiJriXeCpByA7qw8Anx4+ZU6ZREREuimFkbboMwQcCeBxwfG9AGQP7APAJ4fKzCuXiIhIN6Qw0hZW62nzjYwf6Gum2V1YjqveY1bJREREuh2FkbZqMqJmYN8YUuIc1HkMdh3TfCMiIiKtpTDSVk06sVoslmDtyCfqxCoiItJqCiNtFRpG/FPdjw/0G1EnVhERkVZTGGmr9DFgsUJ1KVQWATDBP6JGNSMiIiKtpzDSVlExkDrS97hJJ9b9pVWU19aZVTIREZFuRWGkPYJNNZ8CkBLvZGDfGAwDth/WEF8REZHWUBhpj+CImu3BTcH5RhRGREREWkVhpD2ajKiBhqYazcQqIiLSOgoj7REII8f3gbsKaJgWXp1YRUREWkdhpD3i0yE+AzB896kBzhuQhMUCR8tqKa6oNbd8IiIi3YDCSHs16cQa77QzIj0egE91nxoREZGzUhhpr2b7jfQB1G9ERESkNRRG2qu5ETWBfiMaUSMiInJWCiPtlTnety7aAV7f3XqzA/eoOXwKwz9VvIiIiDRPYaS9UoaDPQbqquDEAQBGZybisFk5VV3HoRM1JhdQRESka1MYaS+rDTLG+h4X+fqNOOxWxvRPBGCr+o2IiIickcJIR2imE2ugqeZTzTciIiJyRgojHaHZMNIH8PUbERERkZYpjHSEzGzf+vDH4PUCkJ3lqxnZfqSceo/XrJKJiIh0eQojHaH/BHDEQ80JKPIN8R2WGk+8005NnYd9JZXmlk9ERKQLUxjpCLYoGHyR7/GBtwGwWi2MG+Af4qt+IyIiIi1SGOkoQy/xrfe/Hdw0Pisw34gmPxMREWmJwkhHGeYPIwffh3o3ABMCnVhVMyIiItKiNoWRJUuWMGTIEKKjo8nJyWHjxo1n3P/UqVPMnTuXfv364XQ6GTlyJGvWrGlTgbus9HMhNsU3+dmRTQCM908Lv6ewgto6j4mFExER6brCDiMrV64kPz+fBQsWsHnzZrKzs5kyZQrFxcXN7u92u7nyyiv54osveOGFF9izZw/Lli1jwIAB7S58l2K1wtCv+h77+430T4omNd5Jvddgx9FyEwsnIiLSdYUdRhYtWsScOXOYPXs2Y8eOZenSpcTGxrJ8+fJm91++fDknTpxg9erVXHzxxQwZMoRLLrmE7Ozsdhe+y2nSb8RisTRMfqb5RkRERJoVVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3n55ZfJzc1l7ty5ZGRkcN555/Hwww/j8bTcbOFyuSgvL2+0dAuBfiOHPwJ3FQDj/f1GPlUnVhERkWaFFUZKS0vxeDxkZGQ02p6RkUFhYWGzx+zfv58XXngBj8fDmjVruO+++/jtb3/L//zP/7T4PgsXLiQpKSm4ZGVlhVNM8/QdCkmDwFsHB33hLDD5mTqxioiINC/io2m8Xi/p6ek88cQTTJo0iRkzZvDzn/+cpUuXtnjM/PnzKSsrCy6HDh2KdDE7hsUCwwL9RtYDDTUj+0urKKupM6dcIiIiXVhYYSQ1NRWbzUZRUVGj7UVFRWRmZjZ7TL9+/Rg5ciQ2my24bcyYMRQWFuJ2u5s9xul0kpiY2GjpNoZe6lv7+40kxzkYlBwLwDY11YiIiJwmrDDicDiYNGkS69atC27zer2sW7eO3NzcZo+5+OKL2bdvH15vw/1ZPvvsM/r164fD4WhjsbuwwIiawm1QfQKA8QMDk5+dMqlQIiIiXVfYzTT5+fksW7aMP//5z+zatYs77riDqqoqZs+eDcDMmTOZP39+cP877riDEydOcOedd/LZZ5/x6quv8vDDDzN37tyO+xRdSUIGpI0BDDjwDtBwB1+NqBERETmdPdwDZsyYQUlJCffffz+FhYVMmDCBtWvXBju1FhQUYLU2ZJysrCxee+017r77bsaPH8+AAQO48847+elPf9pxn6KrGXYJlOzyzTdy7rVk+yc/++SQmmlERESashiGYZhdiLMpLy8nKSmJsrKy7tF/ZPcaeP6bkDwcfriZanc95y14Da8BH/7sCjISo80uoYiISMS19vtb96aJhCEXg8UKJz6HssPEOuyMzEgANMRXRESkKYWRSIhOgv7n+x77R9WMD87EqqYaERGRUAojkRKYjdV/n5pgvxF1YhUREWlEYSRSQu9TYxjBETWfHDqF19vlu+mIiIh0GoWRSMnKAXs0VBZC6WeMykwgzmGjvLaebUfUVCMiIhKgMBIpUdG+QAKw/22ibFYuHZUOwOs7m7+Pj4iISG+kMBJJTfqNXHWuby6WN3YWtXSEiIhIr6MwEklDL/Wtv/g3eD1cOiodu9XCZ0WVfFFaZWbJREREugyFkUjqPwGcSVBbBsc+ISkmii8NSwFUOyIiIhKgMBJJVhsM+bLvsb+p5sqxvqYa9RsRERHxURiJtGEhQ3xpCCObDp6ktNJlVqlERES6DIWRSAvMN1LwAdS76N8nhvMGJOI14M1dxeaWTUREpAtQGIm0tFEQnwn1NXBoIwBXjc0E1FQjIiICCiORZ7HA0K/6HjfpN/LvvaVUu+vNKpmIiEiXoDDSGQJhxN9vZHRmAlnJMbjqvbzzWamJBRMRETGfwkhnCHRiPbIJasuxWCxcOcbXVKMhviIi0tspjHSGPoOg71AwPHDwfaBhNtZ1u4uo93jNLJ2IiIipFEY6S5Op4S8Y3Jc+sVGcqq7j44MnTSyYiIiIuRRGOsvQxvON2G1WrhjtnwBth5pqRESk91IY6SxDLwEsULwDSvcBDaNq3thViGEYJhZORETEPAojnSUuBUZc5Xv88ZMAfHVkKk67lUMnathdWGFi4URERMyjMNKZJn/Ht97yLLiriHXY+cqIVECjakREpPdSGOlMwy+H5GHgKoNP/wZoNlYRERGFkc5ktcKFt/seb1wGhsHlY9KxWGD7kXKOnqoxt3wiIiImUBjpbBNuAnuMryNrwQZS451cMLgvoKYaERHpnRRGOltMXxj/X77HG5cBDU01CiMiItIbKYyYYfIc33rXy1BRGBzi+8H+45TV1JlYMBERkc6nMGKGzHGQ9SXw1sOmFQxJjWNkRjz1XoP1e4rNLp2IiEinUhgxS6B25OOnwFMXrB3RbKwiItLbKIyYZcx/QFw6VBbCrn8G+42s31OMq95jcuFEREQ6T5vCyJIlSxgyZAjR0dHk5OSwcePGFvddsWIFFoul0RIdHd3mAvcYdgdcMNv3+KM/MW5AEhmJTqrcHt7//Li5ZRMREelEYYeRlStXkp+fz4IFC9i8eTPZ2dlMmTKF4uKW+zokJiZy7Nix4HLw4MF2FbrHmHQrWGxw8D2sJTsb7lWjUTUiItKLhB1GFi1axJw5c5g9ezZjx45l6dKlxMbGsnz58haPsVgsZGZmBpeMjIx2FbrHSOwPY6b5Hm9cxpUhQ3y9Xt04T0REeoewwojb7WbTpk3k5eU1nMBqJS8vjw0bNrR4XGVlJYMHDyYrK4vp06ezY8eOM76Py+WivLy80dJjBTqyfrqS3P52Epx2SipcfLBfTTUiItI7hBVGSktL8Xg8p9VsZGRkUFjY/L1VRo0axfLly3nppZf4y1/+gtfr5aKLLuLw4cMtvs/ChQtJSkoKLllZWeEUs3sZfDGkjYG6ahzbn2f6xP4ALFm/z+SCiYiIdI6Ij6bJzc1l5syZTJgwgUsuuYQXX3yRtLQ0Hn/88RaPmT9/PmVlZcHl0KFDkS6meSyWhtqRjcv43leHYrdaeG/fcTYdPGlu2URERDpBWGEkNTUVm81GUVHjDpZFRUVkZma26hxRUVFMnDiRffta/uXvdDpJTExstPRo42eAMxFOfM7AEx9y/fkDAHj0zb0mF0xERCTywgojDoeDSZMmsW7duuA2r9fLunXryM3NbdU5PB4P27Zto1+/fuGVtCdzxvtuoAfw0Z/4/qXnYLXA+j0lfHr4lKlFExERibSwm2ny8/NZtmwZf/7zn9m1axd33HEHVVVVzJ7tmzNj5syZzJ8/P7j/gw8+yOuvv87+/fvZvHkz3/rWtzh48CC33357x32KnuBC//XY8y+G2EqZPiFQO6K+IyIi0rPZwz1gxowZlJSUcP/991NYWMiECRNYu3ZtsFNrQUEBVmtDxjl58iRz5syhsLCQvn37MmnSJN5//33Gjh3bcZ+iJ0gdAcMug/1vwcfLmXvZf7N66xHe2FnErmPljOnXw5uqRESk17IYhtHlJ7QoLy8nKSmJsrKynt1/ZPer8PxNEJMM+TuZ+/ddvPrpMa4Z148lN59vdulERETC0trvb92bpisZ+TVIGgQ1J+Cd/+UHl58DwJrtx9hXXGFy4URERCJDYaQrsdrgql/6Hr/7O0Z793PV2AwMA/6gviMiItJDKYx0NedeC2OvBcMDq7/PDy8ZDMDLnxzlQGmVqUUTERGJBIWRrujq/4XYFCjewXn7/8Rlo9LwGvDYW6odERGRnkdhpCuKT4Orf+N7/O//5ScT3ACs2nKEQyeqTSyYiIhIx1MY6arOvd53R19vPWM+vIdLhveh3mvwx7c/N7tkIiIiHUphpKuyWOCaRRDTFwq38T9pbwDwwseHOVZWY3LhREREOo7CSFcWnw5Tfc01WZ/+gf8cWIbb4+Xxt/ebXDAREZGOozDS1Y37Txh1DXjr+IX3D9ip568bCyiuqDW7ZCIiIh1CYaSrs1jg64sgug/xJ3bwQMo6XPVelr2j2hEREekZFEa6g4RMmPprAL5Z8xwjLIf5ywcFHK90mVwwERGR9lMY6S7Gz4CRX8PqrWNJ3J9w17l5aM0us0slIiLSbgoj3YXFAl//HTiTGFn/GXPsa3hx8xFe2nrE7JKJiIi0i8JId5LYH762EIAfR/2D0ZYC7l21XROhiYhIt6Yw0t1MuAnOuRK74eavMb8m1X2Iu1Zupd7jNbtkIiIibaIw0t1YLHD9E5Axjr7ekzzveIjigt08qrv6iohIN6Uw0h3FJsPM1ZA2mgzLCZ6Leph/vLmBj784YXbJREREwqYw0l3FpcLMlyB5OFnWEp6Jeohf/vVNymrqzC6ZiIhIWBRGurOETJj1T7x9BjPUWsRva+7jVy/8G8MwzC6ZiIhIqymMdHdJA7DO+ifuuP6cYz3KzL0/5JUPdphdKhERkVZTGOkJ+g7GcdsrVDlSGWM9xNC1t1Bw5KjZpRIREWkVhZGeImU40d9+hTJrEudZ9lP91HXUVZeZXSoREZGzUhjpQWwZY3B9cxWniGd0/W4K//gf4K4yu1giIiJnpDDSw6SPmMSOy1dQbsSQVbGVyj/mQanmIBERka5LYaQHuvirV/LMOb/jhBFP/MmdeJZ+BT553uxiiYiINEthpIf69jf+i3szH+cD7xhs9dWw6ruw6g5wVZpdNBERkUYURnqo6Cgbv7nta/yu329YVPefeLDAJ8/BE5fAsU/NLp6IiEiQwkgPFue08+Rtufx7wG3c5LqXIpLh+D74Ux5sXAaaHE1ERLoAhZEeLt5pZ8XsydQM+BJfq32YdyyTwOOCNT+Gld+Cat3PRkREzKUw0gskxUTx9G2T6ddvIDNr8vmtdTaGNQp2vwJLvwIH3jG7iCIi0ospjPQSfWId/OX2HEZlJPJo9ZXMtj1MXdIQKD8Mf54Gf/0mlOwxu5giItILtSmMLFmyhCFDhhAdHU1OTg4bN25s1XHPP/88FouFa6+9ti1vK+2UHOfg2Tk5nJMez/qKAVxd+xCV42aCxQZ71sBjX4J/3gkVhWYXVUREepGww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcfEZj/viiy/48Y9/zFe+8pU2F1baLzXeyXO35zA0NY69ZRau/vx6imeuh9FfB8MLm1bA7yfCmw+Bq8Ls4oqISC8QdhhZtGgRc+bMYfbs2YwdO5alS5cSGxvL8uXLWzzG4/Fw880388ADDzBs2LB2FVjaLz0xmufm5DAoOZaCE9Vct7KUbV9+DGavhYEXQl01vPP/fKFk4zLw1JldZBER6cHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDicQ8++CDp6el8+9vfbtX7uFwuysvLGy3SsfolxfDcHF8NyZFTNdyw9H3+XjIQvv0G/NczkDwcqkp8o26W5MC2FxRKREQkIsIKI6WlpXg8HjIyMhptz8jIoLCw+X4G7777Lk8++STLli1r9fssXLiQpKSk4JKVlRVOMaWVBvaNZfXci8kbk4673st/v/Ap9760HffIr8PcD+Hq/4W4NDjxOfzj2/C7c2HdL+FUgdlFFxGRHiSio2kqKiq45ZZbWLZsGampqa0+bv78+ZSVlQWXQ4cORbCUvVtSTBRP3HIB+VeOxGKBv3xQwDee2EBRlQcmz4EfboFLfwbxGVBZBP/+X1g8Hp69Efb8C7wesz+CiIh0cxbDaP00nG63m9jYWF544YVGI2JmzZrFqVOneOmllxrtv3XrViZOnIjNZgtu83q9gK95Z8+ePQwfPvys71teXk5SUhJlZWUkJia2trgSprd2F3Pn81sor60nLcHJYzefz4VDkn0veup8I24+Xg771zcclDgQJs2CibdAYj9Tyi0iIl1Ta7+/wwojADk5OUyePJlHH30U8IWLQYMGMW/ePO65555G+9bW1rJvX+Pb1997771UVFTwyCOPMHLkSBwOR4d9GGm/L0qr+N5fNrG7sAK71cJ9Xx/LzNzBWCyWhp2Ofw6bnoItz0KNfwZXiw1Gfg3Ou963dsab8wFERKTLiFgYWblyJbNmzeLxxx9n8uTJLF68mL/97W/s3r2bjIwMZs6cyYABA1i4cGGzx996662cOnWK1atXd/iHkY5R7a7np//Yxj8/OQrA9RMH8NB144hx2BrvWFcLu/7pqy0peL9huz0azsmDsdfCyCkQrf9mIiK9UWu/v+3hnnjGjBmUlJRw//33U1hYyIQJE1i7dm2wU2tBQQFWqyZ27c5iHXZ+/40JZA9MYuG/dvPiliPsPFbOr24Yz4SsPg07RkXD+Bt9S/Eu+PRvsHM1nNjvm2p+9ytgc8DwK+Dca2HUVIhOMulTiYhIVxV2zYgZVDNing2fH2fec5s5XuXGYoFbvjSYH08ZRWJ0VPMHGAYUbYedL8GO1XB8b8Nr1igYfhkMuxQGXwQZ48AWdh4WEZFuImLNNGZQGDFXaaWLh1/dxYtbjgCQnuBkwbRzuXpcZuO+JE0Zhq/GZOdqXzgp2d34dUcCDMrxBZPBF0P/iWB3Ru6DiIhIp1IYkQ73/r5Sfr56OwdKqwC4bFQaD04/j6zk2NadoHg3fLYWDr4PBR+Aq6zx6/Zo3wywgy+CftmQNhr6DgGrrdnTiYhI16YwIhFRW+fhsfWfs3T957g9XqKjrNyVN5Jvf3koUbYw+gp5PVC0wxdMDr7nW1eXnr6fPQbSRkL6WEgfA2ljfOukgXCmWhkRETGdwohE1L7iSn6+ahsfHvAN7R2dmcBD153HpMHJbTuhYUDpXl8wKfgAindCyR7wuJrf35EAqSMgZTiknONbkof5nquTrIh0dYbhm7/J4/YvIY+99Q3bvB7f8+DS5Hm9C+proK7Gd1+xulr/ugbq/Y/r/ec0PCHn8Jz+/MoH4JwrOvRjKoxIxBmGwT82H+GhV3dystp335qrxmZw95UjGdOvA/47eT1w4gCU7PL1PQksx/f6/gdqSVy6P6QMhz5DID7dN4NsQoZvHZcGthY64IqIObxe/5doNbgrfV+yQZaQmlD/OvC86Zeq4Q157P+SDX5h1/q+oOtr/V/WIds9Lt+Xtsfl2x4IBsFtbt/5LDawWsFi9T+2+dYWq287Fv9xrpB14Nzuhm3eLnivrxuehHH/2aGnVBiRTnOiys2v/rWLv286TOCv6Zrx/bjrihGMyEjo+Desd/vul3N8X8iy37euKm7dOWJTID7TF1Ti0iA2GWKS/eu+viV0myNezULSM3g9/i9kV8Ov5/rahl/U9SG/rOtCfnHX1/p/qTfz6zz0eSAAGIbvseFtCAmGf3u9C9xVUFflW7urfY97NYtvKgSbw/djyRble2y1gdUesoQ8t9h8nf6jYn1TLUTF+B7bo/3bYnyLzdHkeH+ACj2fxQoZ5/l+tHUghRHpdHuLKli8bi+vfnoM8H13T8/uz515IxmaGtc5hagt9wcVf1gpOwyVxVBZ6F8X+/5BDJfVDs5EcCaErP1LdMhzRzw44vxLC4+jYv3/8yvcdFmhX9iBL+vAL+PgL25vk+f+taeu8S/r4K/rkOr4wJcyRstrr/9c3rqQavy6xtX4ZwsG3nrw1Id8lpoz1yp2FVFxvi9Zi6XhegDBXzvB5zTz5Wpt/EUb/MKO8a3tMb4vbrt/CW6P9n1p252N16GPrbaQ2peQgBX6N4HRzHmcYHeErP2PA4EjcO4e+G+CwoiYZtexchb/32e8tqMIAJvVwnUTB/DDy0cwKKWVI28ixev1TWFfUei78V9lsa82peYkVJ/wvVZ90rcObGup30p7WKwt/KMYeO7wzcsS+IUUeGy1hzy3+9ahv3hsUaf/gmr2y47Tn7eq3BYaVZk3fW4Yjb+EA1+eoV/Ghqf5f4yD/0j7f8UF29CbqeIOfRwMDCFrT8hjwxtSxhbWhrfxObrDF3ZHsEb5/96cIb+kQ35V22Mafl0Hf2GHfvE3+aUe/JVtCWnCsIY0Y/jXtqiGkB4VGxLa43zvqYkzewyFETHd9iNl/O6Nz1i329d0YrdauPGCgXz7y8M4J72b3LvGMHxV1DUnwVXhX8pDHocstWX+KueqhnbvwHN3Jbgq21YrI+ay2v2/mqMaqsaDX8hN+g1Ybc2Hq9Bt1ij/cPWzBCSrzR86Hb7gaWsSUBtVvTdXjR+ybhp8AzUBGjYvEaYwIl3GloKT/O7/9vLOZyXBbRefk8ItXxpC3ph07OEMCe7OAm3lZ+tIF/iF7q1raKMPVtfXh2wP6WnfbFu+//UWazKarltR/uaaE4Kv+QWrt6P8tR+OxjUgFkvDKIBGowjqfDUaHrfvc9qi/Ofynyf0ceCLPfSL1dbkeaCGyWJtpuzekMf+6xJaXR84j82pWYJF2kFhRLqcj744weNv7+fN3UV4/X91/ZOiuSlnEDMuHERagmZfFRHpSRRGpMs6fLKa5z4sYOVHhzhe5QYgymZh6nn9mJk7mEmD+555mnkREekWFEaky3PVe1iz7RjPbDjI5oJTwe1j+iVy46SBfD27H+kJ0eYVUERE2kVhRLqV7UfKeGbDQV765Ai1dV4ArBa4aHgq/zGhP1POzSQpRhOViYh0Jwoj0i2VVdexeusRXtp6pFFticNm5bLRaUyfMIDLR6cTHaVRACIiXZ3CiHR7Bcer+eenR1m95Qh7iyuD2+Oddq46N4Orz+vHxeekEuNQMBER6YoURqTHMAyD3YUVvPzJUV7eepQjp2qCrznsVnKHpXD56HQuH51OVrLJk6qJiEiQwoj0SF6vweaCk/zzk6P8367iRsEE4Jz0eC4fnc5lo9K5YEhfonrLHCYiIl2Qwoj0eIZhsLe4kjd3F/Pm7mI2HTyJx9vw55wQbefL56SSOzyF3GEpnJMeryHDIiKdSGFEep2y6jre2VvCW7uLWf9ZCSf8c5gEpMY7g8Ekd3gKQ1JiFU5ERCJIYUR6NY/X4JPDp3h/Xykb9h/n4y9O4qr3NtonMzGa3OEp5AxN5vzBfRmeFo/NqnAiItJRFEZEQrjqPWwtOMWG/cfZ8PlxthScwu1pHE7inXbGD0xi4qA+TMjqy4SsPpqiXkSkHRRGRM6gts7DpoMn2fD5cT4+eIJPD5dR7T79jroD+sT4w0kfzhuQxNj+iSRGa/I1EZHWUBgRCYPHa/BZUQVbD51ia8Epthw6yd7iSpr7v2NQciznDUjk3P6+cHJu/0RNWy8i0gyFEZF2qqitY9vhMrYcOsUnh06x42j5aUOJA9ITnJzbP5FRmYmMyoxnRHoC56THa6ZYEenVFEZEIuBklZudx8rZcbSM7Ud86/2lVc3WoFgtMCQljhEZ8YzKSGBERgKjMhMYkhKHw675T0Sk51MYEekk1e56dh2rYOfRMvYUVfBZUSWfFVVwqrqu2f2tFshKjmVoahxDU+MYlhrH0NR4hqbF0S8xGqtG9IhID6EwImIiwzAoqXDxWVEle4oq2FtU4V9XUumqb/E4p93K0NQ4BqfEMijZt2T51wP6xuC0q9lHRLoPhRGRLigQUvaXVnHAv+wvqeJAaSUFJ6qp87T8v6PF4psbJRBOsvrGkpUcw0D/Oj0hWvOkiEiXojAi0s3Ue7wcOVXD/pIqCk5UB5dD/nVzQ49DRdksDOjTEE4G9o1lYN8Y+iXF0C8pmozEaPVVEZFO1drvb3tbTr5kyRJ+85vfUFhYSHZ2No8++iiTJ09udt8XX3yRhx9+mH379lFXV8eIESP40Y9+xC233NKWtxbpsew2K4NT4hicEnfaa4ZhcLzKHQwngYBy+GQNh05Wc/RULXUegy+OV/PF8epmz2+x+KbE75cU7V98ISXTH1QyEqNJT3AS52zTPwsiIm0W9r86K1euJD8/n6VLl5KTk8PixYuZMmUKe/bsIT09/bT9k5OT+fnPf87o0aNxOBy88sorzJ49m/T0dKZMmdIhH0Kkp7NYLKTGO0mNd3L+oL6nvV7v8VJYXsvhkzW+gOIPKodPVnOsrJbCslrcHi8lFS5KKlx8erisxfeKd9pJT3SSnuAMBpSMxGjSEpykJfi2pyVEkxht1719RKRDhN1Mk5OTw4UXXsgf/vAHALxeL1lZWfzgBz/gnnvuadU5zj//fK655hp++ctftmp/NdOItE+gZqWwrJajp2ooLK/l6KlaCstqOFpWS0mFi6Ly2rM2BYVy2K2kxYcGFKc/MDlIjnOSEu8gJc5BSryTPjFRGiUk0gtFpJnG7XazadMm5s+fH9xmtVrJy8tjw4YNZz3eMAzefPNN9uzZw69//etw3lpE2iG0ZuW8AUkt7lfpqqeovJai8oaAUlzuoqjCRUmFb1txhYuK2nrc9b4+Li1NBBfKaoHkOAfJcQ5S4pwk+4OK77kvvCTHOUiJ923rG+tQZ1yRXiSsMFJaWorH4yEjI6PR9oyMDHbv3t3icWVlZQwYMACXy4XNZuOxxx7jyiuvbHF/l8uFy+UKPi8vLw+nmCLSRvFOO/Fp8QxPiz/jfrV1nmAwKalwUVLpoqS8lpJKNyeqXJyocnO80s3xKjdlNXV4DSitdFNa6QYqz1oOiwWSYqJIjnXQJzaKvrEO+sY56Bsb5V/7lj6xUb4lxkFSTBTRUVY1HYl0Q53SUy0hIYGtW7dSWVnJunXryM/PZ9iwYVx66aXN7r9w4UIeeOCBziiaiLRBdJSNLP8cKGdT5/FyssoXTHwBxRdWTlT5wkkwvPi3naquwzDgVHVdixPHtcRht9InJoqkGF9ISfKHFN/jhnVScB/f64nRduw2jTQSMUtYfUbcbjexsbG88MILXHvttcHts2bN4tSpU7z00kutOs/tt9/OoUOHeO2115p9vbmakaysLPUZEekF6jxeTlb7QsnJKjcnq92crK7zBxXf45NVbk5U+2pdyqrrOFVTh8fbvlkKYh024p12EqLtJERH+dd2EpxRwW1JMXaSYqNIjG4cahJjonQfIpFmRKTPiMPhYNKkSaxbty4YRrxeL+vWrWPevHmtPo/X620UNppyOp04nc5wiiYiPUSUzUp6QnRYd0I2DINKVz1lNb7alMD6VE1DYCmrqWv0emAJzIhb7fZQ7fZQXNHyv01n4rBbSYqJIsEfaOL9QSY+GGp8gSbwPDT4BB7HOezq6Cu9UtjNNPn5+cyaNYsLLriAyZMns3jxYqqqqpg9ezYAM2fOZMCAASxcuBDwNblccMEFDB8+HJfLxZo1a3jmmWf44x//2LGfRER6LYvF4q/NiGLg6SOfz6jO46Wytp6K2nrKa+uoqK2notYXUgKPfa/VU+4PMOW1DWGm3N8nxl3fMHS67Z8D4h2+IBPvbFgHwkuc0xdqfNujiHPaiHP4tsc5bb61w06sf7s6AUt3EXYYmTFjBiUlJdx///0UFhYyYcIE1q5dG+zUWlBQgNXa0PZaVVXF97//fQ4fPkxMTAyjR4/mL3/5CzNmzOi4TyEi0kZRNquvU2yco03Hh9bKlNXUUVlb3zjI+B9XhgSbCpf/uasuGITqvQaGgW//M9y/KBzRUVZfqAkJNvH+ZqemYSfWYSfOYSPW6V87fAEnsI6JsqlzsESMpoMXETGZYRi46r2NamKqXA2hpcrtDzQu3/ZKf6CpctVT5fZQ5aqn2uV/3e1pd/+Z5lgsEBvlCyvxTjuxjkBNTEONTJx/e6zT5tvXYSfGYSPWYfOv/a/7++fEOuy6RUEPF9Hp4EVEpONYLBaio2xER9lIS2hff7lAsKn2h5RAgAkEm8qQMON7Xuffx0O1O2Tt9lDtDze+8+ILPm5Pu5qimnLYrI2amJo2N8U6fE1OMaFrp42YqIaam/hAM5U/ECngdD8KIyIiPUhosEluY9NTKK/XoLbeQ6WrnmqXhyp/YPGtfdsqXfVUu+updHmocdcHOwNX+x/X1Pme17gbgo673guA2+PFXe3lZJjDuM8kymZpFG5Ca2Ri/M1RgRqbWIedmKjTa2+io2whx9j8+6gfTqQojIiISIusVov/C9oOCR133jqP1xdk/KGmyl87E6jJCQSZKrcv4FT5w0yVq56aOn/TlDskHLnqcfkDTp3HaNM8Na3htFuDISY2JNDE+vvbxEb5w4vD1uhxIPBER51+rK/Wx9ar57pRGBERkU4XZbOSFGslKTaqw84ZCDiBWptAf5pAgAnU2ISGm2DtTeC1Ov/juvpG2wK9K131Xlz1HVuTE+CwWRv627TQkbhpR+PGNT1NApL/XN0h5CiMiIhIjxCJgAON++FUhzZD+WtnqutCHrsbgk9tSPNUMOQEm60azhPocBxosjpFxwYdh782J65JWGnchGXnuokDGDew5XtXRZLCiIiIyBl0dD+cUIZh4PZ4fU1QgVobf+1OYFugI3FwHdI0VV3XcEww5Lh8ASkYcuq9uOu9Z222mjioj8KIiIhIb2OxWHDabTjtNvqc/VZPrRYIOdUhwSbQxyYQVkJDTnWdh5EZHdgpKEwKIyIiIj1MaMhp64R+nanr92oRERGRHk1hREREREylMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRUCiMiIiJiKoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIipusVdew3DAKC8vNzkkoiIiEhrBb63A9/jLekWYaSiogKArKwsk0siIiIi4aqoqCApKanF1y3G2eJKF+D1ejl69CgJCQlYLJYOO295eTlZWVkcOnSIxMTEDjuvNE/Xu3PpencuXe/Opevd+dpyzQ3DoKKigv79+2O1ttwzpFvUjFitVgYOHBix8ycmJuqPuRPpencuXe/OpevduXS9O1+41/xMNSIB6sAqIiIiplIYEREREVP16jDidDpZsGABTqfT7KL0CrrenUvXu3PpencuXe/OF8lr3i06sIqIiEjP1atrRkRERMR8CiMiIiJiKoURERERMZXCiIiIiJiqV4eRJUuWMGTIEKKjo8nJyWHjxo1mF6lHeOedd5g2bRr9+/fHYrGwevXqRq8bhsH9999Pv379iImJIS8vj71795pT2B5g4cKFXHjhhSQkJJCens61117Lnj17Gu1TW1vL3LlzSUlJIT4+nhtuuIGioiKTSty9/fGPf2T8+PHBiZ9yc3P517/+FXxd1zpyfvWrX2GxWLjrrruC23S9O9YvfvELLBZLo2X06NHB1yN1vXttGFm5ciX5+fksWLCAzZs3k52dzZQpUyguLja7aN1eVVUV2dnZLFmypNnX/9//+3/8/ve/Z+nSpXz44YfExcUxZcoUamtrO7mkPcPbb7/N3Llz+eCDD3jjjTeoq6vjqquuoqqqKrjP3XffzT//+U/+/ve/8/bbb3P06FGuv/56E0vdfQ0cOJBf/epXbNq0iY8//pjLL7+c6dOns2PHDkDXOlI++ugjHn/8ccaPH99ou653xzv33HM5duxYcHn33XeDr0Xsehu91OTJk425c+cGn3s8HqN///7GwoULTSxVzwMYq1atCj73er1GZmam8Zvf/Ca47dSpU4bT6TT++te/mlDCnqe4uNgAjLffftswDN/1jYqKMv7+978H99m1a5cBGBs2bDCrmD1K3759jT/96U+61hFSUVFhjBgxwnjjjTeMSy65xLjzzjsNw9DfdiQsWLDAyM7Obva1SF7vXlkz4na72bRpE3l5ecFtVquVvLw8NmzYYGLJer4DBw5QWFjY6NonJSWRk5Oja99BysrKAEhOTgZg06ZN1NXVNbrmo0ePZtCgQbrm7eTxeHj++eepqqoiNzdX1zpC5s6dyzXXXNPouoL+tiNl79699O/fn2HDhnHzzTdTUFAARPZ6d4sb5XW00tJSPB4PGRkZjbZnZGSwe/duk0rVOxQWFgI0e+0Dr0nbeb1e7rrrLi6++GLOO+88wHfNHQ4Hffr0abSvrnnbbdu2jdzcXGpra4mPj2fVqlWMHTuWrVu36lp3sOeff57Nmzfz0Ucfnfaa/rY7Xk5ODitWrGDUqFEcO3aMBx54gK985Sts3749ote7V4YRkZ5q7ty5bN++vVEbr3S8UaNGsXXrVsrKynjhhReYNWsWb7/9ttnF6nEOHTrEnXfeyRtvvEF0dLTZxekVpk6dGnw8fvx4cnJyGDx4MH/729+IiYmJ2Pv2ymaa1NRUbDbbaT2Ai4qKyMzMNKlUvUPg+urad7x58+bxyiuv8NZbbzFw4MDg9szMTNxuN6dOnWq0v6552zkcDs455xwmTZrEwoULyc7O5pFHHtG17mCbNm2iuLiY888/H7vdjt1u5+233+b3v/89drudjIwMXe8I69OnDyNHjmTfvn0R/fvulWHE4XAwadIk1q1bF9zm9XpZt24dubm5Jpas5xs6dCiZmZmNrn15eTkffvihrn0bGYbBvHnzWLVqFW+++SZDhw5t9PqkSZOIiopqdM337NlDQUGBrnkH8Xq9uFwuXesOdsUVV7Bt2za2bt0aXC644AJuvvnm4GNd78iqrKzk888/p1+/fpH9+25X99du7PnnnzecTqexYsUKY+fOncZ3vvMdo0+fPkZhYaHZRev2KioqjC1bthhbtmwxAGPRokXGli1bjIMHDxqGYRi/+tWvjD59+hgvvfSS8emnnxrTp083hg4datTU1Jhc8u7pjjvuMJKSkoz169cbx44dCy7V1dXBfb73ve8ZgwYNMt58803j448/NnJzc43c3FwTS9193XPPPcbbb79tHDhwwPj000+Ne+65x7BYLMbrr79uGIaudaSFjqYxDF3vjvajH/3IWL9+vXHgwAHjvffeM/Ly8ozU1FSjuLjYMIzIXe9eG0YMwzAeffRRY9CgQYbD4TAmT55sfPDBB2YXqUd46623DOC0ZdasWYZh+Ib33nfffUZGRobhdDqNK664wtizZ4+5he7GmrvWgPHUU08F96mpqTG+//3vG3379jViY2ON6667zjh27Jh5he7GbrvtNmPw4MGGw+Ew0tLSjCuuuCIYRAxD1zrSmoYRXe+ONWPGDKNfv36Gw+EwBgwYYMyYMcPYt29f8PVIXW+LYRhG++pWRERERNquV/YZERERka5DYURERERMpTAiIiIiplIYEREREVMpjIiIiIipFEZERETEVAojIiIiYiqFERERETGVwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFT/X+aPmnAN4NmKQAAAABJRU5ErkJggg=="
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABIqElEQVR4nO3deXwU9f0/8Nfeu7nvOxDuQ0i4YxSLhVQqyk/RtoioiNWqBatSq1A5vEGtFFRa1IK3iLe2WBSj0i/IZSAKcl+GIyeQ7GaTPWd+f8yeIYFssrtDsq/n4zGPnZ2dzX52jMwrn897PqMQRVEEERERkUyUcjeAiIiIIhvDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCu13A1oC0EQcPLkScTGxkKhUMjdHCIiImoDURRhMpmQlZUFpbL1/o9OEUZOnjyJ3NxcuZtBRERE7XDs2DHk5OS0+nqnCCOxsbEApC8TFxcnc2uIiIioLYxGI3Jzcz3n8dZ0ijDiHpqJi4tjGCEiIupkzldiwQJWIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGs2hVGli1bhry8POj1ehQWFmLr1q2t7mu32/HYY4+hV69e0Ov1KCgowNq1a9vdYCIiIupaAg4jq1evxqxZs7BgwQJs374dBQUFGD9+PKqrq1vcf+7cuXjppZfwwgsvYPfu3bjrrrswadIk7Nixo8ONJyIios5PIYqiGMgbCgsLMXLkSLz44osApPvG5Obm4p577sHs2bPP2j8rKwsPP/wwZsyY4dl2/fXXw2Aw4K233mrTZxqNRsTHx6O+vp6TnhEREXUSbT1/B9QzYrPZUFpaiuLiYu8PUCpRXFyMTZs2tfgeq9UKvV7vt81gMGDDhg2tfo7VaoXRaPRbiIiIqGsKKIzU1tbC6XQiPT3db3t6ejoqKytbfM/48eOxePFiHDhwAIIgYN26dfjoo49QUVHR6ucsXLgQ8fHxnoU3ySMiIuq6Qn41zdKlS9GnTx/0798fWq0WM2fOxPTp0895K+E5c+agvr7esxw7dizUzSQiIiKZBHSjvJSUFKhUKlRVVfltr6qqQkZGRovvSU1NxSeffAKLxYJTp04hKysLs2fPRs+ePVv9HJ1OB51OF0jTiIiIIp7V4YTZ6oTZ6oDZ5oDZ6kCjzQmLXYDVIT1a7E5Y7E5YHQKsdicsDmnbnWN6ITvBIEu7AwojWq0Ww4cPR0lJCa699loAUgFrSUkJZs6cec736vV6ZGdnw26348MPP8Tvfve7djeaiIioMxFFEXanCJtTQJPNCZPFDpPFAaPr0fO8yQ6jxYEGqwN2pwCHIMLhFOAURNe6CIcgPbc7RTTZnGjwCR52Z0DXpPi5dmh25wgjADBr1ixMmzYNI0aMwKhRo7BkyRKYzWZMnz4dAHDLLbcgOzsbCxcuBABs2bIFJ06cwJAhQ3DixAk88sgjEAQBDz74YHC/CRERUSukk7n3JO50neTdJ3ib09trYHX4P/r2KjS5ehWabE402aXF4rvu2tdqF2BzSj0PVoe0Hti1qx2j1ygRrVUjWqdGlFYFnUYFvVoJvUYFvUYJnVp6lJ6roFMrkRYr34hEwGFk8uTJqKmpwfz581FZWYkhQ4Zg7dq1nqLW8vJyv3oQi8WCuXPn4vDhw4iJicGECRPw5ptvIiEhIWhfgoiIOjeHU4DFIfUaWOxOmG0ONFgcUq+BVeo5cD9vsEo9Cmarw3vydwh+QcD7KMAuhDcInI9CAcTo1IjTaxCrV7sW//UYnRo6tRJqpQIqlRIapQIqpQIalRIqpQJqpQJqlRIGjQrROhVidFLwiNapEa1VQa3qXBOsBzzPiBw4zwgRkbycggibQzrJS4/uxfvc5hBgtvoHCJPFFSqs7uEIh3+vgmvpyPBCeykVgFqphFqlgFathF6tgk4jPbp7D3TNehEMGhUMWpV3XaP0e+7uZdC5HrVqpfTc9bO0KmlRKhVh/75yaOv5O+CeESIiurA5BdFTQ+AuYGy0eYcWpHVpu/t5g2vfBlfPg7tnosFVDNlkd4at/e4TvqenQKdBjGs9ztVrEKuXegF8hx107hO/KwjoNSpo1VKvglolhQ61UiEFEKUiYgJBZ8AwQkQUZnan4ClWdBcx+q1bHLA5BAiiVM/gFAQ4RXedg+hZb7L5DGe4goR0FUVog4NSAejUKs9f/d5HFWJcQwbuYYcYvXc4wr09WquCXquCXu3uZVD69SooFAwJkYZhhIjoPJyCiAZPULDD2OS9CsI3RDRYHN4CR5/HJpu3+LHRJtU5hINaqfAUMBq0KkRpVYjSqD3r7h6IKK0KMTqNp/YgxtXrEKNTI1or9UJEab1hobPVI9CFj2GEiCKC3SmgrtGOukYb6prsOGO2Sc+bbKhv8r+s0tQscDRYHSFpU7RWhTiDxjP84FvIqFOroFYpPMWKSoXCVczofa7XqDw9Du4CRvfzaFcBJHsZqDNgGCGiC1qTzYnaBitqG6w41WCTHs02nDbbYLFLxZM2p1Q86V53F1PaHAKMFjvqGu1BCRR6jdITGqQQoUGcK0DEGdSI1alh0KpdPQ7eoQd3D4T7uTswsIeBSMIwQkQhJQgiTFap16G+ye4zyZMDDe519xUYPhNBucNHYxDrHxQKIN6gQYJBg4QoLRKiNEiM0iLe4B8qpMDhuy69plUzPBCFAsMIEbWJKIpotDlx2mzDmUabz6M05HG60Yb6Rilw+C4mix1CB6/a1KqVSI3RISVGi+QYHZKjtUiK1ko1DK7LJd2FlFq1ElqVyrMep1cjIUqLxCgpYKh4BQXRBYdhhCgCCYKI+iY7TrtDhVmqo6hrtOGMu66i0Y4zrse6Rmlfm6P9hZc6tVLqgTD410bE6vwnenIPgaTEaJEcrUNKrA7RWhVrH4i6MIYRoi5CFEUYmxyoMDahot6CijoLqowWnHbVV5wyWz3rZxrtcLazu0KrViI5WovEKKl3IjFai6Qojaf3IT5Kg3iDd4kzaBCn10CvUQX5GxNRV8EwQtQJOAURtQ1WVNZLAaPKZEVlvRQ6Kl1LRb0l4ImpYnVqJMVoPUEi0VVHkWDQIjHaGzDcz5OitTBo2EtBRMHFMEIkM4dTQJXJihNnmnCyrgkn6pqkgGF0BQ+jBTUma5vrLpKitciI0yMzXo+0OD1SYqQejKRoadgjMVrjedSp2VtBRPJjGCEKMVEUUW2y4nCNGUdPmXH8TCNO1llw4owreBgtbRoyUSkVSI3RIT1ej/RYHTLi9ciI1yMr3oCMeCl8pMfpORxCRJ0OwwhRkJwx23C41oyjtWYc8VmOnjKf9/JUjUqBzHgDshMMyEowSMEiXo+MOD3S43TIiNMjOUbHK0GIqEtiGCEKgNnqwNFTrqBRIz0edoWO+iZ7q+9TKRXITTQgLyUauYlRyE70Bo+cRANSY3S8aRcRRSyGEaJmrA4njp1uxJHaRhypbfB5NKPKaD3nezPj9eiREo28lGj0TIn2rOcmRnHCLCKiVjCMUMQyWuzYdaIeB6oaPD0cR2ulmo5zlXAkRWvRwxU0fJe85GgYtKzXICIKFMMIRQR38Nh1oh4/Hpcej55qbHX/aK0KPVKj0SMlBj2So6SejtQY9EiORnyUJowtJyLq+hhGqMux2J346WQ9dpTX4QdX8DhSa25x3+wEAwZmxXmGVHqkRKNHajRSY3ScS4OIKEwYRqjTO1nXhO3lZ7D95zpsLz+D3SeNsDnPnrY8O8GAwdnxGJwTj8HZ8RiUHY+kaK0MLSYiIl8MI9SpiKKIfVUmbDhQ6wkglUbLWfslR2sxtFsihnZLwKBsKXwweBARXZgYRuiCV2204P8O1GLDQWmpMflf0aJSKjAgMxZDcxMxrHsChnVLRLekKA6zEBF1EgwjdMFptDmw5chpbDhQiw0HarGvyuT3ul6jRGGPZBT2TMKwbonIz4lHlJa/ykREnRX/BacLgslix1d7qrDmxwr8b3+tX82HQgEMzo7H6N4pGN0nBcO7J/KeKkREXQjDCMnGZLGjZE81/vNjBf63v8YvgGQnGHBZHyl8XNorBYms9yCiC50gAE4boNHL3ZJOh2GEwqrB6kCJqwfk2/01sDm8AaR3WgyuGpyJq/Iz0ScthjUfRG1lqQfqj7uWY0DdMe9zmxnQxzdb4lrYlgAYEgFDAqCNkbok20MUAasJaDoNNLqWJp/HpjOAUg3EZgAxGdJjbAYQky61o6XPddoBcy3QUAU0VLseq6Sf5bQBgkPax/fRvS4KgC4WiEoCDElAVLLPeqLrMQnQxQX2nZvqgOrdQNVPQNUu1+NuwG6WflZMGhCdJj3GpLseXeuGRMBhBexNgKNJenQvvs8FJyA6fR4dUuDxbHN9t+hU15LiXY9Jkz5H2Tl6kRlGKOREUUTZsTq8/t1R/HdXJaw+AaRnajSuzs/CVYMz0TedASTi2Myuk4vPCcZcA1iM0j+yrZ5EEwBttPR+S713sRr9n1vqpX0cltb/wbc3SW1RaQG1Vnr0Xdzb1DpAGwvoYqTP1sZIbfSsx0j7WU1nt8Gvja4aKKUKUKikE7NSBSiUPttcJxBRlE44cD2Kgs82SCf4+mPS9w4mpdo/nBgSpROs4JBOog5LK49N0ncUHO37XLUBiE0HYjOlY2mukX43Gk8BOP+drTtEoZJ+twyJ/t/b9zg0nnKFjp+k494aq1FaTh0MbZvPR6GUwpcmqoXfpRZ+t27+GMgaKktTGUYoZKwOJ/7zQwVe33QUPx6v92zvkRKNq/OlHpB+6bEMIOEgCC2fqN0nR4XCdTJU+58QFSpAqZQeBYfrpNPSicgmPTrtzf6Sc/01JwrebTaz9y9cW4PcR6brMCQB8TlAQjfp0b3oYqVwd67A1lQHWOr8exoaa6WlvdR6b6+DpyfC9ei0Sb8DpgrAVAU0VErtcDQBZ45KS3MKZbOehnTp56m0gErj+t1Vu9Y1gMr1XKGUvn9TC700jWekR3uj9LvZ5NreVvG5QPpFrmWQtMSkAuZT3nDtCdrVgNm13lQnHR+NXgoKatejxuCzTSd9D9//H5v/v6lQSv89zTWu4FbjXW86Lf1/Z65p+/dxtjNEBgHDCAVdRX0T3t5cjlVby3HKbAMAaNVKTMzPwi1F3ZGfE88AAkh/mTjtgGB3PTq96xClf2jgCgnusOD73GFp+R8hc613vfGU9wR0oVIbzu7K1sVJQcVzwmx2ArX7zKiriT572EEX5+1J0Ua38A++a1G7/vFXKKVg5bQDTqt0snTYpEf3NnuT1CabGbA2uNYbXOtmwGaS3uNuiy6uhZ6deCkcAOcObILTNWTQ7L+/53fAtejjgfhuQHy29D07ShSl79l0xhtOmlyPVqO3h0itd63rvc/VOmnRx0uBQxsV2GfbmwBTpbQ0VAJ2y9nBI1RDDvYm/0Dm/s7Nn2ujgYzBUvhIGyj1lrTEkAik9A5NW9vKaZf+/2+oln63FUpAgZb/XXFvS+gmW3MZRigoRFHE1iOn8fqmo/jipyo4XXeay4zX46aLu+OGkblIjtHJ3MrzEJzSXy31x4G6cp8x+OPevxD9TghK70lB4bojr9PhOoG5T2y+JzWbd5tg93a1h5Mm6uyTpC7G+/3dJ0TB4T8uLTilvzjVemnYwu8k5FpX6Vx/lTbvWWm2rjF4TzAxae2rT3DapQCgjZY+k4JDoZBChDZKCjjhpDEAST2kJdzc4TQuM/yfHSoqjbcepxNgGKEOEUURX+6uwgtfH8CuE96/vi/umYRpRXn41cB0qFVKGVvow9rgX+TnGzbqywHjyfaPdQeLQil1zSoU3jFd33Fdv31VroK1NG/hWkyafxFbVIr015v7L3V1F7kqSaVp/a9SIup0GEaoXQRBxJe7K7G05CD2VEghxKBR4dqh2Zh2SXf0z4gLb4OsJsBYAZhO+j8aT3ivLrDUnf/nKFRAXLb/mHtCrnTCVyhaKCIUXeuitK7S+BQ/aly9Ba51tc41pt3KGLdSLdVnnIv7s0TBFVwukKBHRNQBDCMUEEEQ8d9dlXjh6wPYWyldFRCjU2PaJd1x++iewZsPRBSl8GA+JY17NtZKtRCNrufmWlfxW4UUOmym8/5IAK4x9lz/sBGf690Wm3FhXwrnHhYCQwgRdR0MI9QmTkHE5zsr8MLXB7C/SroCIlanxvRL83Db6B5IiGpnCHHagdr9QOVO71KzTwofgQ6Z6OKkSwLjMoHYLOkxLksq8EvIlXo89GHusSEiovNiGKFzEkURa3ZWYMlXB3Cw2hVC9GrcdmkP3HZpD8RHBVA8aGsETm4HKne5gsePQM1eqaCzNdpYIDpZqn2ISpbqIaKSpSU2wxU+sqRHdyEmERF1Kgwj1KqTdU3468c78e0+6Tr1OL0at43ugemX9kC8oQ0hRBCAqp3Aoa+lpXxzy8FDFyddn58x2HXZ3EApXEQlS3UWRETUpTGM0FkEQcSqbeVY+PleNFgd0KqVuHtML/z+sh6I058nhBhPAoe+AQ5/Iz02nzQpLhvIHOIKHq4AktC9/VNPExFRp8cwQn5+PmXGQx/+iM2HpVkIh3VLwDO/KUDvtFaGQEQRqPgB+OkjYP+XQM0e/9e1MUDeZUCvsdKS3IvBg4iI/DCMEACpQPXVjUfwty/3wWIXYNCo8Jfx/TDtkjyolC2Eh6rdwK4PpRBy+rDPCwoge5gUPHr+EsgZ2XXmtiAiopBgGCEcrDbhLx/8iB3ldQCAop7JePr6fHRLbjadc+0BYNdHUgCp2evdrtYDfccDA6+RAkhUUvgaT0REnR7DSARzCiKWrz+EpV8dgM0pIEanxl8nDMCUUbnee8eYKoEf3gV2fSBdAeOm0gK9i4GLrgP6/dp7vw0iIqIAMYxEqPpGO+55dwf+t1+6UuaX/VLx5KTByEowSHN/7P8C2PEmcGCddI8SQJohtOflwKDrgX4TOB03EREFBcNIBDpY3YA73vgeR2rN0GuUePyaQfjN8BwoavcDX74p9YT43nY6txAomCINw3AIhoiIgoxhJMJ8s7caf1q1AyarA1nxevzrhn4YeLoEWPEmcHybd8foNKDgBmDozUBqX/kaTEREXR7DSIQQRRHL1x/GM1/shSgCI7sn4NXBOxGz6hbAJs2sCoVKKkQdehPQ5wremp2IiMKCYSQCWOxOPPThj/i07CQA4K4hOjxofRbKr76RdkjuLfWAFEwBYtNlbCkREUUihpEurqK+CX94oxQ7T9RDrQReH3YYlxx4BgqrUbokt/hRYNQfeCt6IiKSDcNIF1b682nc+eZ21DZY0dPQiA9y3kPSri+lF7NHAJOWAyl95G0kERFFPIaRLmrtrgr8aVUZbE4Bv0/aib8KL0F17DSg1AC/nANcci+g4n9+IiKSH89GXdCmQ6fwp1Vl0DuNeCPlPVzc8JX0QvogqTckY7C8DSQiIvLBMNLF7Kkw4g9vfI+R4g94MfoVJDbUAgolMPp+YMxs3ieGiIguOAwjXcjxM434/YqNmOl8E3dq1wBOSFfKTHoJyBkhd/OIiIhaxDDSRZwx2/DXf32Ml2zPYLD6qLRxxO+BK54AtFHnfC8REZGcGEa6gCarA28vfxLLG/6JKKUVgj4RymuXAf2vkrtpRERE58Uw0sk5Gk5j1z9vxUzzekABNGZfiqjJ/wLisuRuGhERUZswjHRi4tGNML09HSPtVbCLKlSNeAA5V83mBGZERNSpMIx0Rk4H8L9nIK5/FokQcFRIR8WvXkTRZVfI3TIiIqKAMYx0NoITeO9mYN/nUAJ43/ELCFc+jcmXDpS7ZURERO3C/vzOpuRRYN/nsIga3GObieNjnmMQISKiTo1hpDMpWwVsXAoAeMB+F2JGTMZ9xby3DBERdW4cpuksjm0F/v0nAMDzjmtxJGM8PrlmEBQKhcwNIyIi6hiGkc6g/jjw7lTAacNa50g8L/wWn/4mHxoVO7aIiKjz49nsQmczA6umAOZq7Ed3zLLfjTvH9MZFWfFyt4yIiCgoGEYuZIIAfHwXUPkjGlQJmG6ZhYzUZNwzlnUiRETUdXCY5kK2/mlgz2cQlBpMa7wXJxWpeP/6fOg1KrlbRkREFDTsGblQ/fQxsH4RAOBp9R9QKvbDLRd3x4i8JJkbRkREFFztCiPLli1DXl4e9Ho9CgsLsXXr1nPuv2TJEvTr1w8GgwG5ubm4//77YbFY2tXgiHCyDPj4bgDApvQpeMl4KbITDPjLr/vL2y4iIqIQCDiMrF69GrNmzcKCBQuwfft2FBQUYPz48aiurm5x/3feeQezZ8/GggULsGfPHqxYsQKrV6/GX//61w43vksyVQHv3gg4mlCfPQY3lUt33n1y0iDE6DiqRkREXU/AYWTx4sW44447MH36dAwcOBDLly9HVFQUVq5c2eL+3333HS699FLceOONyMvLwxVXXIEpU6actzclIgkC8P40wHgCQnIf3GK8C05RieuGZePyfmlyt46IiCgkAgojNpsNpaWlKC4u9v4ApRLFxcXYtGlTi++55JJLUFpa6gkfhw8fxueff44JEya0+jlWqxVGo9FviQg73wfKNwHaGLzefRF+qBGREqPFvKs43TsREXVdAfX719bWwul0Ij093W97eno69u7d2+J7brzxRtTW1mL06NEQRREOhwN33XXXOYdpFi5ciEcffTSQpnV+9iag5DEAQPWQGXhqow0A8Mj/uwiJ0Vo5W0ZERBRSIb+a5ttvv8VTTz2Ff/zjH9i+fTs++ugjrFmzBo8//nir75kzZw7q6+s9y7Fjx0LdTPltWgYYj0OMz8GMQ4WwO0X8amA6rhqcKXfLiIiIQiqgnpGUlBSoVCpUVVX5ba+qqkJGRkaL75k3bx5uvvlm3H777QCAwYMHw2w24w9/+AMefvhhKJVn5yGdTgedThdI0zq3hmpgw98BAN/m3I1tpRbE6tV44lree4aIiLq+gHpGtFothg8fjpKSEs82QRBQUlKCoqKiFt/T2Nh4VuBQqaRJu0RRDLS9XdO3CwFbA5wZQ3DPzp4AgIcnDEB6nF7mhhEREYVewNeKzpo1C9OmTcOIESMwatQoLFmyBGazGdOnTwcA3HLLLcjOzsbChQsBABMnTsTixYsxdOhQFBYW4uDBg5g3bx4mTpzoCSURrXovUPoaAOCrbvei4aiI3mkxmDwyV952ERERhUnAYWTy5MmoqanB/PnzUVlZiSFDhmDt2rWeotby8nK/npC5c+dCoVBg7ty5OHHiBFJTUzFx4kQ8+eSTwfsWndm6eYAoQOx/Nf6+PwWACVMLu3F4hoiIIoZC7ARjJUajEfHx8aivr0dcXJzczQmeQ98Ab14LKNXYde0XuPqdKug1SmyZU4z4KI3crSMiIuqQtp6/eW8auQhO4Mu50vrI27Fyj9RJNTE/i0GEiIgiCsOIXMreAap2Afp41I28H//ZWQEAuOni7jI3jIiIKLwYRuRgMwNfPyGt/+IveH93I2wOAYOy45CfEy9v24iIiMKMYUQO370ANFQCiXkQRtyBd7aWAwCmFnZn4SoREUUchpFwM1YAG5dK68WPYFN5A47UmhGrU+P/FWTJ2zYiIiIZMIyE2zdPAPZGILcQGHgt3tr8MwBg0rBsROsCvtKaiIio02MYCafKncCOt6X1K55ElcmKL3dLU+vfWNhNxoYRERHJh2EkXETRdSmvCFx0HZA7Eu9tOwanIGJE90T0z+hC86cQEREFgGEkXCp+AA5/C6i0QPECOAURq1yFq7ycl4iIIhnDSLjsXSM99v01kJiHb/ZW42S9BYlRGvx6UMt3PCYiIooEDCPhsu9z6bHfBADA21ukwtXfjsiFXsMbBhIRUeRiGAmHM0el2VYVKqDveBw73Yhv99cAAG4cxcJVIiKKbAwj4bBvrfTYrQiISsKqreUQReCyPinIS4mWt21EREQyYxgJh32uepH+E2BzCHjv+2MAgKm8nJeIiIhhJOSazgBHN0rr/a7EFz9VorbBhvQ4HcYNSJe3bURERBcAhpFQO7AOEJ1A6gAgqaencHXyyG7QqHj4iYiIeDYMtb3eIZqD1SZsPnwaSgVww8hcedtFRER0gWAYCSWHFThYIq33uwpvb5EmORs3IB1ZCQYZG0ZERHThYBgJpaP/B9hMQEwGLGn5+LD0OAAWrhIREfliGAmlve6Jzn6NLUfrYLQ4kBmvxy/6pMrbLiIiogsIw0ioiCKw77/Ser+rsPnwKQDApb1ToFQqZGwYERHRhYVhJFRO7gBMJwFNNNDjF9h0SAojF/dMlrlhREREFxaGkVBx94r0HocGQY2dJ+oBABf3TJKxUURERBcehpFQ8bkx3vdHT8MpiMhNMiAnMUredhEREV1gGEZCodmN8TYfPg0AuLgHh2iIiIiaYxgJBfcQjevGeO7iVdaLEBERnY1hJBTcQzT9J6DB6vDUixSyXoSIiOgsDCPB1uzGeKwXISIiOjeGkWBrdmM81osQERGdG8NIsPncGA8ANrFehIiI6JwYRoLJYQUOfiWt97sKJosdu9zzi/RiGCEiImoJw0gwHf0/wNYAxGQAWUPx/c9n4BREdEuKQjbv0ktERNQihpFg8rkxHpRKn0t6eRUNERFRaxhGgqXZjfEAeItXWS9CRETUKoaRYGl2YzzfepFChhEiIqJWMYwEi3uis97jAI2e9SJERERtxDASLJ4hGumSXtaLEBERtQ3DSDA0uzEewHoRIiKitmIYCYaDJdJjt4uBqCT/+UUYRoiIiM6JYSQYjm2VHrtfCgD4/qhUL9I9OQpZrBchIiI6J4aRYDjuCiO5hQB86kV4PxoiIqLzYhjpqIYa4PRhaT1nOACfMNKLxatERETnwzDSUce3SY+p/QFDIkwWO3a65xdhzwgREdF5MYx01LEt0mPOSABSvYgggvUiREREbcQw0lHunhHWixAREbULw0hHOO3Aie3Seu4oAKwXISIiChTDSEdU7gQcTYA+AUjuw3oRIiKidmAY6Qj3/CI5IwGlEtuOnma9CBERUYAYRjrirPlFpCngizjrKhERUZsxjHSEu2ckV7qSxntzPIYRIiKitmIYaS9jBVB/DFAogezhMPrcj6aQd+olIiJqM4aR9nIP0aRdBOhi8b2rXiQvOQqZ8awXISIiaiuGkfbyDNG4L+mV6kU4RENERBQYhpH2OiuMsF6EiIioPRhG2sNhBSrKpPXcUawXISIi6gCGkfao+AFw2oCoFCCxB+tFiIiIOoBhpD3cN8fLLQQUCuw6YQQADOuWKGOjiIiIOieGkfZoNr/I3kopjAzIjJOrRURERJ0Ww0igRNEnjEgzr+6tMAEA+mXEytUqIiKiTothJFD1x4CGSkCpBrKGosnmxNFTZgBA/0yGESIiokAxjATK3SuSkQ9oDDhQbYIgAsnRWqTG6ORtGxERUSfEMBKoZvOL+A7RKBQKuVpFRETUaTGMBMpzJY0rjFRKYaR/BotXiYiI2oNhJBA2M1C5U1rPcYcR6Uoa1osQERG1D8NIIE7uAEQnEJsFxOdAFEWfnhGGESIiovZoVxhZtmwZ8vLyoNfrUVhYiK1bt7a67+WXXw6FQnHWctVVV7W70bLxnV9EoUBNgxWnzTYoFUCfNIYRIiKi9gg4jKxevRqzZs3CggULsH37dhQUFGD8+PGorq5ucf+PPvoIFRUVnmXXrl1QqVT47W9/2+HGh10r84vkJUfDoFXJ1SoiIqJOLeAwsnjxYtxxxx2YPn06Bg4ciOXLlyMqKgorV65scf+kpCRkZGR4lnXr1iEqKqrzhRFRBI67woirXmSfe4iG9SJERETtFlAYsdlsKC0tRXFxsfcHKJUoLi7Gpk2b2vQzVqxYgRtuuAHR0dGt7mO1WmE0Gv0W2Z0+DDSeAlQ6IDMfALDHXbzKK2mIiIjaLaAwUltbC6fTifT0dL/t6enpqKysPO/7t27dil27duH2228/534LFy5EfHy8Z8nNzQ2kmaHhHqLJGgKopcnNOA08ERFRx4X1apoVK1Zg8ODBGDVq1Dn3mzNnDurr6z3LsWPHwtTCc2g2v4jDKeBgdQMAYAB7RoiIiNpNHcjOKSkpUKlUqKqq8tteVVWFjIyMc77XbDbj3XffxWOPPXbez9HpdNDpLrCp1Y9vkx5d9SJHas2wOQVEa1XISTTI2DAiIqLOLaCeEa1Wi+HDh6OkpMSzTRAElJSUoKio6Jzvff/992G1WnHTTTe1r6VyshiB6t3SuqtnZI+reLVvRiyUSk4DT0RE1F4B9YwAwKxZszBt2jSMGDECo0aNwpIlS2A2mzF9+nQAwC233ILs7GwsXLjQ730rVqzAtddei+Tk5OC0PJxOlAKiACR0A2KlHqB9LF4lIiIKioDDyOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAq/Ttc9u3bhw0bNuDLL78MTqvDzT1E45pfBPAWrw7gZb1EREQdEnAYAYCZM2di5syZLb727bffnrWtX79+EEWxPR91YXAXr+Z4C2/d08D3S2cYISIi6gjem+Z8BMGnZ0QKI0aLHSfqmgBwmIaIiKijGEbOp3Y/YKkHNFFA+iAA3plXs+L1iI/SyNk6IiKiTo9h5HzcU8BnDwdU0qjW3gqpeJWTnREREXUcw8j5nCiVHnNGeDbt9dyThkM0REREHcUwcj7Ve6VH1xAN4BNG2DNCRETUYQwj5yKKQM0eaT21v2uT6L1bL4tXiYiIOoxh5FxMlVLxqkIFpPQBABw/04QGqwMalQI9U1u/8zARERG1DcPIubh7RZJ6eu/U6+oV6ZUaA42Kh4+IiKijeDY9F3e9SGo/zyb3lTQDWLxKREQUFAwj51LjCiNpAzyb9laxeJWIiCiYGEbOxR1GXMWrAOcYISIiCjaGkdaIoneYxtUzYrE7caTWDIDDNERERMHCMNIaUwVgdV1Jk9wbAHCwugGCCCRGaZAWq5O5gURERF0Dw0hrql1X0iT38lxJs8dniEahUMjVMiIioi6FYaQ1LdSLcLIzIiKi4GMYaY27Z8T3ShpXGBmQyeJVIiKiYGEYaU1NC3OMVLqHadgzQkREFCwMIy0RRaBmn7SeKvWM1JisqG2wQaEA+qbHyNg4IiKiroVhpCXGk4DVCCjVnitp3PUiecnRiNKq5WwdERFRl8Iw0hLPPWl6AWotAJ8hmnTWixAREQUTw0hLPJOd+cy86r6ShsWrREREQcUw0hJ3z0iq75U0Us8IL+slIiIKLoaRljTrGXE4BeyvagDAG+QREREFG8NIcy1cSXP0VCNsDgEGjQrdkqJkbBwREVHXwzDSXP1xwGaSrqRJ6gnAO0TTNyMWSiWngSciIgomhpHm3JOdJff2XklT4Zp5lUM0REREQccw0lwL96TxXEnDMEJERBR0DCPNeYpXz76ShtPAExERBR/DSHOey3qlnhGTxY7jZ5oAsGeEiIgoFBhGfPleSePqGdlfJQ3RZMTpkRitlatlREREXRbDiK/6Y4CtAVBqPFfS7HEVr/ZjrwgREVFIMIz4cteLpPQBVBoAwKEaabIzhhEiIqLQYBjx5akX6efZVNdoBwCkxHCIhoiIKBQYRny5e0Z87kljbJLCSJxeI0eLiIiIujyGEV/unhGfu/WaLA4AQCzDCBERUUgwjLgJAlCzX1r37RmxuHpGDGo5WkVERNTlMYy41R8D7GZApfVcSQNwmIaIiCjUGEbcPPek6QOovL0gRtcwTZyBYYSIiCgUGEbcqs+uF3E4BTRYXWFEz2EaIiKiUGAYcas5+0oadxABWMBKREQUKgwjbtVnzzHivpJGr1FCq+ahIiIiCgWeYQHpSppa15U0PnfrrWfxKhERUcgxjABA3c+AvVG6kiaxh2ez97JehhEiIqJQYRgBvPUiKX39r6RpYvEqERFRqDGMAD7Fq/39NrNnhIiIKPQYRgDvPWnS/MMIp4InIiIKPYYRwOduvQP8NntnX+UwDRERUagwjPjekyatWRjhMA0REVHIMYzUHQUcTYBKByTm+b3kLWBlGCEiIgoVhpFqnytplCq/l3jHXiIiotBjGKk5+540bu6aERawEhERhQ7DSHXLl/UC3qtpWMBKREQUOgwj7jlGmhWvAixgJSIiCofIDiOC03tPmhZ6Roy8Nw0REVHIRXYYOXMUcFgAtf6sK2kEQYTJ6hqmYQErERFRyER2GKlp/UqaBpsDoiits2eEiIgodCI7jFS7Z15tvXhVq1JCr1Gd9ToREREFR2SHkZqW70kD+NSLcIiGiIgopCI7jHgu623hShoWrxIREYVFZP/ZP/ZhoHInkDX0rJeM7jv28rJeIiKikIrsMNLvSmlpAe/YS0REFB6RPUxzDiZOeEZERBQWDCOtMHIqeCIiorBgGGkFC1iJiIjCg2GkFbwvDRERUXi0K4wsW7YMeXl50Ov1KCwsxNatW8+5f11dHWbMmIHMzEzodDr07dsXn3/+ebsaHC7GJg7TEBERhUPAZ9rVq1dj1qxZWL58OQoLC7FkyRKMHz8e+/btQ1pa2ln722w2/OpXv0JaWho++OADZGdn4+eff0ZCQkIw2h8y7BkhIiIKj4DDyOLFi3HHHXdg+vTpAIDly5djzZo1WLlyJWbPnn3W/itXrsTp06fx3XffQaORTux5eXkda3UYuKeDj2XPCBERUUgFNExjs9lQWlqK4uJi7w9QKlFcXIxNmza1+J7PPvsMRUVFmDFjBtLT0zFo0CA89dRTcDqdrX6O1WqF0Wj0W8LN0zPCAlYiIqKQCiiM1NbWwul0Ij093W97eno6KisrW3zP4cOH8cEHH8DpdOLzzz/HvHnz8Nxzz+GJJ55o9XMWLlyI+Ph4z5KbmxtIM4PCe28ahhEiIqJQCvnVNIIgIC0tDS+//DKGDx+OyZMn4+GHH8by5ctbfc+cOXNQX1/vWY4dOxbqZvoRRdFnnhGGESIiolAKqCAiJSUFKpUKVVVVfturqqqQkZHR4nsyMzOh0WigUqk82wYMGIDKykrYbDZotdqz3qPT6aDT6QJpWlA12pxwCiIA3rWXiIgo1ALqGdFqtRg+fDhKSko82wRBQElJCYqKilp8z6WXXoqDBw9CEATPtv379yMzM7PFIHIhcBevqpUKGDSq8+xNREREHRHwMM2sWbPwyiuv4PXXX8eePXtw9913w2w2e66uueWWWzBnzhzP/nfffTdOnz6Ne++9F/v378eaNWvw1FNPYcaMGcH7FkHmLl6N1auhUChkbg0REVHXFvAYxOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAqvRknNzcXX3zxBe6//37k5+cjOzsb9957Lx566KHgfYsgY/EqERFR+ChEURTlbsT5GI1GxMfHo76+HnFxcSH/vK/3VuG2177H4Ox4/Pue0SH/PCIioq6oredv3pumBZ6p4Fm8SkREFHIMIy3ghGdEREThwzDSAk4FT0REFD4MIy3wFLCyZ4SIiCjkGEZawDv2EhERhQ/DSAs8BawcpiEiIgo5hpEWsGeEiIgofBhGWsCb5BEREYUPw0gLTE3e6eCJiIgotBhGWsBhGiIiovBhGGlGFEWfGVgZRoiIiEKNYaQZq0OAzSkA4NU0RERE4cAw0ox7wjOlAojWMowQERGFGsNIM0bPVPAaKJUKmVtDRETU9TGMNOMuXuWVNEREROHBMNIM70tDREQUXgwjzXgmPDOwZ4SIiCgcGEaaYc8IERFReDGMNGOycI4RIiKicGIYaYYFrEREROHFMNIMh2mIiIjCi2GkGSOHaYiIiMKKYaQZb88Ih2mIiIjCgWGkGRPv2EtERBRWDCPNeIZpWDNCREQUFgwjzbiHaXg1DRERUXgwjDTjvrQ3nsM0REREYcEw4sPqcMJiFwBwmIaIiChcGEZ8uGdfBYAYDtMQERGFBcOID3cYidWpoVIqZG4NERFRZGAY8cHiVSIiovBjGPFh5BwjREREYccw4sPYxDlGiIiIwo1hxIe3Z4TDNEREROHCMOLDMxU8e0aIiIjChmHEh2eYhjUjREREYcMw4sM9TMOraYiIiMKHYcSH+9JeDtMQERGFD8OID88de1nASkREFDYMIz7YM0JERBR+DCM+TBYWsBIREYUbw4gPIy/tJSIiCjuGER+8Nw0REVH4MYy4OJwCzDYnAA7TEBERhRPDiIu7XgRgzwgREVE4MYy4uMNIlFYFjYqHhYiIKFx41nVh8SoREZE8GEZcWLxKREQkD4YRF0/PCItXiYiIwophxMVzx172jBAREYUVw4gLe0aIiIjkwTDi4rlJHgtYiYiIwophxMVzkzzesZeIiCisGEZc3MM0sewZISIiCiuGERdvASvDCBERUTgxjLh4C1g5TENERBRODCMuJhawEhERyYJhxMVbwMowQkREFE4MIy7eAlYO0xAREYUTwwgAQRDRYOUwDRERkRwYRgCYrA6IorTOnhEiIqLwYhgBYHIN0ejUSug1KplbQ0REFFkYRuAzxwiLV4mIiMKOYQQ+c4xwiIaIiCjsGEbgvayXU8ETERGFX7vCyLJly5CXlwe9Xo/CwkJs3bq11X1fe+01KBQKv0Wv17e7waHguWMvh2mIiIjCLuAwsnr1asyaNQsLFizA9u3bUVBQgPHjx6O6urrV98TFxaGiosKz/Pzzzx1qdLB5JjzjMA0REVHYBXz2Xbx4Me644w5Mnz4dALB8+XKsWbMGK1euxOzZs1t8j0KhQEZGRsdaGkIm9owQEZ3F6XTCbrfL3Qy6gGk0GqhUHb8KNaAwYrPZUFpaijlz5ni2KZVKFBcXY9OmTa2+r6GhAd27d4cgCBg2bBieeuopXHTRRa3ub7VaYbVaPc+NRmMgzQyYt4CVYYSISBRFVFZWoq6uTu6mUCeQkJCAjIwMKBSKdv+MgMJIbW0tnE4n0tPT/banp6dj7969Lb6nX79+WLlyJfLz81FfX4+//e1vuOSSS/DTTz8hJyenxfcsXLgQjz76aCBN6xDvfWk4TENE5A4iaWlpiIqK6tBJhrouURTR2NjoKdPIzMxs988K+dm3qKgIRUVFnueXXHIJBgwYgJdeegmPP/54i++ZM2cOZs2a5XluNBqRm5sbsjZ670vDnhEiimxOp9MTRJKTk+VuDl3gDAYDAKC6uhppaWntHrIJKIykpKRApVKhqqrKb3tVVVWba0I0Gg2GDh2KgwcPtrqPTqeDTqcLpGkd4pn0jAWsRBTh3DUiUVFRMreEOgv374rdbm93GAnoahqtVovhw4ejpKTEs00QBJSUlPj1fpyL0+nEzp07O9SdE2wmq3uYhj0jREQAODRDbRaM35WAuwJmzZqFadOmYcSIERg1ahSWLFkCs9nsubrmlltuQXZ2NhYuXAgAeOyxx3DxxRejd+/eqKurw7PPPouff/4Zt99+e4cbHyzenhGGESIionALOIxMnjwZNTU1mD9/PiorKzFkyBCsXbvWU9RaXl4OpdLb4XLmzBnccccdqKysRGJiIoYPH47vvvsOAwcODN636CB3zUg8C1iJiIjCTiGKoih3I87HaDQiPj4e9fX1iIuLC+rPFkURvf76OQQR2PLXcUiPu7BmhyUiCieLxYIjR46gR48eF9xs2XRhOtfvTFvP3xF/bxqzzQnBFcc4TENERMHCCePaLuLDiHuOEY1KAb0m4g8HEVGntXbtWowePRoJCQlITk7G1VdfjUOHDnleP378OKZMmYKkpCRER0djxIgR2LJli+f1f//73xg5ciT0ej1SUlIwadIkz2sKhQKffPKJ3+clJCTgtddeAwAcPXoUCoUCq1evxpgxY6DX6/H222/j1KlTmDJlCrKzsxEVFYXBgwdj1apVfj9HEAQ888wz6N27N3Q6Hbp164Ynn3wSADB27FjMnDnTb/+amhpotVq/i0k6u4gvkvBMBa/XsHqciKgFoiiiye4M++caNKqA/l02m82YNWsW8vPz0dDQgPnz52PSpEkoKytDY2MjxowZg+zsbHz22WfIyMjA9u3bIQgCAGDNmjWYNGkSHn74Ybzxxhuw2Wz4/PPPA27z7Nmz8dxzz2Ho0KHQ6/WwWCwYPnw4HnroIcTFxWHNmjW4+eab0atXL4waNQqANLfWK6+8gr///e8YPXo0KioqPBOJ3n777Zg5cyaee+45z5QXb731FrKzszF27NiA23ehivgw4pkKnpf1EhG1qMnuxMD5X4T9c3c/Nh5R2rafpq6//nq/5ytXrkRqaip2796N7777DjU1Ndi2bRuSkpIAAL179/bs++STT+KGG27wm/27oKAg4Dbfd999uO666/y2PfDAA571e+65B1988QXee+89jBo1CiaTCUuXLsWLL76IadOmAQB69eqF0aNHAwCuu+46zJw5E59++il+97vfAQBee+013HrrrV3qD+iIH5fgHXuJiLqGAwcOYMqUKejZsyfi4uKQl5cHQLrKs6ysDEOHDvUEkebKysowbty4DrdhxIgRfs+dTicef/xxDB48GElJSYiJicEXX3yB8vJyAMCePXtgtVpb/Wy9Xo+bb74ZK1euBABs374du3btwq233trhtl5IIv4MzKngiYjOzaBRYfdj42X53EBMnDgR3bt3xyuvvIKsrCwIgoBBgwbBZrN5pi1v9bPO87pCoUDzi09bKlCNjo72e/7ss89i6dKlWLJkCQYPHozo6Gjcd999sNlsbfpcQBqqGTJkCI4fP45XX30VY8eORffu3c/7vs6EPSPuCc84xwgRUYsUCgWitOqwL4EMQ5w6dQr79u3D3LlzMW7cOAwYMABnzpzxvJ6fn4+ysjKcPn26xffn5+efsyA0NTUVFRUVnucHDhxAY2Pjedu1ceNGXHPNNbjppptQUFCAnj17Yv/+/Z7X+/TpA4PBcM7PHjx4MEaMGIFXXnkF77zzDm677bbzfm5nE/FhxOSuGWHPCBFRp5WYmIjk5GS8/PLLOHjwIL7++mu/G65OmTIFGRkZuPbaa7Fx40YcPnwYH374ITZt2gQAWLBgAVatWoUFCxZgz5492LlzJ55++mnP+8eOHYsXX3wRO3bswPfff4+77roLGs35zxt9+vTBunXr8N1332HPnj248847/e7vptfr8dBDD+HBBx/EG2+8gUOHDmHz5s1YsWKF38+5/fbbsWjRIoii6HeVT1cR8WHE6L6ahgWsRESdllKpxLvvvovS0lIMGjQI999/P5599lnP61qtFl9++SXS0tIwYcIEDB48GIsWLfLc2O3yyy/H+++/j88++wxDhgzB2LFjsXXrVs/7n3vuOeTm5uKyyy7DjTfeiAceeKBNNxOcO3cuhg0bhvHjx+Pyyy/3BCJf8+bNw5///GfMnz8fAwYMwOTJk1FdXe23z5QpU6BWqzFlypQuORldxM/AOvvDH/HutmN44Iq+mDm2T1B/NhFRZ8MZWC9MR48eRa9evbBt2zYMGzZM7ub4CcYMrBFfKMFLe4mI6EJlt9tx6tQpzJ07FxdffPEFF0SChcM0rgLWWF7aS0REF5iNGzciMzMT27Ztw/Lly+VuTshE/BmYBaxERHShuvzyy8+6pLgrYs8IC1iJiIhkxTDSxJ4RIiIiOUV0GBFF0aeANeJHrIiIiGQR0WHEYhdgd0pjcZwOnoiISB4RHUbcvSJKBRCtDeweCERERBQcER1GTD5zjHSlWzETERF1JhEdRurdN8njEA0RUcTLy8vDkiVL5G5GRIroMMLiVSIiIvlFdhjhZb1ERNQFOJ1OCIIgdzPaLbLDiIVTwRMRdQUvv/wysrKyzjohX3PNNbjttttw6NAhXHPNNUhPT0dMTAxGjhyJr776qt2ft3jxYgwePBjR0dHIzc3FH//4RzQ0NPjts3HjRlx++eWIiopCYmIixo8fjzNnzgAABEHAM888g969e0On06Fbt2548sknAQDffvstFAoF6urqPD+rrKwMCoUCR48eBQC89tprSEhIwGeffYaBAwdCp9OhvLwc27Ztw69+9SukpKQgPj4eY8aMwfbt2/3aVVdXhzvvvBPp6enQ6/UYNGgQ/vOf/8BsNiMuLg4ffPCB3/6ffPIJoqOjYTKZ2n28zieiwwingiciagNRBGzm8C8BTIP+29/+FqdOncI333zj2Xb69GmsXbsWU6dORUNDAyZMmICSkhLs2LEDv/71rzFx4kSUl5e365AolUo8//zz+Omnn/D666/j66+/xoMPPuh5vaysDOPGjcPAgQOxadMmbNiwARMnToTT6QQAzJkzB4sWLcK8efOwe/duvPPOO0hPTw+oDY2NjXj66afxr3/9Cz/99BPS0tJgMpkwbdo0bNiwAZs3b0afPn0wYcIET5AQBAFXXnklNm7ciLfeegu7d+/GokWLoFKpEB0djRtuuAGvvvqq3+e8+uqr+M1vfoPY2Nh2Hau2iOguAfdN8jgVPBHROdgbgaeywv+5fz0JaKPbtGtiYiKuvPJKvPPOOxg3bhwA4IMPPkBKSgp++ctfQqlUoqCgwLP/448/jo8//hifffYZZs6cGXDT7rvvPs96Xl4ennjiCdx11134xz/+AQB45plnMGLECM9zALjooosAACaTCUuXLsWLL76IadOmAQB69eqF0aNHB9QGu92Of/zjH37fa+zYsX77vPzyy0hISMD69etx9dVX46uvvsLWrVuxZ88e9O3bFwDQs2dPz/633347LrnkElRUVCAzMxPV1dX4/PPPO9SL1BYR3TNiZM8IEVGXMXXqVHz44YewWq0AgLfffhs33HADlEolGhoa8MADD2DAgAFISEhATEwM9uzZ0+6eka+++grjxo1DdnY2YmNjcfPNN+PUqVNobGwE4O0ZacmePXtgtVpbfb2ttFot8vPz/bZVVVXhjjvuQJ8+fRAfH4+4uDg0NDR4vmdZWRlycnI8QaS5UaNG4aKLLsLrr78OAHjrrbfQvXt3/OIXv+hQW88nwntGeDUNEdF5aaKkXgo5PjcAEydOhCiKWLNmDUaOHIn/+7//w9///ncAwAMPPIB169bhb3/7G3r37g2DwYDf/OY3sNlsATfr6NGjuPrqq3H33XfjySefRFJSEjZs2IDf//73sNlsiIqKgsFgaPX953oNkIaAAPjdrddut7f4c5rPkTVt2jScOnUKS5cuRffu3aHT6VBUVOT5nuf7bEDqHVm2bBlmz56NV199FdOnTw/5XFwR3jPiLmBlzwgRUasUCmm4JNxLgCdAvV6P6667Dm+//TZWrVqFfv36YdiwYQCkYtJbb70VkyZNwuDBg5GRkeEpBg1UaWkpBEHAc889h4svvhh9+/bFyZP+YS0/Px8lJSUtvr9Pnz4wGAytvp6amgoAqKio8GwrKytrU9s2btyIP/3pT5gwYQIuuugi6HQ61NbW+rXr+PHj2L9/f6s/46abbsLPP/+M559/Hrt37/YMJYVSZIcRz6W97BkhIuoKpk6dijVr1mDlypWYOnWqZ3ufPn3w0UcfoaysDD/88ANuvPHGdl8K27t3b9jtdrzwwgs4fPgw3nzzTSxfvtxvnzlz5mDbtm344x//iB9//BF79+7FP//5T9TW1kKv1+Ohhx7Cgw8+iDfeeAOHDh3C5s2bsWLFCs/Pz83NxSOPPIIDBw5gzZo1eO6559rUtj59+uDNN9/Enj17sGXLFkydOtWvN2TMmDH4xS9+geuvvx7r1q3DkSNH8N///hdr16717JOYmIjrrrsOf/nLX3DFFVcgJyenXccpEBEdRiaPzMWdY3qiV1qM3E0hIqIgGDt2LJKSkrBv3z7ceOONnu2LFy9GYmIiLrnkEkycOBHjx4/39JoEqqCgAIsXL8bTTz+NQYMG4e2338bChQv99unbty++/PJL/PDDDxg1ahSKiorw6aefQq2W/vidN28e/vznP2P+/PkYMGAAJk+ejOrqagCARqPBqlWrsHfvXuTn5+Ppp5/GE0880aa2rVixAmfOnMGwYcNw8803409/+hPS0tL89vnwww8xcuRITJkyBQMHDsSDDz7oucrHzT3kdNttt7XrGAVKIYoBXDslE6PRiPj4eNTX1yMuLk7u5hARdVkWiwVHjhxBjx49oNfr5W4OyeTNN9/E/fffj5MnT0Kr1Z5z33P9zrT1/M3xCSIiIgIgzV1SUVGBRYsW4c477zxvEAmWiB6mISIiau7tt99GTExMi4t7rpCu6plnnkH//v2RkZGBOXPmhO1zOUxDREQeHKaRJiWrqqpq8TWNRoPu3buHuUUXNg7TEBERBVlsbGxIpz6ns3GYhoiIiGTFMEJERGfpzLejp/AKxu8Kh2mIiMhDq9VCqVTi5MmTSE1NhVarDflU4NQ5iaIIm82GmpoaKJXKDl15wzBCREQeSqUSPXr0QEVFxVlTnBO1JCoqCt26dfPcU6c9GEaIiMiPVqtFt27d4HA4zpqZk8iXSqWCWq3ucO8ZwwgREZ1FoVBAo9FAo+GNRCn0WMBKREREsmIYISIiIlkxjBAREZGsOkXNiHvGeqPRKHNLiIiIqK3c5+3z3XmmU4QRk8kEAMjNzZW5JURERBQok8mE+Pj4Vl/vFDfKEwQBJ0+eRGxsbFAn3zEajcjNzcWxY8d4A74w4PEOLx7v8OLxDi8e7/Bq7/EWRREmkwlZWVnnnIekU/SMKJVK5OTkhOznx8XF8Zc5jHi8w4vHO7x4vMOLxzu82nO8z9Uj4sYCViIiIpIVwwgRERHJKqLDiE6nw4IFC6DT6eRuSkTg8Q4vHu/w4vEOLx7v8Ar18e4UBaxERETUdUV0zwgRERHJj2GEiIiIZMUwQkRERLJiGCEiIiJZRXQYWbZsGfLy8qDX61FYWIitW7fK3aQu4X//+x8mTpyIrKwsKBQKfPLJJ36vi6KI+fPnIzMzEwaDAcXFxThw4IA8je0CFi5ciJEjRyI2NhZpaWm49tprsW/fPr99LBYLZsyYgeTkZMTExOD6669HVVWVTC3u3P75z38iPz/fM/lTUVER/vvf/3pe57EOnUWLFkGhUOC+++7zbOPxDq5HHnkECoXCb+nfv7/n9VAd74gNI6tXr8asWbOwYMECbN++HQUFBRg/fjyqq6vlblqnZzabUVBQgGXLlrX4+jPPPIPnn38ey5cvx5YtWxAdHY3x48fDYrGEuaVdw/r16zFjxgxs3rwZ69atg91uxxVXXAGz2ezZ5/7778e///1vvP/++1i/fj1OnjyJ6667TsZWd145OTlYtGgRSktL8f3332Ps2LG45ppr8NNPPwHgsQ6Vbdu24aWXXkJ+fr7fdh7v4LvoootQUVHhWTZs2OB5LWTHW4xQo0aNEmfMmOF57nQ6xaysLHHhwoUytqrrASB+/PHHnueCIIgZGRnis88+69lWV1cn6nQ6cdWqVTK0sOuprq4WAYjr168XRVE6vhqNRnz//fc9++zZs0cEIG7atEmuZnYpiYmJ4r/+9S8e6xAxmUxinz59xHXr1oljxowR7733XlEU+bsdCgsWLBALCgpafC2Uxzsie0ZsNhtKS0tRXFzs2aZUKlFcXIxNmzbJ2LKu78iRI6isrPQ79vHx8SgsLOSxD5L6+noAQFJSEgCgtLQUdrvd75j3798f3bp14zHvIKfTiXfffRdmsxlFRUU81iEyY8YMXHXVVX7HFeDvdqgcOHAAWVlZ6NmzJ6ZOnYry8nIAoT3eneJGecFWW1sLp9OJ9PR0v+3p6enYu3evTK2KDJWVlQDQ4rF3v0btJwgC7rvvPlx66aUYNGgQAOmYa7VaJCQk+O3LY95+O3fuRFFRESwWC2JiYvDxxx9j4MCBKCsr47EOsnfffRfbt2/Htm3bznqNv9vBV1hYiNdeew39+vVDRUUFHn30UVx22WXYtWtXSI93RIYRoq5qxowZ2LVrl98YLwVfv379UFZWhvr6enzwwQeYNm0a1q9fL3ezupxjx47h3nvvxbp166DX6+VuTkS48sorPev5+fkoLCxE9+7d8d5778FgMITscyNymCYlJQUqleqsCuCqqipkZGTI1KrI4D6+PPbBN3PmTPznP//BN998g5ycHM/2jIwM2Gw21NXV+e3PY95+Wq0WvXv3xvDhw7Fw4UIUFBRg6dKlPNZBVlpaiurqagwbNgxqtRpqtRrr16/H888/D7VajfT0dB7vEEtISEDfvn1x8ODBkP5+R2QY0Wq1GD58OEpKSjzbBEFASUkJioqKZGxZ19ejRw9kZGT4HXuj0YgtW7bw2LeTKIqYOXMmPv74Y3z99dfo0aOH3+vDhw+HRqPxO+b79u1DeXk5j3mQCIIAq9XKYx1k48aNw86dO1FWVuZZRowYgalTp3rWebxDq6GhAYcOHUJmZmZof787VP7aib377ruiTqcTX3vtNXH37t3iH/7wBzEhIUGsrKyUu2mdnslkEnfs2CHu2LFDBCAuXrxY3LFjh/jzzz+LoiiKixYtEhMSEsRPP/1U/PHHH8VrrrlG7NGjh9jU1CRzyzunu+++W4yPjxe//fZbsaKiwrM0NjZ69rnrrrvEbt26iV9//bX4/fffi0VFRWJRUZGMre68Zs+eLa5fv148cuSI+OOPP4qzZ88WFQqF+OWXX4qiyGMdar5X04gij3ew/fnPfxa//fZb8ciRI+LGjRvF4uJiMSUlRayurhZFMXTHO2LDiCiK4gsvvCB269ZN1Gq14qhRo8TNmzfL3aQu4ZtvvhEBnLVMmzZNFEXp8t558+aJ6enpok6nE8eNGyfu27dP3kZ3Yi0dawDiq6++6tmnqalJ/OMf/ygmJiaKUVFR4qRJk8SKigr5Gt2J3XbbbWL37t1FrVYrpqamiuPGjfMEEVHksQ615mGExzu4Jk+eLGZmZoparVbMzs4WJ0+eLB48eNDzeqiOt0IURbFjfStERERE7ReRNSNERER04WAYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrBhGiIiISFb/HzA/XZhSOg8yAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABIqElEQVR4nO3deXwU9f0/8Nfeu7nvOxDuQ0i4YxSLhVQqyk/RtoioiNWqBatSq1A5vEGtFFRa1IK3iLe2WBSj0i/IZSAKcl+GIyeQ7GaTPWd+f8yeIYFssrtDsq/n4zGPnZ2dzX52jMwrn897PqMQRVEEERERkUyUcjeAiIiIIhvDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCu13A1oC0EQcPLkScTGxkKhUMjdHCIiImoDURRhMpmQlZUFpbL1/o9OEUZOnjyJ3NxcuZtBRERE7XDs2DHk5OS0+nqnCCOxsbEApC8TFxcnc2uIiIioLYxGI3Jzcz3n8dZ0ijDiHpqJi4tjGCEiIupkzldiwQJWIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGs2hVGli1bhry8POj1ehQWFmLr1q2t7mu32/HYY4+hV69e0Ov1KCgowNq1a9vdYCIiIupaAg4jq1evxqxZs7BgwQJs374dBQUFGD9+PKqrq1vcf+7cuXjppZfwwgsvYPfu3bjrrrswadIk7Nixo8ONJyIios5PIYqiGMgbCgsLMXLkSLz44osApPvG5Obm4p577sHs2bPP2j8rKwsPP/wwZsyY4dl2/fXXw2Aw4K233mrTZxqNRsTHx6O+vp6TnhEREXUSbT1/B9QzYrPZUFpaiuLiYu8PUCpRXFyMTZs2tfgeq9UKvV7vt81gMGDDhg2tfo7VaoXRaPRbiIiIqGsKKIzU1tbC6XQiPT3db3t6ejoqKytbfM/48eOxePFiHDhwAIIgYN26dfjoo49QUVHR6ucsXLgQ8fHxnoU3ySMiIuq6Qn41zdKlS9GnTx/0798fWq0WM2fOxPTp0895K+E5c+agvr7esxw7dizUzSQiIiKZBHSjvJSUFKhUKlRVVfltr6qqQkZGRovvSU1NxSeffAKLxYJTp04hKysLs2fPRs+ePVv9HJ1OB51OF0jTiIiIIp7V4YTZ6oTZ6oDZ5oDZ6kCjzQmLXYDVIT1a7E5Y7E5YHQKsdicsDmnbnWN6ITvBIEu7AwojWq0Ww4cPR0lJCa699loAUgFrSUkJZs6cec736vV6ZGdnw26348MPP8Tvfve7djeaiIioMxFFEXanCJtTQJPNCZPFDpPFAaPr0fO8yQ6jxYEGqwN2pwCHIMLhFOAURNe6CIcgPbc7RTTZnGjwCR52Z0DXpPi5dmh25wgjADBr1ixMmzYNI0aMwKhRo7BkyRKYzWZMnz4dAHDLLbcgOzsbCxcuBABs2bIFJ06cwJAhQ3DixAk88sgjEAQBDz74YHC/CRERUSukk7n3JO50neTdJ3ib09trYHX4P/r2KjS5ehWabE402aXF4rvu2tdqF2BzSj0PVoe0Hti1qx2j1ygRrVUjWqdGlFYFnUYFvVoJvUYFvUYJnVp6lJ6roFMrkRYr34hEwGFk8uTJqKmpwfz581FZWYkhQ4Zg7dq1nqLW8vJyv3oQi8WCuXPn4vDhw4iJicGECRPw5ptvIiEhIWhfgoiIOjeHU4DFIfUaWOxOmG0ONFgcUq+BVeo5cD9vsEo9Cmarw3vydwh+QcD7KMAuhDcInI9CAcTo1IjTaxCrV7sW//UYnRo6tRJqpQIqlRIapQIqpQIalRIqpQJqpQJqlRIGjQrROhVidFLwiNapEa1VQa3qXBOsBzzPiBw4zwgRkbycggibQzrJS4/uxfvc5hBgtvoHCJPFFSqs7uEIh3+vgmvpyPBCeykVgFqphFqlgFathF6tgk4jPbp7D3TNehEMGhUMWpV3XaP0e+7uZdC5HrVqpfTc9bO0KmlRKhVh/75yaOv5O+CeESIiurA5BdFTQ+AuYGy0eYcWpHVpu/t5g2vfBlfPg7tnosFVDNlkd4at/e4TvqenQKdBjGs9ztVrEKuXegF8hx107hO/KwjoNSpo1VKvglolhQ61UiEFEKUiYgJBZ8AwQkQUZnan4ClWdBcx+q1bHLA5BAiiVM/gFAQ4RXedg+hZb7L5DGe4goR0FUVog4NSAejUKs9f/d5HFWJcQwbuYYcYvXc4wr09WquCXquCXu3uZVD69SooFAwJkYZhhIjoPJyCiAZPULDD2OS9CsI3RDRYHN4CR5/HJpu3+LHRJtU5hINaqfAUMBq0KkRpVYjSqD3r7h6IKK0KMTqNp/YgxtXrEKNTI1or9UJEab1hobPVI9CFj2GEiCKC3SmgrtGOukYb6prsOGO2Sc+bbKhv8r+s0tQscDRYHSFpU7RWhTiDxjP84FvIqFOroFYpPMWKSoXCVczofa7XqDw9Du4CRvfzaFcBJHsZqDNgGCGiC1qTzYnaBitqG6w41WCTHs02nDbbYLFLxZM2p1Q86V53F1PaHAKMFjvqGu1BCRR6jdITGqQQoUGcK0DEGdSI1alh0KpdPQ7eoQd3D4T7uTswsIeBSMIwQkQhJQgiTFap16G+ye4zyZMDDe519xUYPhNBucNHYxDrHxQKIN6gQYJBg4QoLRKiNEiM0iLe4B8qpMDhuy69plUzPBCFAsMIEbWJKIpotDlx2mzDmUabz6M05HG60Yb6Rilw+C4mix1CB6/a1KqVSI3RISVGi+QYHZKjtUiK1ko1DK7LJd2FlFq1ElqVyrMep1cjIUqLxCgpYKh4BQXRBYdhhCgCCYKI+iY7TrtDhVmqo6hrtOGMu66i0Y4zrse6Rmlfm6P9hZc6tVLqgTD410bE6vwnenIPgaTEaJEcrUNKrA7RWhVrH4i6MIYRoi5CFEUYmxyoMDahot6CijoLqowWnHbVV5wyWz3rZxrtcLazu0KrViI5WovEKKl3IjFai6Qojaf3IT5Kg3iDd4kzaBCn10CvUQX5GxNRV8EwQtQJOAURtQ1WVNZLAaPKZEVlvRQ6Kl1LRb0l4ImpYnVqJMVoPUEi0VVHkWDQIjHaGzDcz5OitTBo2EtBRMHFMEIkM4dTQJXJihNnmnCyrgkn6pqkgGF0BQ+jBTUma5vrLpKitciI0yMzXo+0OD1SYqQejKRoadgjMVrjedSp2VtBRPJjGCEKMVEUUW2y4nCNGUdPmXH8TCNO1llw4owreBgtbRoyUSkVSI3RIT1ej/RYHTLi9ciI1yMr3oCMeCl8pMfpORxCRJ0OwwhRkJwx23C41oyjtWYc8VmOnjKf9/JUjUqBzHgDshMMyEowSMEiXo+MOD3S43TIiNMjOUbHK0GIqEtiGCEKgNnqwNFTrqBRIz0edoWO+iZ7q+9TKRXITTQgLyUauYlRyE70Bo+cRANSY3S8aRcRRSyGEaJmrA4njp1uxJHaRhypbfB5NKPKaD3nezPj9eiREo28lGj0TIn2rOcmRnHCLCKiVjCMUMQyWuzYdaIeB6oaPD0cR2ulmo5zlXAkRWvRwxU0fJe85GgYtKzXICIKFMMIRQR38Nh1oh4/Hpcej55qbHX/aK0KPVKj0SMlBj2So6SejtQY9EiORnyUJowtJyLq+hhGqMux2J346WQ9dpTX4QdX8DhSa25x3+wEAwZmxXmGVHqkRKNHajRSY3ScS4OIKEwYRqjTO1nXhO3lZ7D95zpsLz+D3SeNsDnPnrY8O8GAwdnxGJwTj8HZ8RiUHY+kaK0MLSYiIl8MI9SpiKKIfVUmbDhQ6wkglUbLWfslR2sxtFsihnZLwKBsKXwweBARXZgYRuiCV2204P8O1GLDQWmpMflf0aJSKjAgMxZDcxMxrHsChnVLRLekKA6zEBF1EgwjdMFptDmw5chpbDhQiw0HarGvyuT3ul6jRGGPZBT2TMKwbonIz4lHlJa/ykREnRX/BacLgslix1d7qrDmxwr8b3+tX82HQgEMzo7H6N4pGN0nBcO7J/KeKkREXQjDCMnGZLGjZE81/vNjBf63v8YvgGQnGHBZHyl8XNorBYms9yCiC50gAE4boNHL3ZJOh2GEwqrB6kCJqwfk2/01sDm8AaR3WgyuGpyJq/Iz0ScthjUfRG1lqQfqj7uWY0DdMe9zmxnQxzdb4lrYlgAYEgFDAqCNkbok20MUAasJaDoNNLqWJp/HpjOAUg3EZgAxGdJjbAYQky61o6XPddoBcy3QUAU0VLseq6Sf5bQBgkPax/fRvS4KgC4WiEoCDElAVLLPeqLrMQnQxQX2nZvqgOrdQNVPQNUu1+NuwG6WflZMGhCdJj3GpLseXeuGRMBhBexNgKNJenQvvs8FJyA6fR4dUuDxbHN9t+hU15LiXY9Jkz5H2Tl6kRlGKOREUUTZsTq8/t1R/HdXJaw+AaRnajSuzs/CVYMz0TedASTi2Myuk4vPCcZcA1iM0j+yrZ5EEwBttPR+S713sRr9n1vqpX0cltb/wbc3SW1RaQG1Vnr0Xdzb1DpAGwvoYqTP1sZIbfSsx0j7WU1nt8Gvja4aKKUKUKikE7NSBSiUPttcJxBRlE44cD2Kgs82SCf4+mPS9w4mpdo/nBgSpROs4JBOog5LK49N0ncUHO37XLUBiE0HYjOlY2mukX43Gk8BOP+drTtEoZJ+twyJ/t/b9zg0nnKFjp+k494aq1FaTh0MbZvPR6GUwpcmqoXfpRZ+t27+GMgaKktTGUYoZKwOJ/7zQwVe33QUPx6v92zvkRKNq/OlHpB+6bEMIOEgCC2fqN0nR4XCdTJU+58QFSpAqZQeBYfrpNPSicgmPTrtzf6Sc/01JwrebTaz9y9cW4PcR6brMCQB8TlAQjfp0b3oYqVwd67A1lQHWOr8exoaa6WlvdR6b6+DpyfC9ei0Sb8DpgrAVAU0VErtcDQBZ45KS3MKZbOehnTp56m0gErj+t1Vu9Y1gMr1XKGUvn9TC700jWekR3uj9LvZ5NreVvG5QPpFrmWQtMSkAuZT3nDtCdrVgNm13lQnHR+NXgoKatejxuCzTSd9D9//H5v/v6lQSv89zTWu4FbjXW86Lf1/Z65p+/dxtjNEBgHDCAVdRX0T3t5cjlVby3HKbAMAaNVKTMzPwi1F3ZGfE88AAkh/mTjtgGB3PTq96xClf2jgCgnusOD73GFp+R8hc613vfGU9wR0oVIbzu7K1sVJQcVzwmx2ArX7zKiriT572EEX5+1J0Ua38A++a1G7/vFXKKVg5bQDTqt0snTYpEf3NnuT1CabGbA2uNYbXOtmwGaS3uNuiy6uhZ6deCkcAOcObILTNWTQ7L+/53fAtejjgfhuQHy29D07ShSl79l0xhtOmlyPVqO3h0itd63rvc/VOmnRx0uBQxsV2GfbmwBTpbQ0VAJ2y9nBI1RDDvYm/0Dm/s7Nn2ujgYzBUvhIGyj1lrTEkAik9A5NW9vKaZf+/2+oln63FUpAgZb/XXFvS+gmW3MZRigoRFHE1iOn8fqmo/jipyo4XXeay4zX46aLu+OGkblIjtHJ3MrzEJzSXy31x4G6cp8x+OPevxD9TghK70lB4bojr9PhOoG5T2y+JzWbd5tg93a1h5Mm6uyTpC7G+/3dJ0TB4T8uLTilvzjVemnYwu8k5FpX6Vx/lTbvWWm2rjF4TzAxae2rT3DapQCgjZY+k4JDoZBChDZKCjjhpDEAST2kJdzc4TQuM/yfHSoqjbcepxNgGKEOEUURX+6uwgtfH8CuE96/vi/umYRpRXn41cB0qFVKGVvow9rgX+TnGzbqywHjyfaPdQeLQil1zSoU3jFd33Fdv31VroK1NG/hWkyafxFbVIr015v7L3V1F7kqSaVp/a9SIup0GEaoXQRBxJe7K7G05CD2VEghxKBR4dqh2Zh2SXf0z4gLb4OsJsBYAZhO+j8aT3ivLrDUnf/nKFRAXLb/mHtCrnTCVyhaKCIUXeuitK7S+BQ/aly9Ba51tc41pt3KGLdSLdVnnIv7s0TBFVwukKBHRNQBDCMUEEEQ8d9dlXjh6wPYWyldFRCjU2PaJd1x++iewZsPRBSl8GA+JY17NtZKtRCNrufmWlfxW4UUOmym8/5IAK4x9lz/sBGf690Wm3FhXwrnHhYCQwgRdR0MI9QmTkHE5zsr8MLXB7C/SroCIlanxvRL83Db6B5IiGpnCHHagdr9QOVO71KzTwofgQ6Z6OKkSwLjMoHYLOkxLksq8EvIlXo89GHusSEiovNiGKFzEkURa3ZWYMlXB3Cw2hVC9GrcdmkP3HZpD8RHBVA8aGsETm4HKne5gsePQM1eqaCzNdpYIDpZqn2ISpbqIaKSpSU2wxU+sqRHdyEmERF1Kgwj1KqTdU3468c78e0+6Tr1OL0at43ugemX9kC8oQ0hRBCAqp3Aoa+lpXxzy8FDFyddn58x2HXZ3EApXEQlS3UWRETUpTGM0FkEQcSqbeVY+PleNFgd0KqVuHtML/z+sh6I058nhBhPAoe+AQ5/Iz02nzQpLhvIHOIKHq4AktC9/VNPExFRp8cwQn5+PmXGQx/+iM2HpVkIh3VLwDO/KUDvtFaGQEQRqPgB+OkjYP+XQM0e/9e1MUDeZUCvsdKS3IvBg4iI/DCMEACpQPXVjUfwty/3wWIXYNCo8Jfx/TDtkjyolC2Eh6rdwK4PpRBy+rDPCwoge5gUPHr+EsgZ2XXmtiAiopBgGCEcrDbhLx/8iB3ldQCAop7JePr6fHRLbjadc+0BYNdHUgCp2evdrtYDfccDA6+RAkhUUvgaT0REnR7DSARzCiKWrz+EpV8dgM0pIEanxl8nDMCUUbnee8eYKoEf3gV2fSBdAeOm0gK9i4GLrgP6/dp7vw0iIqIAMYxEqPpGO+55dwf+t1+6UuaX/VLx5KTByEowSHN/7P8C2PEmcGCddI8SQJohtOflwKDrgX4TOB03EREFBcNIBDpY3YA73vgeR2rN0GuUePyaQfjN8BwoavcDX74p9YT43nY6txAomCINw3AIhoiIgoxhJMJ8s7caf1q1AyarA1nxevzrhn4YeLoEWPEmcHybd8foNKDgBmDozUBqX/kaTEREXR7DSIQQRRHL1x/GM1/shSgCI7sn4NXBOxGz6hbAJs2sCoVKKkQdehPQ5wremp2IiMKCYSQCWOxOPPThj/i07CQA4K4hOjxofRbKr76RdkjuLfWAFEwBYtNlbCkREUUihpEurqK+CX94oxQ7T9RDrQReH3YYlxx4BgqrUbokt/hRYNQfeCt6IiKSDcNIF1b682nc+eZ21DZY0dPQiA9y3kPSri+lF7NHAJOWAyl95G0kERFFPIaRLmrtrgr8aVUZbE4Bv0/aib8KL0F17DSg1AC/nANcci+g4n9+IiKSH89GXdCmQ6fwp1Vl0DuNeCPlPVzc8JX0QvogqTckY7C8DSQiIvLBMNLF7Kkw4g9vfI+R4g94MfoVJDbUAgolMPp+YMxs3ieGiIguOAwjXcjxM434/YqNmOl8E3dq1wBOSFfKTHoJyBkhd/OIiIhaxDDSRZwx2/DXf32Ml2zPYLD6qLRxxO+BK54AtFHnfC8REZGcGEa6gCarA28vfxLLG/6JKKUVgj4RymuXAf2vkrtpRERE58Uw0sk5Gk5j1z9vxUzzekABNGZfiqjJ/wLisuRuGhERUZswjHRi4tGNML09HSPtVbCLKlSNeAA5V83mBGZERNSpMIx0Rk4H8L9nIK5/FokQcFRIR8WvXkTRZVfI3TIiIqKAMYx0NoITeO9mYN/nUAJ43/ELCFc+jcmXDpS7ZURERO3C/vzOpuRRYN/nsIga3GObieNjnmMQISKiTo1hpDMpWwVsXAoAeMB+F2JGTMZ9xby3DBERdW4cpuksjm0F/v0nAMDzjmtxJGM8PrlmEBQKhcwNIyIi6hiGkc6g/jjw7lTAacNa50g8L/wWn/4mHxoVO7aIiKjz49nsQmczA6umAOZq7Ed3zLLfjTvH9MZFWfFyt4yIiCgoGEYuZIIAfHwXUPkjGlQJmG6ZhYzUZNwzlnUiRETUdXCY5kK2/mlgz2cQlBpMa7wXJxWpeP/6fOg1KrlbRkREFDTsGblQ/fQxsH4RAOBp9R9QKvbDLRd3x4i8JJkbRkREFFztCiPLli1DXl4e9Ho9CgsLsXXr1nPuv2TJEvTr1w8GgwG5ubm4//77YbFY2tXgiHCyDPj4bgDApvQpeMl4KbITDPjLr/vL2y4iIqIQCDiMrF69GrNmzcKCBQuwfft2FBQUYPz48aiurm5x/3feeQezZ8/GggULsGfPHqxYsQKrV6/GX//61w43vksyVQHv3gg4mlCfPQY3lUt33n1y0iDE6DiqRkREXU/AYWTx4sW44447MH36dAwcOBDLly9HVFQUVq5c2eL+3333HS699FLceOONyMvLwxVXXIEpU6actzclIgkC8P40wHgCQnIf3GK8C05RieuGZePyfmlyt46IiCgkAgojNpsNpaWlKC4u9v4ApRLFxcXYtGlTi++55JJLUFpa6gkfhw8fxueff44JEya0+jlWqxVGo9FviQg73wfKNwHaGLzefRF+qBGREqPFvKs43TsREXVdAfX719bWwul0Ij093W97eno69u7d2+J7brzxRtTW1mL06NEQRREOhwN33XXXOYdpFi5ciEcffTSQpnV+9iag5DEAQPWQGXhqow0A8Mj/uwiJ0Vo5W0ZERBRSIb+a5ttvv8VTTz2Ff/zjH9i+fTs++ugjrFmzBo8//nir75kzZw7q6+s9y7Fjx0LdTPltWgYYj0OMz8GMQ4WwO0X8amA6rhqcKXfLiIiIQiqgnpGUlBSoVCpUVVX5ba+qqkJGRkaL75k3bx5uvvlm3H777QCAwYMHw2w24w9/+AMefvhhKJVn5yGdTgedThdI0zq3hmpgw98BAN/m3I1tpRbE6tV44lree4aIiLq+gHpGtFothg8fjpKSEs82QRBQUlKCoqKiFt/T2Nh4VuBQqaRJu0RRDLS9XdO3CwFbA5wZQ3DPzp4AgIcnDEB6nF7mhhEREYVewNeKzpo1C9OmTcOIESMwatQoLFmyBGazGdOnTwcA3HLLLcjOzsbChQsBABMnTsTixYsxdOhQFBYW4uDBg5g3bx4mTpzoCSURrXovUPoaAOCrbvei4aiI3mkxmDwyV952ERERhUnAYWTy5MmoqanB/PnzUVlZiSFDhmDt2rWeotby8nK/npC5c+dCoVBg7ty5OHHiBFJTUzFx4kQ8+eSTwfsWndm6eYAoQOx/Nf6+PwWACVMLu3F4hoiIIoZC7ARjJUajEfHx8aivr0dcXJzczQmeQ98Ab14LKNXYde0XuPqdKug1SmyZU4z4KI3crSMiIuqQtp6/eW8auQhO4Mu50vrI27Fyj9RJNTE/i0GEiIgiCsOIXMreAap2Afp41I28H//ZWQEAuOni7jI3jIiIKLwYRuRgMwNfPyGt/+IveH93I2wOAYOy45CfEy9v24iIiMKMYUQO370ANFQCiXkQRtyBd7aWAwCmFnZn4SoREUUchpFwM1YAG5dK68WPYFN5A47UmhGrU+P/FWTJ2zYiIiIZMIyE2zdPAPZGILcQGHgt3tr8MwBg0rBsROsCvtKaiIio02MYCafKncCOt6X1K55ElcmKL3dLU+vfWNhNxoYRERHJh2EkXETRdSmvCFx0HZA7Eu9tOwanIGJE90T0z+hC86cQEREFgGEkXCp+AA5/C6i0QPECOAURq1yFq7ycl4iIIhnDSLjsXSM99v01kJiHb/ZW42S9BYlRGvx6UMt3PCYiIooEDCPhsu9z6bHfBADA21ukwtXfjsiFXsMbBhIRUeRiGAmHM0el2VYVKqDveBw73Yhv99cAAG4cxcJVIiKKbAwj4bBvrfTYrQiISsKqreUQReCyPinIS4mWt21EREQyYxgJh32uepH+E2BzCHjv+2MAgKm8nJeIiIhhJOSazgBHN0rr/a7EFz9VorbBhvQ4HcYNSJe3bURERBcAhpFQO7AOEJ1A6gAgqaencHXyyG7QqHj4iYiIeDYMtb3eIZqD1SZsPnwaSgVww8hcedtFRER0gWAYCSWHFThYIq33uwpvb5EmORs3IB1ZCQYZG0ZERHThYBgJpaP/B9hMQEwGLGn5+LD0OAAWrhIREfliGAmlve6Jzn6NLUfrYLQ4kBmvxy/6pMrbLiIiogsIw0ioiCKw77/Ser+rsPnwKQDApb1ToFQqZGwYERHRhYVhJFRO7gBMJwFNNNDjF9h0SAojF/dMlrlhREREFxaGkVBx94r0HocGQY2dJ+oBABf3TJKxUURERBcehpFQ8bkx3vdHT8MpiMhNMiAnMUredhEREV1gGEZCodmN8TYfPg0AuLgHh2iIiIiaYxgJBfcQjevGeO7iVdaLEBERnY1hJBTcQzT9J6DB6vDUixSyXoSIiOgsDCPB1uzGeKwXISIiOjeGkWBrdmM81osQERGdG8NIsPncGA8ANrFehIiI6JwYRoLJYQUOfiWt97sKJosdu9zzi/RiGCEiImoJw0gwHf0/wNYAxGQAWUPx/c9n4BREdEuKQjbv0ktERNQihpFg8rkxHpRKn0t6eRUNERFRaxhGgqXZjfEAeItXWS9CRETUKoaRYGl2YzzfepFChhEiIqJWMYwEi3uis97jAI2e9SJERERtxDASLJ4hGumSXtaLEBERtQ3DSDA0uzEewHoRIiKitmIYCYaDJdJjt4uBqCT/+UUYRoiIiM6JYSQYjm2VHrtfCgD4/qhUL9I9OQpZrBchIiI6J4aRYDjuCiO5hQB86kV4PxoiIqLzYhjpqIYa4PRhaT1nOACfMNKLxatERETnwzDSUce3SY+p/QFDIkwWO3a65xdhzwgREdF5MYx01LEt0mPOSABSvYgggvUiREREbcQw0lHunhHWixAREbULw0hHOO3Aie3Seu4oAKwXISIiChTDSEdU7gQcTYA+AUjuw3oRIiKidmAY6Qj3/CI5IwGlEtuOnma9CBERUYAYRjrirPlFpCngizjrKhERUZsxjHSEu2ckV7qSxntzPIYRIiKitmIYaS9jBVB/DFAogezhMPrcj6aQd+olIiJqM4aR9nIP0aRdBOhi8b2rXiQvOQqZ8awXISIiaiuGkfbyDNG4L+mV6kU4RENERBQYhpH2OiuMsF6EiIioPRhG2sNhBSrKpPXcUawXISIi6gCGkfao+AFw2oCoFCCxB+tFiIiIOoBhpD3cN8fLLQQUCuw6YQQADOuWKGOjiIiIOieGkfZoNr/I3kopjAzIjJOrRURERJ0Ww0igRNEnjEgzr+6tMAEA+mXEytUqIiKiTothJFD1x4CGSkCpBrKGosnmxNFTZgBA/0yGESIiokAxjATK3SuSkQ9oDDhQbYIgAsnRWqTG6ORtGxERUSfEMBKoZvOL+A7RKBQKuVpFRETUaTGMBMpzJY0rjFRKYaR/BotXiYiI2oNhJBA2M1C5U1rPcYcR6Uoa1osQERG1D8NIIE7uAEQnEJsFxOdAFEWfnhGGESIiovZoVxhZtmwZ8vLyoNfrUVhYiK1bt7a67+WXXw6FQnHWctVVV7W70bLxnV9EoUBNgxWnzTYoFUCfNIYRIiKi9gg4jKxevRqzZs3CggULsH37dhQUFGD8+PGorq5ucf+PPvoIFRUVnmXXrl1QqVT47W9/2+HGh10r84vkJUfDoFXJ1SoiIqJOLeAwsnjxYtxxxx2YPn06Bg4ciOXLlyMqKgorV65scf+kpCRkZGR4lnXr1iEqKqrzhRFRBI67woirXmSfe4iG9SJERETtFlAYsdlsKC0tRXFxsfcHKJUoLi7Gpk2b2vQzVqxYgRtuuAHR0dGt7mO1WmE0Gv0W2Z0+DDSeAlQ6IDMfALDHXbzKK2mIiIjaLaAwUltbC6fTifT0dL/t6enpqKysPO/7t27dil27duH2228/534LFy5EfHy8Z8nNzQ2kmaHhHqLJGgKopcnNOA08ERFRx4X1apoVK1Zg8ODBGDVq1Dn3mzNnDurr6z3LsWPHwtTCc2g2v4jDKeBgdQMAYAB7RoiIiNpNHcjOKSkpUKlUqKqq8tteVVWFjIyMc77XbDbj3XffxWOPPXbez9HpdNDpLrCp1Y9vkx5d9SJHas2wOQVEa1XISTTI2DAiIqLOLaCeEa1Wi+HDh6OkpMSzTRAElJSUoKio6Jzvff/992G1WnHTTTe1r6VyshiB6t3SuqtnZI+reLVvRiyUSk4DT0RE1F4B9YwAwKxZszBt2jSMGDECo0aNwpIlS2A2mzF9+nQAwC233ILs7GwsXLjQ730rVqzAtddei+Tk5OC0PJxOlAKiACR0A2KlHqB9LF4lIiIKioDDyOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAq/Ttc9u3bhw0bNuDLL78MTqvDzT1E45pfBPAWrw7gZb1EREQdEnAYAYCZM2di5syZLb727bffnrWtX79+EEWxPR91YXAXr+Z4C2/d08D3S2cYISIi6gjem+Z8BMGnZ0QKI0aLHSfqmgBwmIaIiKijGEbOp3Y/YKkHNFFA+iAA3plXs+L1iI/SyNk6IiKiTo9h5HzcU8BnDwdU0qjW3gqpeJWTnREREXUcw8j5nCiVHnNGeDbt9dyThkM0REREHcUwcj7Ve6VH1xAN4BNG2DNCRETUYQwj5yKKQM0eaT21v2uT6L1bL4tXiYiIOoxh5FxMlVLxqkIFpPQBABw/04QGqwMalQI9U1u/8zARERG1DcPIubh7RZJ6eu/U6+oV6ZUaA42Kh4+IiKijeDY9F3e9SGo/zyb3lTQDWLxKREQUFAwj51LjCiNpAzyb9laxeJWIiCiYGEbOxR1GXMWrAOcYISIiCjaGkdaIoneYxtUzYrE7caTWDIDDNERERMHCMNIaUwVgdV1Jk9wbAHCwugGCCCRGaZAWq5O5gURERF0Dw0hrql1X0iT38lxJs8dniEahUMjVMiIioi6FYaQ1LdSLcLIzIiKi4GMYaY27Z8T3ShpXGBmQyeJVIiKiYGEYaU1NC3OMVLqHadgzQkREFCwMIy0RRaBmn7SeKvWM1JisqG2wQaEA+qbHyNg4IiKiroVhpCXGk4DVCCjVnitp3PUiecnRiNKq5WwdERFRl8Iw0hLPPWl6AWotAJ8hmnTWixAREQUTw0hLPJOd+cy86r6ShsWrREREQcUw0hJ3z0iq75U0Us8IL+slIiIKLoaRljTrGXE4BeyvagDAG+QREREFG8NIcy1cSXP0VCNsDgEGjQrdkqJkbBwREVHXwzDSXP1xwGaSrqRJ6gnAO0TTNyMWSiWngSciIgomhpHm3JOdJff2XklT4Zp5lUM0REREQccw0lwL96TxXEnDMEJERBR0DCPNeYpXz76ShtPAExERBR/DSHOey3qlnhGTxY7jZ5oAsGeEiIgoFBhGfPleSePqGdlfJQ3RZMTpkRitlatlREREXRbDiK/6Y4CtAVBqPFfS7HEVr/ZjrwgREVFIMIz4cteLpPQBVBoAwKEaabIzhhEiIqLQYBjx5akX6efZVNdoBwCkxHCIhoiIKBQYRny5e0Z87kljbJLCSJxeI0eLiIiIujyGEV/unhGfu/WaLA4AQCzDCBERUUgwjLgJAlCzX1r37RmxuHpGDGo5WkVERNTlMYy41R8D7GZApfVcSQNwmIaIiCjUGEbcPPek6QOovL0gRtcwTZyBYYSIiCgUGEbcqs+uF3E4BTRYXWFEz2EaIiKiUGAYcas5+0oadxABWMBKREQUKgwjbtVnzzHivpJGr1FCq+ahIiIiCgWeYQHpSppa15U0PnfrrWfxKhERUcgxjABA3c+AvVG6kiaxh2ez97JehhEiIqJQYRgBvPUiKX39r6RpYvEqERFRqDGMAD7Fq/39NrNnhIiIKPQYRgDvPWnS/MMIp4InIiIKPYYRwOduvQP8NntnX+UwDRERUagwjPjekyatWRjhMA0REVHIMYzUHQUcTYBKByTm+b3kLWBlGCEiIgoVhpFqnytplCq/l3jHXiIiotBjGKk5+540bu6aERawEhERhQ7DSHXLl/UC3qtpWMBKREQUOgwj7jlGmhWvAixgJSIiCofIDiOC03tPmhZ6Roy8Nw0REVHIRXYYOXMUcFgAtf6sK2kEQYTJ6hqmYQErERFRyER2GKlp/UqaBpsDoiits2eEiIgodCI7jFS7Z15tvXhVq1JCr1Gd9ToREREFR2SHkZqW70kD+NSLcIiGiIgopCI7jHgu623hShoWrxIREYVFZP/ZP/ZhoHInkDX0rJeM7jv28rJeIiKikIrsMNLvSmlpAe/YS0REFB6RPUxzDiZOeEZERBQWDCOtMHIqeCIiorBgGGkFC1iJiIjCg2GkFbwvDRERUXi0K4wsW7YMeXl50Ov1KCwsxNatW8+5f11dHWbMmIHMzEzodDr07dsXn3/+ebsaHC7GJg7TEBERhUPAZ9rVq1dj1qxZWL58OQoLC7FkyRKMHz8e+/btQ1pa2ln722w2/OpXv0JaWho++OADZGdn4+eff0ZCQkIw2h8y7BkhIiIKj4DDyOLFi3HHHXdg+vTpAIDly5djzZo1WLlyJWbPnn3W/itXrsTp06fx3XffQaORTux5eXkda3UYuKeDj2XPCBERUUgFNExjs9lQWlqK4uJi7w9QKlFcXIxNmza1+J7PPvsMRUVFmDFjBtLT0zFo0CA89dRTcDqdrX6O1WqF0Wj0W8LN0zPCAlYiIqKQCiiM1NbWwul0Ij093W97eno6KisrW3zP4cOH8cEHH8DpdOLzzz/HvHnz8Nxzz+GJJ55o9XMWLlyI+Ph4z5KbmxtIM4PCe28ahhEiIqJQCvnVNIIgIC0tDS+//DKGDx+OyZMn4+GHH8by5ctbfc+cOXNQX1/vWY4dOxbqZvoRRdFnnhGGESIiolAKqCAiJSUFKpUKVVVVfturqqqQkZHR4nsyMzOh0WigUqk82wYMGIDKykrYbDZotdqz3qPT6aDT6QJpWlA12pxwCiIA3rWXiIgo1ALqGdFqtRg+fDhKSko82wRBQElJCYqKilp8z6WXXoqDBw9CEATPtv379yMzM7PFIHIhcBevqpUKGDSq8+xNREREHRHwMM2sWbPwyiuv4PXXX8eePXtw9913w2w2e66uueWWWzBnzhzP/nfffTdOnz6Ne++9F/v378eaNWvw1FNPYcaMGcH7FkHmLl6N1auhUChkbg0REVHXFvAYxOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAqvRknNzcXX3zxBe6//37k5+cjOzsb9957Lx566KHgfYsgY/EqERFR+ChEURTlbsT5GI1GxMfHo76+HnFxcSH/vK/3VuG2177H4Ox4/Pue0SH/PCIioq6oredv3pumBZ6p4Fm8SkREFHIMIy3ghGdEREThwzDSAk4FT0REFD4MIy3wFLCyZ4SIiCjkGEZawDv2EhERhQ/DSAs8BawcpiEiIgo5hpEWsGeEiIgofBhGWsCb5BEREYUPw0gLTE3e6eCJiIgotBhGWsBhGiIiovBhGGlGFEWfGVgZRoiIiEKNYaQZq0OAzSkA4NU0RERE4cAw0ox7wjOlAojWMowQERGFGsNIM0bPVPAaKJUKmVtDRETU9TGMNOMuXuWVNEREROHBMNIM70tDREQUXgwjzXgmPDOwZ4SIiCgcGEaaYc8IERFReDGMNGOycI4RIiKicGIYaYYFrEREROHFMNIMh2mIiIjCi2GkGSOHaYiIiMKKYaQZb88Ih2mIiIjCgWGkGRPv2EtERBRWDCPNeIZpWDNCREQUFgwjzbiHaXg1DRERUXgwjDTjvrQ3nsM0REREYcEw4sPqcMJiFwBwmIaIiChcGEZ8uGdfBYAYDtMQERGFBcOID3cYidWpoVIqZG4NERFRZGAY8cHiVSIiovBjGPFh5BwjREREYccw4sPYxDlGiIiIwo1hxIe3Z4TDNEREROHCMOLDMxU8e0aIiIjChmHEh2eYhjUjREREYcMw4sM9TMOraYiIiMKHYcSH+9JeDtMQERGFD8OID88de1nASkREFDYMIz7YM0JERBR+DCM+TBYWsBIREYUbw4gPIy/tJSIiCjuGER+8Nw0REVH4MYy4OJwCzDYnAA7TEBERhRPDiIu7XgRgzwgREVE4MYy4uMNIlFYFjYqHhYiIKFx41nVh8SoREZE8GEZcWLxKREQkD4YRF0/PCItXiYiIwophxMVzx172jBAREYUVw4gLe0aIiIjkwTDi4rlJHgtYiYiIwophxMVzkzzesZeIiCisGEZc3MM0sewZISIiCiuGERdvASvDCBERUTgxjLh4C1g5TENERBRODCMuJhawEhERyYJhxMVbwMowQkREFE4MIy7eAlYO0xAREYUTwwgAQRDRYOUwDRERkRwYRgCYrA6IorTOnhEiIqLwYhgBYHIN0ejUSug1KplbQ0REFFkYRuAzxwiLV4mIiMKOYQQ+c4xwiIaIiCjsGEbgvayXU8ETERGFX7vCyLJly5CXlwe9Xo/CwkJs3bq11X1fe+01KBQKv0Wv17e7waHguWMvh2mIiIjCLuAwsnr1asyaNQsLFizA9u3bUVBQgPHjx6O6urrV98TFxaGiosKz/Pzzzx1qdLB5JjzjMA0REVHYBXz2Xbx4Me644w5Mnz4dALB8+XKsWbMGK1euxOzZs1t8j0KhQEZGRsdaGkIm9owQEZ3F6XTCbrfL3Qy6gGk0GqhUHb8KNaAwYrPZUFpaijlz5ni2KZVKFBcXY9OmTa2+r6GhAd27d4cgCBg2bBieeuopXHTRRa3ub7VaYbVaPc+NRmMgzQyYt4CVYYSISBRFVFZWoq6uTu6mUCeQkJCAjIwMKBSKdv+MgMJIbW0tnE4n0tPT/banp6dj7969Lb6nX79+WLlyJfLz81FfX4+//e1vuOSSS/DTTz8hJyenxfcsXLgQjz76aCBN6xDvfWk4TENE5A4iaWlpiIqK6tBJhrouURTR2NjoKdPIzMxs988K+dm3qKgIRUVFnueXXHIJBgwYgJdeegmPP/54i++ZM2cOZs2a5XluNBqRm5sbsjZ670vDnhEiimxOp9MTRJKTk+VuDl3gDAYDAKC6uhppaWntHrIJKIykpKRApVKhqqrKb3tVVVWba0I0Gg2GDh2KgwcPtrqPTqeDTqcLpGkd4pn0jAWsRBTh3DUiUVFRMreEOgv374rdbm93GAnoahqtVovhw4ejpKTEs00QBJSUlPj1fpyL0+nEzp07O9SdE2wmq3uYhj0jREQAODRDbRaM35WAuwJmzZqFadOmYcSIERg1ahSWLFkCs9nsubrmlltuQXZ2NhYuXAgAeOyxx3DxxRejd+/eqKurw7PPPouff/4Zt99+e4cbHyzenhGGESIionALOIxMnjwZNTU1mD9/PiorKzFkyBCsXbvWU9RaXl4OpdLb4XLmzBnccccdqKysRGJiIoYPH47vvvsOAwcODN636CB3zUg8C1iJiIjCTiGKoih3I87HaDQiPj4e9fX1iIuLC+rPFkURvf76OQQR2PLXcUiPu7BmhyUiCieLxYIjR46gR48eF9xs2XRhOtfvTFvP3xF/bxqzzQnBFcc4TENERMHCCePaLuLDiHuOEY1KAb0m4g8HEVGntXbtWowePRoJCQlITk7G1VdfjUOHDnleP378OKZMmYKkpCRER0djxIgR2LJli+f1f//73xg5ciT0ej1SUlIwadIkz2sKhQKffPKJ3+clJCTgtddeAwAcPXoUCoUCq1evxpgxY6DX6/H222/j1KlTmDJlCrKzsxEVFYXBgwdj1apVfj9HEAQ888wz6N27N3Q6Hbp164Ynn3wSADB27FjMnDnTb/+amhpotVq/i0k6u4gvkvBMBa/XsHqciKgFoiiiye4M++caNKqA/l02m82YNWsW8vPz0dDQgPnz52PSpEkoKytDY2MjxowZg+zsbHz22WfIyMjA9u3bIQgCAGDNmjWYNGkSHn74Ybzxxhuw2Wz4/PPPA27z7Nmz8dxzz2Ho0KHQ6/WwWCwYPnw4HnroIcTFxWHNmjW4+eab0atXL4waNQqANLfWK6+8gr///e8YPXo0KioqPBOJ3n777Zg5cyaee+45z5QXb731FrKzszF27NiA23ehivgw4pkKnpf1EhG1qMnuxMD5X4T9c3c/Nh5R2rafpq6//nq/5ytXrkRqaip2796N7777DjU1Ndi2bRuSkpIAAL179/bs++STT+KGG27wm/27oKAg4Dbfd999uO666/y2PfDAA571e+65B1988QXee+89jBo1CiaTCUuXLsWLL76IadOmAQB69eqF0aNHAwCuu+46zJw5E59++il+97vfAQBee+013HrrrV3qD+iIH5fgHXuJiLqGAwcOYMqUKejZsyfi4uKQl5cHQLrKs6ysDEOHDvUEkebKysowbty4DrdhxIgRfs+dTicef/xxDB48GElJSYiJicEXX3yB8vJyAMCePXtgtVpb/Wy9Xo+bb74ZK1euBABs374du3btwq233trhtl5IIv4MzKngiYjOzaBRYfdj42X53EBMnDgR3bt3xyuvvIKsrCwIgoBBgwbBZrN5pi1v9bPO87pCoUDzi09bKlCNjo72e/7ss89i6dKlWLJkCQYPHozo6Gjcd999sNlsbfpcQBqqGTJkCI4fP45XX30VY8eORffu3c/7vs6EPSPuCc84xwgRUYsUCgWitOqwL4EMQ5w6dQr79u3D3LlzMW7cOAwYMABnzpzxvJ6fn4+ysjKcPn26xffn5+efsyA0NTUVFRUVnucHDhxAY2Pjedu1ceNGXHPNNbjppptQUFCAnj17Yv/+/Z7X+/TpA4PBcM7PHjx4MEaMGIFXXnkF77zzDm677bbzfm5nE/FhxOSuGWHPCBFRp5WYmIjk5GS8/PLLOHjwIL7++mu/G65OmTIFGRkZuPbaa7Fx40YcPnwYH374ITZt2gQAWLBgAVatWoUFCxZgz5492LlzJ55++mnP+8eOHYsXX3wRO3bswPfff4+77roLGs35zxt9+vTBunXr8N1332HPnj248847/e7vptfr8dBDD+HBBx/EG2+8gUOHDmHz5s1YsWKF38+5/fbbsWjRIoii6HeVT1cR8WHE6L6ahgWsRESdllKpxLvvvovS0lIMGjQI999/P5599lnP61qtFl9++SXS0tIwYcIEDB48GIsWLfLc2O3yyy/H+++/j88++wxDhgzB2LFjsXXrVs/7n3vuOeTm5uKyyy7DjTfeiAceeKBNNxOcO3cuhg0bhvHjx+Pyyy/3BCJf8+bNw5///GfMnz8fAwYMwOTJk1FdXe23z5QpU6BWqzFlypQuORldxM/AOvvDH/HutmN44Iq+mDm2T1B/NhFRZ8MZWC9MR48eRa9evbBt2zYMGzZM7ub4CcYMrBFfKMFLe4mI6EJlt9tx6tQpzJ07FxdffPEFF0SChcM0rgLWWF7aS0REF5iNGzciMzMT27Ztw/Lly+VuTshE/BmYBaxERHShuvzyy8+6pLgrYs8IC1iJiIhkxTDSxJ4RIiIiOUV0GBFF0aeANeJHrIiIiGQR0WHEYhdgd0pjcZwOnoiISB4RHUbcvSJKBRCtDeweCERERBQcER1GTD5zjHSlWzETERF1JhEdRurdN8njEA0RUcTLy8vDkiVL5G5GRIroMMLiVSIiIvlFdhjhZb1ERNQFOJ1OCIIgdzPaLbLDiIVTwRMRdQUvv/wysrKyzjohX3PNNbjttttw6NAhXHPNNUhPT0dMTAxGjhyJr776qt2ft3jxYgwePBjR0dHIzc3FH//4RzQ0NPjts3HjRlx++eWIiopCYmIixo8fjzNnzgAABEHAM888g969e0On06Fbt2548sknAQDffvstFAoF6urqPD+rrKwMCoUCR48eBQC89tprSEhIwGeffYaBAwdCp9OhvLwc27Ztw69+9SukpKQgPj4eY8aMwfbt2/3aVVdXhzvvvBPp6enQ6/UYNGgQ/vOf/8BsNiMuLg4ffPCB3/6ffPIJoqOjYTKZ2n28zieiwwingiciagNRBGzm8C8BTIP+29/+FqdOncI333zj2Xb69GmsXbsWU6dORUNDAyZMmICSkhLs2LEDv/71rzFx4kSUl5e365AolUo8//zz+Omnn/D666/j66+/xoMPPuh5vaysDOPGjcPAgQOxadMmbNiwARMnToTT6QQAzJkzB4sWLcK8efOwe/duvPPOO0hPTw+oDY2NjXj66afxr3/9Cz/99BPS0tJgMpkwbdo0bNiwAZs3b0afPn0wYcIET5AQBAFXXnklNm7ciLfeegu7d+/GokWLoFKpEB0djRtuuAGvvvqq3+e8+uqr+M1vfoPY2Nh2Hau2iOguAfdN8jgVPBHROdgbgaeywv+5fz0JaKPbtGtiYiKuvPJKvPPOOxg3bhwA4IMPPkBKSgp++ctfQqlUoqCgwLP/448/jo8//hifffYZZs6cGXDT7rvvPs96Xl4ennjiCdx11134xz/+AQB45plnMGLECM9zALjooosAACaTCUuXLsWLL76IadOmAQB69eqF0aNHB9QGu92Of/zjH37fa+zYsX77vPzyy0hISMD69etx9dVX46uvvsLWrVuxZ88e9O3bFwDQs2dPz/633347LrnkElRUVCAzMxPV1dX4/PPPO9SL1BYR3TNiZM8IEVGXMXXqVHz44YewWq0AgLfffhs33HADlEolGhoa8MADD2DAgAFISEhATEwM9uzZ0+6eka+++grjxo1DdnY2YmNjcfPNN+PUqVNobGwE4O0ZacmePXtgtVpbfb2ttFot8vPz/bZVVVXhjjvuQJ8+fRAfH4+4uDg0NDR4vmdZWRlycnI8QaS5UaNG4aKLLsLrr78OAHjrrbfQvXt3/OIXv+hQW88nwntGeDUNEdF5aaKkXgo5PjcAEydOhCiKWLNmDUaOHIn/+7//w9///ncAwAMPPIB169bhb3/7G3r37g2DwYDf/OY3sNlsATfr6NGjuPrqq3H33XfjySefRFJSEjZs2IDf//73sNlsiIqKgsFgaPX953oNkIaAAPjdrddut7f4c5rPkTVt2jScOnUKS5cuRffu3aHT6VBUVOT5nuf7bEDqHVm2bBlmz56NV199FdOnTw/5XFwR3jPiLmBlzwgRUasUCmm4JNxLgCdAvV6P6667Dm+//TZWrVqFfv36YdiwYQCkYtJbb70VkyZNwuDBg5GRkeEpBg1UaWkpBEHAc889h4svvhh9+/bFyZP+YS0/Px8lJSUtvr9Pnz4wGAytvp6amgoAqKio8GwrKytrU9s2btyIP/3pT5gwYQIuuugi6HQ61NbW+rXr+PHj2L9/f6s/46abbsLPP/+M559/Hrt37/YMJYVSZIcRz6W97BkhIuoKpk6dijVr1mDlypWYOnWqZ3ufPn3w0UcfoaysDD/88ANuvPHGdl8K27t3b9jtdrzwwgs4fPgw3nzzTSxfvtxvnzlz5mDbtm344x//iB9//BF79+7FP//5T9TW1kKv1+Ohhx7Cgw8+iDfeeAOHDh3C5s2bsWLFCs/Pz83NxSOPPIIDBw5gzZo1eO6559rUtj59+uDNN9/Enj17sGXLFkydOtWvN2TMmDH4xS9+geuvvx7r1q3DkSNH8N///hdr16717JOYmIjrrrsOf/nLX3DFFVcgJyenXccpEBEdRiaPzMWdY3qiV1qM3E0hIqIgGDt2LJKSkrBv3z7ceOONnu2LFy9GYmIiLrnkEkycOBHjx4/39JoEqqCgAIsXL8bTTz+NQYMG4e2338bChQv99unbty++/PJL/PDDDxg1ahSKiorw6aefQq2W/vidN28e/vznP2P+/PkYMGAAJk+ejOrqagCARqPBqlWrsHfvXuTn5+Ppp5/GE0880aa2rVixAmfOnMGwYcNw8803409/+hPS0tL89vnwww8xcuRITJkyBQMHDsSDDz7oucrHzT3kdNttt7XrGAVKIYoBXDslE6PRiPj4eNTX1yMuLk7u5hARdVkWiwVHjhxBjx49oNfr5W4OyeTNN9/E/fffj5MnT0Kr1Z5z33P9zrT1/M3xCSIiIgIgzV1SUVGBRYsW4c477zxvEAmWiB6mISIiau7tt99GTExMi4t7rpCu6plnnkH//v2RkZGBOXPmhO1zOUxDREQeHKaRJiWrqqpq8TWNRoPu3buHuUUXNg7TEBERBVlsbGxIpz6ns3GYhoiIiGTFMEJERGfpzLejp/AKxu8Kh2mIiMhDq9VCqVTi5MmTSE1NhVarDflU4NQ5iaIIm82GmpoaKJXKDl15wzBCREQeSqUSPXr0QEVFxVlTnBO1JCoqCt26dfPcU6c9GEaIiMiPVqtFt27d4HA4zpqZk8iXSqWCWq3ucO8ZwwgREZ1FoVBAo9FAo+GNRCn0WMBKREREsmIYISIiIlkxjBAREZGsOkXNiHvGeqPRKHNLiIiIqK3c5+3z3XmmU4QRk8kEAMjNzZW5JURERBQok8mE+Pj4Vl/vFDfKEwQBJ0+eRGxsbFAn3zEajcjNzcWxY8d4A74w4PEOLx7v8OLxDi8e7/Bq7/EWRREmkwlZWVnnnIekU/SMKJVK5OTkhOznx8XF8Zc5jHi8w4vHO7x4vMOLxzu82nO8z9Uj4sYCViIiIpIVwwgRERHJKqLDiE6nw4IFC6DT6eRuSkTg8Q4vHu/w4vEOLx7v8Ar18e4UBaxERETUdUV0zwgRERHJj2GEiIiIZMUwQkRERLJiGCEiIiJZRXQYWbZsGfLy8qDX61FYWIitW7fK3aQu4X//+x8mTpyIrKwsKBQKfPLJJ36vi6KI+fPnIzMzEwaDAcXFxThw4IA8je0CFi5ciJEjRyI2NhZpaWm49tprsW/fPr99LBYLZsyYgeTkZMTExOD6669HVVWVTC3u3P75z38iPz/fM/lTUVER/vvf/3pe57EOnUWLFkGhUOC+++7zbOPxDq5HHnkECoXCb+nfv7/n9VAd74gNI6tXr8asWbOwYMECbN++HQUFBRg/fjyqq6vlblqnZzabUVBQgGXLlrX4+jPPPIPnn38ey5cvx5YtWxAdHY3x48fDYrGEuaVdw/r16zFjxgxs3rwZ69atg91uxxVXXAGz2ezZ5/7778e///1vvP/++1i/fj1OnjyJ6667TsZWd145OTlYtGgRSktL8f3332Ps2LG45ppr8NNPPwHgsQ6Vbdu24aWXXkJ+fr7fdh7v4LvoootQUVHhWTZs2OB5LWTHW4xQo0aNEmfMmOF57nQ6xaysLHHhwoUytqrrASB+/PHHnueCIIgZGRnis88+69lWV1cn6nQ6cdWqVTK0sOuprq4WAYjr168XRVE6vhqNRnz//fc9++zZs0cEIG7atEmuZnYpiYmJ4r/+9S8e6xAxmUxinz59xHXr1oljxowR7733XlEU+bsdCgsWLBALCgpafC2Uxzsie0ZsNhtKS0tRXFzs2aZUKlFcXIxNmzbJ2LKu78iRI6isrPQ79vHx8SgsLOSxD5L6+noAQFJSEgCgtLQUdrvd75j3798f3bp14zHvIKfTiXfffRdmsxlFRUU81iEyY8YMXHXVVX7HFeDvdqgcOHAAWVlZ6NmzJ6ZOnYry8nIAoT3eneJGecFWW1sLp9OJ9PR0v+3p6enYu3evTK2KDJWVlQDQ4rF3v0btJwgC7rvvPlx66aUYNGgQAOmYa7VaJCQk+O3LY95+O3fuRFFRESwWC2JiYvDxxx9j4MCBKCsr47EOsnfffRfbt2/Htm3bznqNv9vBV1hYiNdeew39+vVDRUUFHn30UVx22WXYtWtXSI93RIYRoq5qxowZ2LVrl98YLwVfv379UFZWhvr6enzwwQeYNm0a1q9fL3ezupxjx47h3nvvxbp166DX6+VuTkS48sorPev5+fkoLCxE9+7d8d5778FgMITscyNymCYlJQUqleqsCuCqqipkZGTI1KrI4D6+PPbBN3PmTPznP//BN998g5ycHM/2jIwM2Gw21NXV+e3PY95+Wq0WvXv3xvDhw7Fw4UIUFBRg6dKlPNZBVlpaiurqagwbNgxqtRpqtRrr16/H888/D7VajfT0dB7vEEtISEDfvn1x8ODBkP5+R2QY0Wq1GD58OEpKSjzbBEFASUkJioqKZGxZ19ejRw9kZGT4HXuj0YgtW7bw2LeTKIqYOXMmPv74Y3z99dfo0aOH3+vDhw+HRqPxO+b79u1DeXk5j3mQCIIAq9XKYx1k48aNw86dO1FWVuZZRowYgalTp3rWebxDq6GhAYcOHUJmZmZof787VP7aib377ruiTqcTX3vtNXH37t3iH/7wBzEhIUGsrKyUu2mdnslkEnfs2CHu2LFDBCAuXrxY3LFjh/jzzz+LoiiKixYtEhMSEsRPP/1U/PHHH8VrrrlG7NGjh9jU1CRzyzunu+++W4yPjxe//fZbsaKiwrM0NjZ69rnrrrvEbt26iV9//bX4/fffi0VFRWJRUZGMre68Zs+eLa5fv148cuSI+OOPP4qzZ88WFQqF+OWXX4qiyGMdar5X04gij3ew/fnPfxa//fZb8ciRI+LGjRvF4uJiMSUlRayurhZFMXTHO2LDiCiK4gsvvCB269ZN1Gq14qhRo8TNmzfL3aQu4ZtvvhEBnLVMmzZNFEXp8t558+aJ6enpok6nE8eNGyfu27dP3kZ3Yi0dawDiq6++6tmnqalJ/OMf/ygmJiaKUVFR4qRJk8SKigr5Gt2J3XbbbWL37t1FrVYrpqamiuPGjfMEEVHksQ615mGExzu4Jk+eLGZmZoparVbMzs4WJ0+eLB48eNDzeqiOt0IURbFjfStERERE7ReRNSNERER04WAYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrBhGiIiISFb/HzA/XZhSOg8yAAAAAElFTkSuQmCC"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "history = swivel_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Swivel trains faster but achieves a lower validation accuracy, and requires more epochs to train on."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Deploying the model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The first step is to serialize one of our trained Keras model as a SavedModel:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-07-31 13:36:40.513145: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n",
-      "WARNING:absl:Found untraced functions such as _destroy_resource while saving (showing 1 of 1). These functions will not be directly callable after loading.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: ./savedmodels/swivel/assets\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: ./savedmodels/swivel/assets\n"
-     ]
-    }
    ],
-   "source": [
-    "OUTPUT_DIR = \"./savedmodels\"\n",
-    "shutil.rmtree(OUTPUT_DIR, ignore_errors=True)\n",
-    "\n",
-    "EXPORT_PATH = os.path.join(OUTPUT_DIR, 'swivel')\n",
-    "os.environ['EXPORT_PATH'] = EXPORT_PATH\n",
-    "\n",
-    "shutil.rmtree(EXPORT_PATH, ignore_errors=True)\n",
-    "\n",
-    "tf.saved_model.save(swivel_model, EXPORT_PATH)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then we can deploy the model using the gcloud CLI as before:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Lab Task 3a: Complete the following script to deploy the swivel model "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating title_model\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n",
-      "Created ai platform model [projects/qwiklabs-gcp-04-af059b23c3fc/models/title_model].\n",
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating title_model:swivel\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n",
-      "Creating version (this might take a few minutes)......\n",
-      "...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................done.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "# TODO 5\n",
-    "\n",
-    "MODEL_NAME=title_model\n",
-    "VERSION_NAME=swivel\n",
-    "\n",
-    "if [[ $(gcloud ai-platform models list --format='value(name)' | grep ^$MODEL_NAME$) ]]; then\n",
-    "    echo \"$MODEL_NAME already exists\"\n",
-    "else\n",
-    "    echo \"Creating $MODEL_NAME\"\n",
-    "    gcloud ai-platform models create --region=$REGION $MODEL_NAME\n",
-    "fi\n",
-    "\n",
-    "if [[ $(gcloud ai-platform versions list --model $MODEL_NAME --format='value(name)' | grep ^$VERSION_NAME$) ]]; then\n",
-    "    echo \"Deleting already existing $MODEL_NAME:$VERSION_NAME ... \"\n",
-    "    echo yes | gcloud ai-platform versions delete --model=$MODEL_NAME $VERSION_NAME\n",
-    "    echo \"Please run this cell again if you don't see a Creating message ... \"\n",
-    "    sleep 2\n",
-    "fi\n",
-    "\n",
-    "echo \"Creating $MODEL_NAME:$VERSION_NAME\"\n",
-    "gcloud ai-platform versions create \\\n",
-    "  --model=$MODEL_NAME \\\n",
-    "  --framework=# TODO \\\n",
-    "  --python-version=# TODO \\\n",
-    "  --runtime-version=2.1 \\\n",
-    "  --origin=# TODO \\\n",
-    "  --staging-bucket=# TODO \\\n",
-    "  --machine-type n1-standard-4 \\\n",
-    "  --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Before we try our deployed model, let's inspect its signature to know what to send to the deployed API:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The given SavedModel SignatureDef contains the following input(s):\n",
-      "  inputs['keras_layer_1_input'] tensor_info:\n",
-      "      dtype: DT_STRING\n",
-      "      shape: (-1)\n",
-      "      name: serving_default_keras_layer_1_input:0\n",
-      "The given SavedModel SignatureDef contains the following output(s):\n",
-      "  outputs['dense_3'] tensor_info:\n",
-      "      dtype: DT_FLOAT\n",
-      "      shape: (-1, 3)\n",
-      "      name: StatefulPartitionedCall_2:0\n",
-      "Method name is: tensorflow/serving/predict\n",
-      "./savedmodels/swivel\n",
-      "./savedmodels/swivel/assets\n",
-      "./savedmodels/swivel/assets/tokens.txt\n",
-      "./savedmodels/swivel/variables\n",
-      "./savedmodels/swivel/variables/variables.index\n",
-      "./savedmodels/swivel/variables/variables.data-00000-of-00001\n",
-      "./savedmodels/swivel/saved_model.pb\n"
-     ]
-    }
-   ],
-   "source": [
-    "!saved_model_cli show \\\n",
-    " --tag_set serve \\\n",
-    " --signature_def serving_default \\\n",
-    " --dir {EXPORT_PATH}\n",
-    "!find {EXPORT_PATH}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's go ahead and hit our model:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Lab Task 3b: Create the JSON object to send a title to the API  you just deployed\n",
-    "(**Hint:** Look at the 'saved_model_cli show' command output above.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Writing input.json\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%writefile input.json\n",
-    "{# TODO}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n",
-      "[[0.885626853, 0.0408654884, 0.0735076517]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "!gcloud ai-platform predict \\\n",
-    "  --model title_model \\\n",
-    "  --json-instances input.json \\\n",
-    "  --version swivel \\\n",
-    "  --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Bonus"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Try to beat the best model by modifying the model architecture, changing the TF-Hub embedding, and tweaking the training parameters."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Copyright 2023 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/courses/machine_learning/deepdive2/text_classification/solutions/reusable_embeddings.ipynb
+++ b/courses/machine_learning/deepdive2/text_classification/solutions/reusable_embeddings.ipynb
@@ -2,16 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "# Reusable Embeddings\n",
     "\n",
     "**Learning Objectives**\n",
     "1. Learn how to use a pre-trained TF Hub text modules to generate sentence vectors.\n",
     "1. Learn how to incorporate a pre-trained TF-Hub module into a Keras model.\n",
-    "1. Learn how to deploy and use a text model on CAIP.\n",
-    "\n",
-    "\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -21,50 +17,49 @@
     "First, we will load and pre-process the texts and labels so that they are suitable to be fed to sequential Keras models with first layer being TF-hub pre-trained modules. Thanks to this first layer, we won't need to tokenize and integerize the text before passing it to our models. The pre-trained layer will take care of that for us, and consume directly raw text. However, we will still have to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
     "\n",
     "Then we will build, train and compare simple DNN models starting with different pre-trained TF-Hub layers."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "import os\n",
     "\n",
     "from google.cloud import bigquery\n",
     "import pandas as pd"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "source": [
+    "%load_ext google.cloud.bigquery"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "The google.cloud.bigquery extension is already loaded. To reload it, use:\n",
       "  %reload_ext google.cloud.bigquery\n"
      ]
     }
    ],
-   "source": [
-    "%load_ext google.cloud.bigquery"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Replace the variable values in the cell below:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "PROJECT = \"qwiklabs-gcp-04-af059b23c3fc\"  # Replace with your PROJECT\n",
     "BUCKET = PROJECT \n",
@@ -73,54 +68,94 @@
     "os.environ['PROJECT'] = PROJECT\n",
     "os.environ['BUCKET'] = BUCKET\n",
     "os.environ['REGION'] = REGION"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Create a Dataset from BigQuery \n",
     "\n",
     "Hacker news headlines are available as a BigQuery public dataset. The [dataset](https://bigquery.cloud.google.com/table/bigquery-public-data:hacker_news.stories?tab=details) contains all headlines from the sites inception in October 2006 until October 2015. \n",
     "\n",
     "Here is a sample of the dataset:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "source": [
+    "%%bigquery --project $PROJECT\n",
+    "\n",
+    "SELECT\n",
+    "    url, title, score\n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.full`\n",
+    "WHERE\n",
+    "    LENGTH(title) > 10\n",
+    "    AND score > 10\n",
+    "    AND LENGTH(url) > 0\n",
+    "LIMIT 10"
+   ],
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Query is running:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "3bcdab5bc931436e8e1a828e24183747",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Downloading:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "03eb58f0245b473280e245f29141ae44",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                                 url  \\\n",
+       "0  http://www.businessweek.com/technology/how-sof...   \n",
+       "1  http://www.businessinsider.com/henry-blodget-a...   \n",
+       "2                          https://www.babeloop.com/   \n",
+       "3                https://github.com/pksunkara/alpaca   \n",
+       "4  http://www.zetalab.de/blog/developing-an-app-f...   \n",
+       "5  http://www.uxpx.net/2011/02/16/why-you-choose-...   \n",
+       "6  https://www.reddit.com/r/technology/comments/3...   \n",
+       "7                             http://meettheboss.tv/   \n",
+       "8  http://digg.com/story/r/how_google_can_still_b...   \n",
+       "9  http://www.youtube.com/watch?v=_3XjMjG6pEo&fea...   \n",
+       "\n",
+       "                                               title  score  \n",
+       "0       How Software is Harming Science, Engineering     11  \n",
+       "1         Andreessen: Watching Netscape Disintegrate     11  \n",
+       "2  Show HN: Babeloop, a new music sight-reading w...     12  \n",
+       "3  Show HN: Given an API, Generate client librari...    268  \n",
+       "4  Developing an App for iOS, Android and Windows...     13  \n",
+       "5                        Why you choose turbotax.com     13  \n",
+       "6         Anti TPP Site Blocked by Google & Facebook     13  \n",
+       "7             Ask HN: Review our Business TV Startup     13  \n",
+       "8  How Google can still become the greatest compa...     13  \n",
+       "9  Hacking a crowd of 430 hackers with 1720 balloons     14  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -209,94 +244,88 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                                 url  \\\n",
-       "0  http://www.businessweek.com/technology/how-sof...   \n",
-       "1  http://www.businessinsider.com/henry-blodget-a...   \n",
-       "2                          https://www.babeloop.com/   \n",
-       "3                https://github.com/pksunkara/alpaca   \n",
-       "4  http://www.zetalab.de/blog/developing-an-app-f...   \n",
-       "5  http://www.uxpx.net/2011/02/16/why-you-choose-...   \n",
-       "6  https://www.reddit.com/r/technology/comments/3...   \n",
-       "7                             http://meettheboss.tv/   \n",
-       "8  http://digg.com/story/r/how_google_can_still_b...   \n",
-       "9  http://www.youtube.com/watch?v=_3XjMjG6pEo&fea...   \n",
-       "\n",
-       "                                               title  score  \n",
-       "0       How Software is Harming Science, Engineering     11  \n",
-       "1         Andreessen: Watching Netscape Disintegrate     11  \n",
-       "2  Show HN: Babeloop, a new music sight-reading w...     12  \n",
-       "3  Show HN: Given an API, Generate client librari...    268  \n",
-       "4  Developing an App for iOS, Android and Windows...     13  \n",
-       "5                        Why you choose turbotax.com     13  \n",
-       "6         Anti TPP Site Blocked by Google & Facebook     13  \n",
-       "7             Ask HN: Review our Business TV Startup     13  \n",
-       "8  How Google can still become the greatest compa...     13  \n",
-       "9  Hacking a crowd of 430 hackers with 1720 balloons     14  "
       ]
      },
-     "execution_count": 4,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 4
     }
    ],
-   "source": [
-    "%%bigquery --project $PROJECT\n",
-    "\n",
-    "SELECT\n",
-    "    url, title, score\n",
-    "FROM\n",
-    "    `bigquery-public-data.hacker_news.full`\n",
-    "WHERE\n",
-    "    LENGTH(title) > 10\n",
-    "    AND score > 10\n",
-    "    AND LENGTH(url) > 0\n",
-    "LIMIT 10"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's do some regular expression parsing in BigQuery to get the source of the newspaper article from the URL. For example, if the url is http://mobile.nytimes.com/...., I want to be left with <i>nytimes</i>"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "source": [
+    "%%bigquery --project $PROJECT\n",
+    "\n",
+    "SELECT\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source,\n",
+    "    COUNT(title) AS num_articles\n",
+    "FROM\n",
+    "    `bigquery-public-data.hacker_news.full`\n",
+    "WHERE\n",
+    "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
+    "    AND LENGTH(title) > 10\n",
+    "GROUP BY\n",
+    "    source\n",
+    "ORDER BY num_articles DESC\n",
+    "  LIMIT 100"
+   ],
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Query is running:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "aed7cb8b7d11416b98f5863207853a4a",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
+      "text/plain": [
+       "Downloading:   0%|          |"
+      ],
       "application/vnd.jupyter.widget-view+json": {
        "model_id": "93ff6b4a40634ec5a059dde32093d99b",
        "version_major": 2,
        "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
+      }
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "          source  num_articles\n",
+       "0         github        139395\n",
+       "1         medium        125985\n",
+       "2        youtube        101025\n",
+       "3        nytimes         73114\n",
+       "4       blogspot         59863\n",
+       "..           ...           ...\n",
+       "95  nextplatform          2647\n",
+       "96     anandtech          2629\n",
+       "97   extremetech          2598\n",
+       "98      politico          2594\n",
+       "99       9to5mac          2590\n",
+       "\n",
+       "[100 rows x 2 columns]"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -380,83 +409,24 @@
        "</table>\n",
        "<p>100 rows × 2 columns</p>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "          source  num_articles\n",
-       "0         github        139395\n",
-       "1         medium        125985\n",
-       "2        youtube        101025\n",
-       "3        nytimes         73114\n",
-       "4       blogspot         59863\n",
-       "..           ...           ...\n",
-       "95  nextplatform          2647\n",
-       "96     anandtech          2629\n",
-       "97   extremetech          2598\n",
-       "98      politico          2594\n",
-       "99       9to5mac          2590\n",
-       "\n",
-       "[100 rows x 2 columns]"
       ]
      },
-     "execution_count": 5,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 5
     }
    ],
-   "source": [
-    "%%bigquery --project $PROJECT\n",
-    "\n",
-    "SELECT\n",
-    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source,\n",
-    "    COUNT(title) AS num_articles\n",
-    "FROM\n",
-    "    `bigquery-public-data.hacker_news.full`\n",
-    "WHERE\n",
-    "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
-    "    AND LENGTH(title) > 10\n",
-    "GROUP BY\n",
-    "    source\n",
-    "ORDER BY num_articles DESC\n",
-    "  LIMIT 100"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now that we have good parsing of the URL to get the source, let's put together a dataset of source and titles. This will be our labeled dataset for machine learning."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "SELECT \n",
-      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
-      "    source\n",
-      "FROM\n",
-      "  (\n",
-      "SELECT\n",
-      "    title,\n",
-      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source\n",
-      "    \n",
-      "FROM\n",
-      "    `bigquery-public-data.hacker_news.full`\n",
-      "WHERE\n",
-      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
-      "    AND LENGTH(title) > 10\n",
-      ")\n",
-      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
-      "\n"
-     ]
-    }
-   ],
    "source": [
     "regex = '.*://(.[^/]+)/'\n",
     "\n",
@@ -484,23 +454,63 @@
     "\"\"\".format(sub_query=sub_query)\n",
     "\n",
     "print(query)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\n",
+      "SELECT \n",
+      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
+      "    source\n",
+      "FROM\n",
+      "  (\n",
+      "SELECT\n",
+      "    title,\n",
+      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source\n",
+      "    \n",
+      "FROM\n",
+      "    `bigquery-public-data.hacker_news.full`\n",
+      "WHERE\n",
+      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
+      "    AND LENGTH(title) > 10\n",
+      ")\n",
+      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
+      "\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset). AutoML however figures out on its own how to create these splits, so we won't need to do that here. \n",
     "\n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "source": [
+    "bq = bigquery.Client(project=PROJECT)\n",
+    "title_dataset = bq.query(query).to_dataframe()\n",
+    "title_dataset.head()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                               title  source\n",
+       "0                              php bdd is now  nice   github\n",
+       "1                                     skinny vagrant  github\n",
+       "2  want to control an angularjs app using your we...  github\n",
+       "3  show hn  authority  orm-neutral  oo rails auth...  github\n",
+       "4                      just ported mongobox to redis  github"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -553,30 +563,16 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                               title  source\n",
-       "0                              php bdd is now  nice   github\n",
-       "1                                     skinny vagrant  github\n",
-       "2  want to control an angularjs app using your we...  github\n",
-       "3  show hn  authority  orm-neutral  oo rails auth...  github\n",
-       "4                      just ported mongobox to redis  github"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 7
     }
    ],
-   "source": [
-    "bq = bigquery.Client(project=PROJECT)\n",
-    "title_dataset = bq.query(query).to_dataframe()\n",
-    "title_dataset.head()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "AutoML for text classification requires that\n",
     "* the dataset be in csv form with \n",
@@ -584,38 +580,42 @@
     "* the last colum to be the text labels\n",
     "\n",
     "The dataset we pulled from BiqQuery satisfies these requirements."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "source": [
+    "print(\"The full dataset contains {n} titles\".format(n=len(title_dataset)))"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "The full dataset contains 266442 titles\n"
      ]
     }
    ],
-   "source": [
-    "print(\"The full dataset contains {n} titles\".format(n=len(title_dataset)))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's make sure we have roughly the same number of labels for each of our three labels:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "source": [
+    "title_dataset.source.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        139395\n",
@@ -624,43 +624,38 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 9,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 9
     }
    ],
-   "source": [
-    "title_dataset.source.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Finally we will save our data, which is currently in-memory, to disk.\n",
     "\n",
     "We will create a csv file containing the full dataset and another containing only 1000 articles for development.\n",
     "\n",
     "**Note:** It may take a long time to train AutoML on the full dataset, so we recommend to use the sample dataset for the purpose of learning the tool. \n"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "DATADIR = './data/'\n",
     "\n",
     "if not os.path.exists(DATADIR):\n",
     "    os.makedirs(DATADIR)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "FULL_DATASET_NAME = 'titles_full.csv'\n",
     "FULL_DATASET_PATH = os.path.join(DATADIR, FULL_DATASET_NAME)\n",
@@ -670,21 +665,27 @@
     "\n",
     "title_dataset.to_csv(\n",
     "    FULL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now let's sample 1000 articles from the full dataset and make sure we have enough examples for each label in our sample dataset (see [here](https://cloud.google.com/natural-language/automl/docs/beginners-guide) for further details on how to prepare data for AutoML)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "source": [
+    "sample_title_dataset = title_dataset.sample(n=1000)\n",
+    "sample_title_dataset.source.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        528\n",
@@ -693,49 +694,35 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 12,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 12
     }
    ],
-   "source": [
-    "sample_title_dataset = title_dataset.sample(n=1000)\n",
-    "sample_title_dataset.source.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's write the sample datatset to disk."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "SAMPLE_DATASET_NAME = 'titles_sample.csv'\n",
     "SAMPLE_DATASET_PATH = os.path.join(DATADIR, SAMPLE_DATASET_NAME)\n",
     "\n",
     "sample_title_dataset.to_csv(\n",
     "    SAMPLE_DATASET_PATH, header=False, index=False, encoding='utf-8')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.6.5\n"
-     ]
-    }
-   ],
    "source": [
     "import datetime\n",
     "import os\n",
@@ -752,72 +739,98 @@
     "\n",
     "\n",
     "print(tf.__version__)"
-   ]
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "2.6.5\n"
+     ]
+    }
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "%matplotlib inline"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's start by specifying where the information about the trained models will be saved as well as where our dataset is located:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "MODEL_DIR = \"./text_models\"\n",
     "DATA_DIR = \"./data\""
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Loading the dataset"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "As in the previous labs, our dataset consists of titles of articles along with the label indicating from which source these articles have been taken from (GitHub, Tech-Crunch, or the New-York Times):"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "source": [
+    "ls ./data/"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "titles_full.csv  titles_sample.csv\n"
      ]
     }
    ],
-   "source": [
-    "ls ./data/"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {},
+   "source": [
+    "DATASET_NAME = \"titles_full.csv\"\n",
+    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
+    "COLUMNS = ['title', 'source']\n",
+    "\n",
+    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
+    "titles_df.head()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
+      "text/plain": [
+       "                                               title      source\n",
+       "0  a powerful  disturbing history of residential ...     nytimes\n",
+       "1  why are eggs sold by the dozen  why not by 10s...     nytimes\n",
+       "2  a curated list of awesome machine learning fra...      github\n",
+       "3  hn greasemonkey script  show user reputation k...      github\n",
+       "4  zurb launches foundation 3 to take on twitter ...  techcrunch"
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -870,43 +883,30 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                               title      source\n",
-       "0  a powerful  disturbing history of residential ...     nytimes\n",
-       "1  why are eggs sold by the dozen  why not by 10s...     nytimes\n",
-       "2  a curated list of awesome machine learning fra...      github\n",
-       "3  hn greasemonkey script  show user reputation k...      github\n",
-       "4  zurb launches foundation 3 to take on twitter ...  techcrunch"
       ]
      },
-     "execution_count": 18,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 18
     }
    ],
-   "source": [
-    "DATASET_NAME = \"titles_full.csv\"\n",
-    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
-    "COLUMNS = ['title', 'source']\n",
-    "\n",
-    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
-    "titles_df.head()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's look again at the number of examples per label to make sure we have a well-balanced dataset:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 19,
-   "metadata": {},
+   "source": [
+    "titles_df.source.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        139395\n",
@@ -915,38 +915,33 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 19,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 19
     }
    ],
-   "source": [
-    "titles_df.source.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Preparing the labels"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "In this lab, we will use pre-trained [TF-Hub embeddings modules for english](https://tfhub.dev/s?q=tf2%20embeddings%20text%20english) for the first layer of our models. One immediate\n",
     "advantage of doing so is that the TF-Hub embedding module will take care for us of processing the raw text. \n",
     "This also means that our model will be able to consume text directly instead of sequences of integers representing the words.\n",
     "\n",
     "However, as before, we still need to preprocess the labels into one-hot-encoded vectors:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "CLASSES = {\n",
     "    'github': 0,\n",
@@ -954,26 +949,31 @@
     "    'techcrunch': 2\n",
     "}\n",
     "N_CLASSES = len(CLASSES)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 21,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def encode_labels(sources):\n",
     "    classes = [CLASSES[source] for source in sources]\n",
     "    one_hots = to_categorical(classes, num_classes=N_CLASSES)\n",
     "    return one_hots"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 22,
-   "metadata": {},
+   "source": [
+    "encode_labels(titles_df.source[:4])"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0., 1., 0.],\n",
@@ -982,34 +982,29 @@
        "       [1., 0., 0.]], dtype=float32)"
       ]
      },
-     "execution_count": 22,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 22
     }
    ],
-   "source": [
-    "encode_labels(titles_df.source[:4])"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Preparing the train/test splits"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's split our data into train and test splits:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 23,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "N_TRAIN = int(len(titles_df) * 0.95)\n",
     "\n",
@@ -1018,25 +1013,30 @@
     "\n",
     "titles_valid, sources_valid = (\n",
     "    titles_df.title[N_TRAIN:], titles_df.source[N_TRAIN:])"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "To be on the safe side, we verify that the train and test splits\n",
     "have roughly the same number of examples per class.\n",
     "\n",
     "Since it is the case, accuracy will be a good metric to use to measure\n",
     "the performance of our models."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 24,
-   "metadata": {},
+   "source": [
+    "sources_train.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        132432\n",
@@ -1045,21 +1045,21 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 24,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 24
     }
    ],
-   "source": [
-    "sources_train.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "metadata": {},
+   "source": [
+    "sources_valid.value_counts()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "github        6963\n",
@@ -1068,38 +1068,38 @@
        "Name: source, dtype: int64"
       ]
      },
-     "execution_count": 25,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 25
     }
    ],
-   "source": [
-    "sources_valid.value_counts()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Now let's create the features and labels we will feed our models with:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 26,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "X_train, Y_train = titles_train.values, encode_labels(sources_train)\n",
     "X_valid, Y_valid = titles_valid.values, encode_labels(sources_valid)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 27,
-   "metadata": {},
+   "source": [
+    "X_train[:3]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array(['a powerful  disturbing history of residential segregation in america',\n",
@@ -1108,21 +1108,21 @@
        "      dtype=object)"
       ]
      },
-     "execution_count": 27,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 27
     }
    ],
-   "source": [
-    "X_train[:3]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 28,
-   "metadata": {},
+   "source": [
+    "Y_train[:3]"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([[0., 1., 0.],\n",
@@ -1130,41 +1130,44 @@
        "       [1., 0., 0.]], dtype=float32)"
       ]
      },
-     "execution_count": 28,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 28
     }
    ],
-   "source": [
-    "Y_train[:3]"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## NNLM Model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "We will first try a word embedding pre-trained using a [Neural Probabilistic Language Model](http://www.jmlr.org/papers/volume3/bengio03a/bengio03a.pdf). TF-Hub has a 50-dimensional one called \n",
     "[nnlm-en-dim50-with-normalization](https://tfhub.dev/google/tf2-preview/nnlm-en-dim50/1), which also\n",
     "normalizes the vectors produced. \n",
     "\n",
     "Once loaded from its url, the TF-hub module can be used as a normal Keras layer in a sequential or functional model. Since we have enough data to fine-tune the parameters of the pre-trained embedding itself, we will set `trainable=True` in the `KerasLayer` that loads the pre-trained embedding:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 29,
-   "metadata": {},
+   "source": [
+    "# TODO 1\n",
+    "NNLM = \"https://tfhub.dev/google/nnlm-en-dim50/2\"\n",
+    "\n",
+    "nnlm_module = KerasLayer(\n",
+    "    NNLM, output_shape=[50], input_shape=[], dtype=tf.string, trainable=True)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:14:45.799376: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64\n",
       "2023-07-31 13:14:45.799417: W tensorflow/stream_executor/cuda/cuda_driver.cc:269] failed call to cuInit: UNKNOWN ERROR (303)\n",
@@ -1175,27 +1178,25 @@
      ]
     }
    ],
-   "source": [
-    "# TODO 1\n",
-    "NNLM = \"https://tfhub.dev/google/nnlm-en-dim50/2\"\n",
-    "\n",
-    "nnlm_module = KerasLayer(\n",
-    "    NNLM, output_shape=[50], input_shape=[], dtype=tf.string, trainable=True)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Note that this TF-Hub embedding produces a single 50-dimensional vector when passed a sentence:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 30,
-   "metadata": {},
+   "source": [
+    "# TODO 1\n",
+    "nnlm_module(tf.constant([\"The dog is happy to see people in the street.\"]))"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<tf.Tensor: shape=(1, 50), dtype=float32, numpy=\n",
@@ -1212,56 +1213,56 @@
        "      dtype=float32)>"
       ]
      },
-     "execution_count": 30,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 30
     }
    ],
-   "source": [
-    "# TODO 1\n",
-    "nnlm_module(tf.constant([\"The dog is happy to see people in the street.\"]))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Swivel Model"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Then we will try a word embedding obtained using [Swivel](https://arxiv.org/abs/1602.02215), an algorithm that essentially factorizes word co-occurrence matrices to create the words embeddings. \n",
     "TF-Hub hosts the pretrained [gnews-swivel-20dim-with-oov](https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1) 20-dimensional Swivel module."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# TODO 1\n",
     "SWIVEL = \"https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1\"\n",
     "swivel_module = KerasLayer(\n",
     "    SWIVEL, output_shape=[20], input_shape=[], dtype=tf.string, trainable=True)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Similarly as the previous pre-trained embedding, it outputs a single vector when passed a sentence:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "source": [
+    "# TODO 1\n",
+    "swivel_module(tf.constant([\"The dog is happy to see people in the street.\"]))"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<tf.Tensor: shape=(1, 20), dtype=float32, numpy=\n",
@@ -1272,38 +1273,32 @@
        "      dtype=float32)>"
       ]
      },
-     "execution_count": 32,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 32
     }
    ],
-   "source": [
-    "# TODO 1\n",
-    "swivel_module(tf.constant([\"The dog is happy to see people in the street.\"]))"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Building the models"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's write a function that \n",
     "\n",
     "* takes as input an instance of a `KerasLayer` (i.e. the `swivel_module` or the `nnlm_module` we constructed above) as well as the name of the model (say `swivel` or `nnlm`)\n",
     "* returns a compiled Keras sequential model starting with this pre-trained TF-hub layer, adding one or more dense relu layers to it, and ending with a softmax layer giving the probability of each of the classes:"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 33,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def build_model(hub_module, name):\n",
     "    model = Sequential([\n",
@@ -1318,23 +1313,23 @@
     "        metrics=['accuracy']\n",
     "    )\n",
     "    return model"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Let's also wrap the training code into a `train_and_evaluate` function that \n",
     "* takes as input the training and validation data, as well as the compiled model itself, and the `batch_size`\n",
     "* trains the compiled model for 100 epochs at most, and does early-stopping when the validation loss is no longer decreasing\n",
     "* returns an `history` object, which will help us to plot the learning curves"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 35,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "def train_and_evaluate(train_data, val_data, model, batch_size=5000):\n",
     "    X_train, Y_train = train_data\n",
@@ -1353,33 +1348,38 @@
     "        callbacks=TensorBoard(model_dir),\n",
     "    )\n",
     "    return history"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Training NNLM"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 36,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "data = (X_train, Y_train)\n",
     "val_data = (X_valid, Y_valid)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 37,
-   "metadata": {},
+   "source": [
+    "nnlm_model = build_model(nnlm_module, 'nnlm')\n",
+    "nnlm_history = train_and_evaluate(data, val_data, nnlm_model)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:16:13.668869: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:16:13.668917: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n",
@@ -1387,31 +1387,31 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Epoch 1/50\n",
       " 1/51 [..............................] - ETA: 47s - loss: 1.1633 - accuracy: 0.2336"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:16:14.733319: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:16:14.733366: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n"
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       " 2/51 [>.............................] - ETA: 22s - loss: 1.1584 - accuracy: 0.2316"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:16:15.170245: I tensorflow/core/profiler/lib/profiler_session.cc:66] Profiler session collecting data.\n",
       "2023-07-31 13:16:15.173360: I tensorflow/core/profiler/lib/profiler_session.cc:164] Profiler session tear down.\n",
@@ -1431,8 +1431,8 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "51/51 [==============================] - 23s 446ms/step - loss: 0.9860 - accuracy: 0.6033 - val_loss: 0.7855 - val_accuracy: 0.7875\n",
       "Epoch 2/50\n",
@@ -1536,77 +1536,76 @@
      ]
     }
    ],
-   "source": [
-    "nnlm_model = build_model(nnlm_module, 'nnlm')\n",
-    "nnlm_history = train_and_evaluate(data, val_data, nnlm_model)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 38,
-   "metadata": {},
+   "source": [
+    "history = nnlm_history\n",
+    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
+    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 38,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 38
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABI40lEQVR4nO3dd3xb5b0/8I8ka3hJ8pRH7NhkTydkuCZAGYY00DSMSynkRwIUKDRpgZRbkltIoL0QWkpuymqAstrLCOUSSpuUFUgImcSJQ6bJcGwn3kuyZVuSpfP749HwkB3bkXRs6/N+vc5L8tGR9fgkxB+e8X0UkiRJICIiIpKJUu4GEBERUXhjGCEiIiJZMYwQERGRrBhGiIiISFYMI0RERCQrhhEiIiKSFcMIERERyYphhIiIiGQVIXcD+sLlcqG8vByxsbFQKBRyN4eIiIj6QJIkNDU1IS0tDUplz/0fQyKMlJeXIyMjQ+5mEBER0QCUlZVhxIgRPb4+JMJIbGwsAPHD6PV6mVtDREREfWGxWJCRkeH9Pd6TIRFGPEMzer2eYYSIiGiIOdcUC05gJSIiIlkxjBAREZGsGEaIiIhIVkNizggREYU3SZLQ3t4Op9Mpd1OoA5VKhYiIiPMuu9HvMPLVV1/h6aefRkFBASoqKrBhwwZcd911vb5ny5YtWLZsGQ4fPoyMjAw88sgjuP322wfYZCIiCid2ux0VFRVoaWmRuynkR1RUFFJTU6HRaAb8PfodRqxWK3JycnDnnXfihhtuOOf1xcXFuPbaa3HvvffirbfewubNm3HXXXchNTUVc+fOHVCjiYgoPLhcLhQXF0OlUiEtLQ0ajYbFLwcJSZJgt9tRU1OD4uJijBkzptfCZr3pdxiZN28e5s2b1+fr161bh+zsbDzzzDMAgAkTJuDrr7/G//zP/zCMEBFRr+x2O1wuFzIyMhAVFSV3c6iLyMhIqNVqlJSUwG63Q6fTDej7BH0C686dO5Gfn9/p3Ny5c7Fz584e32Oz2WCxWDodREQUvgb6f9wUfIH4swn6n25lZSVMJlOncyaTCRaLBa2trX7fs3r1ahgMBu/BUvBERETD16CMmitWrIDZbPYeZWVlcjeJiIiIgiToS3tTUlJQVVXV6VxVVRX0ej0iIyP9vker1UKr1Qa7aUREREFz2WWXYdq0aVi7dq3cTRn0gt4zkpeXh82bN3c699lnnyEvLy/YH01ERERDQL/DSHNzMwoLC1FYWAhALN0tLCxEaWkpADHEsmjRIu/19957L06dOoVf//rXOHbsGF588UW89957ePDBBwPzE5yH174uxqMfHsLxqia5m0JERBS2+h1G9u7di+nTp2P69OkAgGXLlmH69OlYuXIlAKCiosIbTAAgOzsbGzduxGeffYacnBw888wz+Mtf/jIolvX+89ty/G1XCU7VWuVuChER9ZEkSWixt8tySJI0oDY3NDRg0aJFiIuLQ1RUFObNm4fjx497Xy8pKcH8+fMRFxeH6OhoTJo0CZs2bfK+d+HChUhKSkJkZCTGjBmD119/PSD3crDo95yRyy67rNc/jDfeeMPve/bv39/fjwq6WJ0aANDU1i5zS4iIqK9aHU5MXPmJLJ995LdzEaXp/3TL22+/HcePH8dHH30EvV6Phx9+GNdccw2OHDkCtVqNJUuWwG6346uvvkJ0dDSOHDmCmJgYAMCjjz6KI0eO4N///jcSExNx4sSJHlejDlVhvTdNrE78+JZWh8wtISKi4coTQrZv346LLroIAPDWW28hIyMDH374IW666SaUlpbixhtvxJQpUwAAF1xwgff9paWlmD59OmbOnAkAyMrKCvnPEGxhHUb07BkhIhpyItUqHPmtPEP9kWpVv99z9OhRREREIDc313suISEB48aNw9GjRwEAv/zlL3Hffffh008/RX5+Pm688UZMnToVAHDffffhxhtvxL59+3D11Vfjuuuu84aa4WJQ1hkJFb2nZ6SNPSNEREOFQqFAlCZCliNY++LcddddOHXqFG677TYcPHgQM2fOxHPPPQdAbMNSUlKCBx98EOXl5bjyyivx0EMPBaUdcgnrMOIZpmliGCEioiCZMGEC2tvbsXv3bu+5uro6FBUVYeLEid5zGRkZuPfee/HBBx/gV7/6FV555RXva0lJSVi8eDH+93//F2vXrsXLL78c0p8h2MJ7mCaSwzRERBRcY8aMwYIFC3D33XfjpZdeQmxsLJYvX4709HQsWLAAAPDAAw9g3rx5GDt2LBoaGvDll19iwoQJAICVK1dixowZmDRpEmw2G/71r395Xxsu2DMCDtMQEVFwvf7665gxYwZ++MMfIi8vD5IkYdOmTVCrxf8UO51OLFmyBBMmTMAPfvADjB07Fi+++CIAQKPRYMWKFZg6dSouvfRSqFQqvPvuu3L+OAGnkAa6aDqELBYLDAYDzGYz9Hp9wL7v5qNV+OmbezF1hAEfLb04YN+XiIgCo62tDcXFxcjOzh7w9vQUXL39GfX193eY94xwmIaIiEhuYR5GWGeEiIhIbmEdRjiBlYiISH5hHUY8PSN2pwttDqfMrSEiIgpPYR1GYjQR8NSv4YoaIiIieYR1GFEqFYjRegqfcaiGiIhIDmEdRgDf/jScxEpERCSPsA8jvpLw7BkhIiKSQ9iHEe7cS0REJK+wDyMsCU9ERINRVlYW1q5d26drFQoFPvzww6C2J5jCPoz4ao0wjBAREckh7MMI54wQERHJi2GEJeGJiIYWSQLsVnmOPu4t+/LLLyMtLQ0ul6vT+QULFuDOO+/EyZMnsWDBAphMJsTExGDWrFn4/PPPA3aLDh48iCuuuAKRkZFISEjAPffcg+bmZu/rW7ZswezZsxEdHQ2j0Yg5c+agpKQEAHDgwAFcfvnliI2NhV6vx4wZM7B3796Atc2fiKB+9yGAE1iJiIYYRwvwZJo8n/1f5YAm+pyX3XTTTfjFL36BL7/8EldeeSUAoL6+Hh9//DE2bdqE5uZmXHPNNXjiiSeg1Wrx17/+FfPnz0dRUREyMzPPq4lWqxVz585FXl4evvnmG1RXV+Ouu+7C0qVL8cYbb6C9vR3XXXcd7r77brzzzjuw2+3Ys2cPFO4qoAsXLsT06dPx5z//GSqVCoWFhVCr1efVpnMJ+zDi2bmXE1iJiChQ4uLiMG/ePLz99tveMPL+++8jMTERl19+OZRKJXJycrzX/+53v8OGDRvw0UcfYenSpef12W+//Tba2trw17/+FdHRIjg9//zzmD9/Pn7/+99DrVbDbDbjhz/8IUaNGgUAmDBhgvf9paWl+M///E+MHz8eADBmzJjzak9fhH0Y0Ud6VtOwZ4SIaEhQR4keCrk+u48WLlyIu+++Gy+++CK0Wi3eeust/OQnP4FSqURzczMee+wxbNy4ERUVFWhvb0draytKS0vPu4lHjx5FTk6ON4gAwJw5c+ByuVBUVIRLL70Ut99+O+bOnYurrroK+fn5+PGPf4zU1FQAwLJly3DXXXfhb3/7G/Lz83HTTTd5Q0uwcM4Ih2mIiIYWhUIMlchxeDY064P58+dDkiRs3LgRZWVl2LZtGxYuXAgAeOihh7BhwwY8+eST2LZtGwoLCzFlyhTY7fZg3bVOXn/9dezcuRMXXXQR1q9fj7Fjx2LXrl0AgMceewyHDx/Gtddeiy+++AITJ07Ehg0bgtoehhFOYCUioiDQ6XS44YYb8NZbb+Gdd97BuHHjcOGFFwIAtm/fjttvvx3XX389pkyZgpSUFJw+fTognzthwgQcOHAAVqvVe2779u1QKpUYN26c99z06dOxYsUK7NixA5MnT8bbb7/tfW3s2LF48MEH8emnn+KGG27A66+/HpC29STsw4hvAivDCBERBdbChQuxceNGvPbaa95eEUDMw/jggw9QWFiIAwcO4NZbb+228uZ8PlOn02Hx4sU4dOgQvvzyS/ziF7/AbbfdBpPJhOLiYqxYsQI7d+5ESUkJPv30Uxw/fhwTJkxAa2srli5dii1btqCkpATbt2/HN99802lOSTBwzoi7Z6TZ1g6XS4JS2fcuOCIiot5cccUViI+PR1FREW699Vbv+TVr1uDOO+/ERRddhMTERDz88MOwWCwB+cyoqCh88sknuP/++zFr1ixERUXhxhtvxJo1a7yvHzt2DG+++Sbq6uqQmpqKJUuW4Gc/+xna29tRV1eHRYsWoaqqComJibjhhhvw+OOPB6RtPVFIUh8XTcvIYrHAYDDAbDZDr9cH9Hu32p2YsPJjAMDBx672ziEhIiL5tbW1obi4GNnZ2dDpdHI3h/zo7c+or7+/w36YRqdWQq0SvSGcxEpERBR6YR9GFAoFV9QQEdGg9dZbbyEmJsbvMWnSJLmbFxBhP2cEEPNG6q12Fj4jIqJB50c/+hFyc3P9vhbsyqihwjCCjrVGGEaIiGhwiY2NRWxsrNzNCKqwH6YBOtYa4TANEdFgNATWWoStQPzZMIyAtUaIiAYrzzBES0uLzC2hnnj+bM5nyIjDNOjQM8IJrEREg4pKpYLRaER1dTUAUSND0Y+S7BQ8kiShpaUF1dXVMBqNUKlUA/5eDCPgzr1ERINZSkoKAHgDCQ0uRqPR+2c0UAwj8O3cy6W9RESDj0KhQGpqKpKTk+Fw8H8aBxO1Wn1ePSIeDCPgzr1EREOBSqUKyC8+Gnw4gRW+/Wm4cy8REVHoMYyAdUaIiIjkxDACX88Ih2mIiIhCj2EEgD6Sq2mIiIjkwjACX50R9owQERGFHsMIfHNGWuxOOJwumVtDREQUXhhG4OsZAYBm9o4QERGFFMMIALVKiUi1WLvOoRoiIqLQYhhx81Rh5SRWIiKi0GIYceP+NERERPJgGHHjihoiIiJ5MIy46T09IywJT0REFFIMI27sGSEiIpIHw4gb54wQERHJg2HEzbOahj0jREREocUw4qbnzr1ERESyYBhx8+zca2llzwgREVEoMYy4eeaMNNnYM0JERBRKDCNuXE1DREQkD4YRN30k64wQERHJgWHEjT0jRERE8mAYcfPOGWlrhyRJMreGiIgofDCMuHlW09idLtjaXTK3hoiIKHwwjLhFayKgUIjnrMJKREQUOgwjbkqlAjFa1hohIiIKNYaRDliFlYiIKPQGFEZeeOEFZGVlQafTITc3F3v27On1+rVr12LcuHGIjIxERkYGHnzwQbS1tQ2owcHEFTVERESh1+8wsn79eixbtgyrVq3Cvn37kJOTg7lz56K6utrv9W+//TaWL1+OVatW4ejRo3j11Vexfv16/Nd//dd5Nz7QvLVG2DNCREQUMv0OI2vWrMHdd9+NO+64AxMnTsS6desQFRWF1157ze/1O3bswJw5c3DrrbciKysLV199NW655ZZz9qbIQc+eESIiopDrVxix2+0oKChAfn6+7xsolcjPz8fOnTv9vueiiy5CQUGBN3ycOnUKmzZtwjXXXNPj59hsNlgslk5HKMRyzggREVHIRfTn4traWjidTphMpk7nTSYTjh075vc9t956K2pra3HxxRdDkiS0t7fj3nvv7XWYZvXq1Xj88cf707SA4M69REREoRf01TRbtmzBk08+iRdffBH79u3DBx98gI0bN+J3v/tdj+9ZsWIFzGaz9ygrKwt2MwGwZ4SIiEgO/eoZSUxMhEqlQlVVVafzVVVVSElJ8fueRx99FLfddhvuuusuAMCUKVNgtVpxzz334De/+Q2Uyu55SKvVQqvV9qdpAcHVNERERKHXr54RjUaDGTNmYPPmzd5zLpcLmzdvRl5ent/3tLS0dAscKpUKAAbdHjBcTUNERBR6/eoZAYBly5Zh8eLFmDlzJmbPno21a9fCarXijjvuAAAsWrQI6enpWL16NQBg/vz5WLNmDaZPn47c3FycOHECjz76KObPn+8NJbI59AHQWAJMuh6Iy/L2jFjYM0JERBQy/Q4jN998M2pqarBy5UpUVlZi2rRp+Pjjj72TWktLSzv1hDzyyCNQKBR45JFHcPbsWSQlJWH+/Pl44oknAvdTDNSO54DyfUDSeCAuy1uB1dLKnhEiIqJQUUiDbazED4vFAoPBALPZDL1eH7hv/LcbgJObgev+DEy7FftLG3D9izuQbozE9uVXBO5ziIiIwlBff3+H9940kUbx2NoIgKtpiIiI5BDmYSROPLY2AAD0ke7VNLZ2uFyDvsOIiIhoWAjvMKIzise2RgC+XXslCbDaOYmViIgoFMI7jHQZptFGKKFWKQCw1ggREVGohHkY6TxMo1AofCtqOG+EiIgoJMI7jHQZpgFYhZWIiCjUwjuMdOkZAXxVWLmihoiIKDTCPIwYxaN7zgjg6xnhzr1EREShEd5hxDNM09ogltAAiNWyZ4SIiCiUwjuMeIZpJCdgbwbgqzXC/WmIiIhCI7zDiDoSUGnE8y5VWLmahoiIKDTCO4woFN0msXI1DRERUWiFdxgBeqzCyp17iYiIQoNhxLuihj0jREREcmAY8Q7TNAJgnREiIqJQYxjpMkzjrTPCnhEiIqKQYBjpMoHVM2eEPSNEREShwTDSpQqrbwIre0aIiIhCgWGkYxVW+IZpWh1OOJwumRpFREQUPhhGPMM07jkjMe4wAgDNnDdCREQUdAwjXYZp1ColojQqAKzCSkREFAoMI10msAKsNUJERBRKDCNdlvYCHSaxsmeEiIgo6BhGPMM0bWbA5QTQodYIV9QQEREFHcOIp2cEEIEEvp17WWuEiIgo+BhGIjSAOlo892yW5y0Jz54RIiKiYGMYAbpNYvWVhGfPCBERUbAxjADdlvdyNQ0REVHoMIwAPe5PY2llzwgREVGwMYwAgM4gHj1zRtgzQkREFDIMI0CHYRp3z4hnAquNPSNERETBxjACdBimaQTAOiNEREShxDACdKvCyjojREREocMwAnTrGdHrWGeEiIgoVBhGgB6X9lraHJAkSZ42ERERhQmGEcA3TNOl6JnDKcHW7pKpUUREROGBYQTwDdO454xEayKgVIhTrMJKREQUXAwjQLdhGqVSgRgtV9QQERGFAsMI4OsZcViBdjuAjpvlsWeEiIgomBhGAEBrAOAel+myvNfCFTVERERBxTACAEoloNOL510msbJnhIiIKLgYRjxYa4SIiEgWDCMeXaqw6r0l4dkzQkREFEwMIx7enpGuwzTsGSEiIgomhhGPLst7uZqGiIgoNBhGPHqowsrVNERERMHFMOLRpQqrnjv3EhERhQTDiId3mMbTM8I6I0RERKHAMOLRZWlvLFfTEBERhQTDiEfXpb2RrDNCREQUCgwjHt2GaTwTWNkzQkREFEwMIx49DNM029rhckkyNYqIiGj4Yxjx6Li0V5K8q2kkCbDaOVRDREQULAwjHp6eEZcDcLRAp1ZBoxK3hytqiIiIgodhxEMTDSjF0IyvCit37iUiIgo2hhEPhcJPFVauqCEiIgo2hpGOulRhZa0RIiKi4GMY6ajL8l49e0aIiIiCjmGko56qsHLOCBERUdAwjHTUpQqrJ4ywZ4SIiCh4GEY66mGYhj0jREREwcMw0lG3YRp3GGllzwgREVGwMIx01GVpL+uMEBERBR/DSEfdlvZyNQ0REVGwDSiMvPDCC8jKyoJOp0Nubi727NnT6/WNjY1YsmQJUlNTodVqMXbsWGzatGlADQ4q75yRRgBcTUNERBQKEf19w/r167Fs2TKsW7cOubm5WLt2LebOnYuioiIkJyd3u95ut+Oqq65CcnIy3n//faSnp6OkpARGozEQ7Q8s75wR1hkhIiIKlX6HkTVr1uDuu+/GHXfcAQBYt24dNm7ciNdeew3Lly/vdv1rr72G+vp67NixA2q1+OWelZV1fq0Olh6X9rJnhIiIKFj6NUxjt9tRUFCA/Px83zdQKpGfn4+dO3f6fc9HH32EvLw8LFmyBCaTCZMnT8aTTz4Jp9PZ4+fYbDZYLJZOR0h0HKZxuXxLe7mahoiIKGj6FUZqa2vhdDphMpk6nTeZTKisrPT7nlOnTuH999+H0+nEpk2b8Oijj+KZZ57Bf//3f/f4OatXr4bBYPAeGRkZ/WnmwHl6RiABNot3NU2rwwmH0xWaNhAREYWZoK+mcblcSE5Oxssvv4wZM2bg5ptvxm9+8xusW7eux/esWLECZrPZe5SVlQW7mYJaB0REiuetDYjR+kaxOG+EiIgoOPo1ZyQxMREqlQpVVVWdzldVVSElJcXve1JTU6FWq6FSqbznJkyYgMrKStjtdmg0mm7v0Wq10Gq1/Wla4ETGAU2tQFsjIuKzEa1RwWp3oqnNgfjo7m0lIiKi89OvnhGNRoMZM2Zg8+bN3nMulwubN29GXl6e3/fMmTMHJ06cgMvlG+b47rvvkJqa6jeIyK7b8l6uqCEiIgqmfg/TLFu2DK+88grefPNNHD16FPfddx+sVqt3dc2iRYuwYsUK7/X33Xcf6uvrcf/99+O7777Dxo0b8eSTT2LJkiWB+ykCqUsVVm+tkVauqCEiIgqGfi/tvfnmm1FTU4OVK1eisrIS06ZNw8cff+yd1FpaWgql0pdxMjIy8Mknn+DBBx/E1KlTkZ6ejvvvvx8PP/xw4H6KQOpShVUf6dksjz0jREREwdDvMAIAS5cuxdKlS/2+tmXLlm7n8vLysGvXroF8VOh12bmXtUaIiIiCi3vTdNXTzr3sGSEiIgoKhpGuulRh1XPOCBERUVAxjHTVZZgmKVYsMa5ussnUICIiouGNYaSrLsM0qQYdAKDS3CpTg4iIiIY3hpGuvEt7GwEAKQZRkbXC3CZPe4iIiIY5hpGuuiztTXP3jDCMEBERBQfDSFddKrCmuMOIudWBFjtX1BAREQUaw0hXnmEaexPgdCBWp0ase8M89o4QEREFHsNIVzqD73mbGYCvd6SSYYSIiCjgGEa6UkUAWr147l7e6wkj5Y1cUUNERBRoDCP+dJk3kuZeUcOeESIiosBjGPGnSxVWb88IwwgREVHAMYz406UKKwufERERBQ/DiD9dq7AaWfiMiIgoWBhG/PFWYe3cM8IwQkREFHgMI/50qcKaysJnREREQcMw4k+XOSOxOjViWPiMiIgoKBhG/OmyWR7AwmdERETBwjDiT5dhGoDzRoiIiIKFYcSfLsM0QIcwwiqsREREAcUw4k+Xpb0AkOKuwlphYc8IERFRIDGM+NNlaS8ApHHOCBERUVAwjPjjGaZx2gCHGJbhZnlERETBwTDij1YPKFTiuWezPHcV1koO0xAREQUUw4g/CgWgM4jn7qEaT89IY4sDrXanXC0jIiIadhhGetJleW+sNgLRGtFbUsEN84iIiAKGYaQnXZb3KhQK74Z5nMRKREQUOAwjPfGzvNdTa6ScYYSIiChgGEZ64lne26EKa4res7yXwzRERESBwjDSE39VWN3DNOwZISIiChyGkZ70MkzDOSNERESBwzDSEz9VWLlZHhERUeAxjPTE78697v1pOGeEiIgoYBhGeuJnzggLnxEREQUew0hPvMM0jd5Tep2v8BnLwhMREQUGw0hP/AzTKBQKb+9IBTfMIyIiCgiGkZ54h2kaAUnynvbNG2HPCBERUSAwjPTE0zMiOQFbk/e0b0UNe0aIiIgCgWGkJ+pIQKUVz7m8l4iIKGgYRnrjGarpuLyXm+UREREFFMNIb/xUYU3hZnlERDRc1J8Cdr8MvLsQcMj3ey1Ctk8eCnqpwsrN8oiIaMixtwAl24HjnwEnPhNhxKN0JzDqclmaxTDSm16qsDa4C59FuuuOEBERDTqSBNSdAE58LgJIyXagvUMPiDICyPgeMPpKIGG0bM1kGOmNnyqsel0EojQqtNidqLS0ITsxWp62ERERdSVJQEMxcHq7CB6ntwPm0s7X6EeI8DHmKiD7+4BOL09bO2AY6Y2fKqyewmenaqyoMLcyjBARkXw8PR+nv/aFj6byzteoNEBmnggfo/OBpPGAQiFPe3vAMNIbP8M0AJBmiBRhpJGTWImIKISstUDFAfdRCJTuApqrOl+jVAPpM4CsOcDIOUBGLqCNkaW5fcUw0hs/wzSAb0UN96chIqKgkCTAchao+NYXPiq/Fee6UmmBEbN84WPELEATFfo2nweGkd74WdoLAGmswkpERIHkdIjAUbJD9HaU7QZaav1fmzAaSJkKpE4FRswWvSBqXWjbG2AMI73xs7QXAFI8+9NwmIaIiAbC1gyc2SOCR8kO4MxeoL3L/+AqI8T8jtQcd/jIAVImA9pYedocRAwjvfFTgRVgSXgiIuqnlnpRx8OzyqXyoNj7rKPIeDHRNPN74jFlypDv8egrhpHeeIdpzJ1Opxo5TENERL1oqhKho2SHeKw+0v0aY6Y7fOQBIy8CEsYAyvAsjM4w0hvPMI3NDLicgFIUOEvV+wqftTmc0KlZ+IyIKGxJkqhkWrYHKN0hAkjdie7XJY7zTTLNzAMM6aFv6yDFMNIbzzANALSZgah4AIA+MgKRahVaHU5UmtuQxVojREThw9EmltWW7RYBpGw3YK3pcpFCzO8Y2SF8xCTJ0dohgWGkNyo1oIkB7M1iEqs7jCgUCqQaReGzcnMrwwgR0XDlWWJ7Zi9w5hsRPMoLAZej83UqDZA2HciYDYy8GMjM9Q310zkxjJyLzugOI42dTqe6q7BWchIrEdHw0doAlO8HzhYAZ/eJx65FxQAgOlkEj4xcMeE0NQeI0Ia+vcMEw8i5RMYBljPdlvd6NszjihoioiGqtRGoOixWtpS7g4e/uR4KFWCaBIyYKTaVy5gNxGUNupLqQxnDyLmcc3kvV9QQEQ1qLhfQWCJCR9UhoPIQUHUQaCz1f31ctigk5jlSpwLqyNC2OcwwjJzLuUrCs2eEiGjwsNaKZbTVx9yPR0Xvh73J//WGDMA0GUibBqTPFPM+ohNC2mRiGDm3HqqwprmHacpZhZWIKPTsLaJ8evURoOaYCB3VR3suoa7SAMkTANMUscrFNFk8cpLpoMAwci4Jo8RjxYFOp7lZHhFRCNmtYiXL6a9FFdOzBd1XtAAAFGI+R/IEUUo9eYIIHoljxApJGpQYRs4l6xLxePprMe7oro7nmTNSb7Wz8BkRUaDZmoGyXb7wUb4PcLV3viY2VZRM94SO5AmisNgQ27GWGEbOLXUaoIkVE1irDorlWwAMkWoWPiMiOl8uF2AudQ+zuOd4eOZ7dN27xZABZF0sjpFzuKJlGGEYORdVBDAyDzj+KVC8zRtGFAqFqDVSa0UFwwgRUe8kSdTrqDrsm99RfQSoKQIcVv/vMWaKAmKeABI3MrRtppBhGOmLrEtEGDm9Dbhoqfd0qtETRri8l4jIy94C1LhXsVQdEctpq48ALXX+r1dpxPBKsnu4JWmCmFxqzAxtu0k2AwojL7zwAp5++mlUVlYiJycHzz33HGbPnn3O97377ru45ZZbsGDBAnz44YcD+Wh5ZLvnjZTsAJztorcEQIqehc+IKMy1mUV59PJ9onJp5SGxaRyk7tcqlED8KMA0EUie6Ase8Rd4/12l8NTvP/3169dj2bJlWLduHXJzc7F27VrMnTsXRUVFSE5O7vF9p0+fxkMPPYRLLrnkvBosi5SpgM4g/qOrPCCK4MA3iZW1RogoLDjaOlcrPbsPqDvu/9qoRNG7kTxJVC81TRQTTVk8jPzodxhZs2YN7r77btxxxx0AgHXr1mHjxo147bXXsHz5cr/vcTqdWLhwIR5//HFs27YNjY2N59XokFOqxGSpok1i3ognjBhZhZWIhhlJEoXD6k8B9Sfdj6eA2u/EPI+uK1oAwJAJpE8H0i4U8+pMk4CYnv/nlKirfoURu92OgoICrFixwntOqVQiPz8fO3fu7PF9v/3tb5GcnIyf/vSn2LZt2zk/x2azwWazeb+2WCz9aWZwZF3iDiNfARc/AKBjSXj2jBDRECNJImRUFIq5HZ7QUV8M2Hr5Nzc6SYSO9At9j9GJIWs2DU/9CiO1tbVwOp0wmUydzptMJhw7dszve77++mu8+uqrKCws7PPnrF69Go8//nh/mhZ8nnkjpbsApwNQqTlnhIiGBpcLaCgWczoqCsUcj4pvAZu5hzcoxDLa+GwxnyNhlHhMmQoYRnA5LQVcUGcMNTU14bbbbsMrr7yCxMS+J+cVK1Zg2bJl3q8tFgsyMjKC0cS+S54ERMYDrfVinDQzF2lGFj4jokHG6RDLZT2bwlUcEIe/3g6VVgyppE4FEsb4godxJKDWhb7tFLb6FUYSExOhUqlQVVXV6XxVVRVSUlK6XX/y5EmcPn0a8+fP955zuVzigyMiUFRUhFGjRnV7n1arhVar7U/Tgk+pBLLmAEf/CZz+CsjMhSFSDZ1aiTaHC1WWNoxMYK0RIgqh1kb3LrQHfUfNMcBp735thM63IVzqNPGYNJ4l0mlQ6FcY0Wg0mDFjBjZv3ozrrrsOgAgXmzdvxtKlS7tdP378eBw8eLDTuUceeQRNTU3405/+JH9vR39lf1+EkeJtwKX/CYVCgTRDJE7VWlHeyDBCREHQZhFDLPXFvnkdDafFo+Ws//doDWIlS8oUcaROA5LGMXjQoNXvYZply5Zh8eLFmDlzJmbPno21a9fCarV6V9csWrQI6enpWL16NXQ6HSZPntzp/UajEQC6nR8SPPvUlO0G2m1AhBYp7iqslRauqCGi89BcLXo5PIXC6k6IEGKt6f19hkxf6PAcxkzO66Ahpd9h5Oabb0ZNTQ1WrlyJyspKTJs2DR9//LF3UmtpaSmU7s3khp2kcUB0MmCtBs7sBbLmeHfvLW/kJFYi6gNHG1Bb5A4dh30BpLfQEZXom0wa536MvwBIHA1ExoWu7URBMqAJrEuXLvU7LAMAW7Zs6fW9b7zxxkA+cnBQKMT+CIc/EKXhs+YgzSBW1LDwGRF1YreK2hw1Rb6jtkgMt3TdAA4AoBCTR02TxIT5pLHu4JEtii4SDWOsv9tf2ZeIMFK8DbhsubdnhMt7icKMJImqzOYywHwGaCwTczlq3cHDXNbze3VGMZximuQ7kiYAmqhQtZ5oUGEY6a+sS8XjmT2Ao7VD4TPOGSEadlxOETCqDgF1JzsHD/MZwN7U+/ujk8QGcEljxcqVxLFiuDc2lXM6iDpgGOmvhFHiH5KmCqBsD1IN0wFwmIZoyGup7zyPo/qIKH/uaOn9fVGJohCYMUNMJk0cI4JH0jggKj40bSca4hhG+kuhEKtqDr4HnN6G1Nw8AEAdC58RDQ2SJHo4PMXAKg6InWabyv1fH6Fz7y47XlQlNWaI8GHIAPTpHFohCgCGkYHIdoeR4m0wXv4bFj4jGqw8ZdC9waNQPLY2+L/eOFIUBvPO5ZgsJpAq+T8ZRMHEMDIQnnojZwugcLQg1RCJ4lorKswMI0Qh53SIno6G02KlSkOx+/lp8dze3P09ygjR25GaIwqCpUwBkicCOn1o205EABhGBiYuS3TRmsuA0l1I0Ue7wwgnsRIFjcsJ1B4HKr8VvRtVh0XYaCzrYamsm3f/lRzfYZoERAyyLSeIwhjDyEB45o0ceFvMGzFeB4DLe4kCxtEqqpBWHhC7y1Z+K75u7yHwq7TifxLis0VtDu/zLFEcjGXQiQY1hpGBynaHkeJtSM38CQCuqCHqM1uzb5msucy3VNbzteUsILm6v08d7d5zZaoYWkkYLUJHTIrYzJKIhiSGkYHyzBsp348RE8Q/mqfrzrEEkCjcSJIIGGe+Ac4WiG0Uao4BbY3nfm90ki90pE4FUnJELwdDB9GwwzAyUMYM0QXccBoXq78DoMauk3VobLHDGKWRu3VE8rA1A+X7O4SPb4DmKv/X6gyiLodhRIc6HSPEOWMmEJPMwmBEYYJh5HxkXQI0nEaGeS/Gp1yNY5VN2HSwErfmZsrdMqLgcrQBdcfd+618J3o7PM+7Dq8oI8SE0RGzgPSZopfDkMGVK0TkxTByPrIvBfb/DSjehuum34Gn/n0MHxaeZRih4aPdLvZaqTwE1BwFatzBo7HE/5wOANCPAEbMdB+zxOoVdWRo201EQwrDyPnwzBup/BYLFkTj9x8De4rrcbaxFelG/uNLQ0xLvSiDXnlQhI/KgyJ4uBz+r9cZ3WXPx7r3XxkvekD0qSFtNhENfQwj50OfCiSMAeqOI7VxH2ZnxWN3cT0+KizHfZeNkrt1RP55qpJWHnSHD3fwsJzxf73OAJimuEuij3Mf48UEU87pIKIAYBg5X9mXiLHz09tw/fT7sLu4Hh/uP8swQoODrUnU56hy93ZUHRJfO6z+rzeOFKtXUqa6l9BOEfM7GDqIKIgYRs5X1iXA3teA4m2Y9/3fYuU/DqOoqglHKyyYkMoJehRCbWZRmbS8UOzBUl4I1J/0f61n8zfTZHGkThVDLDpDCBtMRCQwjJwvz7yRqoMwSE24fHwSPjlchQ8LzzKMUPBY60RvR8fg0VDs/9rYVBE4UtzBI2UKED8KUPE/fyIaHPiv0fmKSQKSJoiVBqe/xvXTZ+GTw1X4qLAcD88dD6WS3ds0QM52sWql9rhYMlv7ne95a73/9xgzfZu/pU0Tj9GJIWw0EVH/MYwEQvYlIoyc+ByXzbsWsboIVJjbsLu4HnmjEuRuHQ0FTofYf6Vsjziqj4ohFqe9hzcogLiR3YNHVHzo2kxEFCAMI4Ewdi6w52Vg/9+gm/pjXDM5Fev3luEfhWcZRsi/5hrgzB6gbDdQ9g1Qvg9o97O3UUQkkDgaSBzrPsaIx/hRgCYq9O0mIgoChpFAGHUlkHMLcOAd4P07cdMPPsL6vcDGgxV47EeToFOr5G4hycnWJJbOeuZ3lO3xP78jMg4YMRvImC16OZLGigJi3IuFiIY5hpFAUCiAa58Rv2xqjmLG3oeQrv8lzloc2FJUjR9MZhGosNHaILa8rzgggkfFAaDuJACpy4UKsZplxCwgI1cEkITRXEJLRGGJYSRQNNHAj/8KvHwZFKe34Q9po7HQchU+3F/OMDJctTb6VrKU7xdHY4n/a/UjxLyOlKm+UulcRktEBIBhJLCSxgI/ehb4v59iTvnr+L4yGV8cU8Lc6oAhUi136+h8tFncNTzcoaOiEKg/5f/auCz3xFL35NLUHK5oISLqBcNIoE35D6BkB7D3VTyrfRE/aH0S/z5YgZ/M5uZ5Q0ZzDVB5QAy3VH4rHnsqHmYcCaRNdx/TRPCIjAtpc4mIhjqGkWCY+yRwdi8MFQfwvOZZrNmfzTAyWJnPipUsnnkeld8CTRX+rzVkisCRNk2EDy6lJSIKCIaRYFDrgJvehGvdpZhhP47Ly15EeeNMpHEnX3m5nEDVYbGctnSXeDSX+blQASSMEvM7UnNEqfSUHCCay7SJiIKBYSRY4rOhvGEd8O6tuCtiEz7+/H+R9h93y92q8GJrAs7s9YWPM3sBe1PnaxQqIHkikJYjAkfqVFEyXRsjT5uJiMIQw0gwjb8WR7MXY0Lxm7j40CrgiiuB+AvkbtXw1G4XO9KeLRATTM/uA2qOoduSWk0skDELyPgekJkLpM9k8CAikhnDSJCl3rAae5/ehZnKIrS9fRt0P9sshnFo4FwuoO64CBxnC8Scj8qD/kunGzKAzO+JWh6Z3xO9IEoWoSMiGkwYRoLMGBuN97IeR3bJ3UioPQRsuAe45o9ATLLcTRsaJAmwnBWhwxM+Kg4ANkv3ayPjgLQLgfQLgfQZ4nmsKfRtJiKifmEYCYHLZk3DAyeW4E3N76E88g/g+OfA9+4D5vySha+6staKGh5n9/nCh7W6+3URke5VLZ7wcSEQl80KpkREQ5BCkqSudaoHHYvFAoPBALPZDL1eL3dz+q3N4cSs//4cE+0H8WraPxBT9614QWcELlkGzL4HUIfZShtJAhpO++p4VB7seVmtQgWYJnXu8UgaD6iYpYmIBrO+/v7mv+YhoFOrMG9KCt7b244n0q7G6vwSYPPvgNoi4LOVwK4/A99/GJj+/wDVMKzU6mgTk0mrDgGVh0ToqDzof6jFs6w2bboIHukzgJQp4RfWiIjCCHtGQmTHiVrc+pfd0KmV+NcvLsboxCjgwLvAltW+WhfxFwCX/waYdMPQ3am1udrdy3HQFz5qvwMkZ/drVRoxoTRliqjnkTIVME0EtLGhbzcREQVcX39/M4yEiCRJuO3VPfj6RC3Gp8TiwyVzoFOrgHYbsPd14KungZZacXH8KCD7EiAzT6wAMY4cHHMh7FagqVIMpTRVApbyzl/XnfA/vwMQk0tNk0XwSJkqHpPGDc+eICIiAsAwMihVN7Xhmj9tQ22zHYvyRuK3Cyb7XrQ1ieGaHc91H76ITXUvTXWHE9PkwM+XcLmA5irRS9NYKg5zGdBYJh4t5T0Mq3TlHmYxTQZSJrt7OyYD+rTBEaiIiChkGEYGqa3f1WDxa3sAAC/dNgNzJ6V0vqC1ESjZDpTuFFVDywsBl6PzNZoY8Us+OkGsxtEZgUijeNQZxblII6CJBmzNQJvZfTSKo7XR93Vro1g6az7jv05HV+poQJ8qAlJsivtwPzeOBJIniM8lIqKwxzAyiD256She/uoUDJFqbLr/EqT3tmeNvUUU9SrdCZTuFqXN+9RDMQAKJaBPF4XCjBmAMdP3XD9ChBDO5yAioj5iGBnE7O0u3LRuBw6cMWNWVhzeuft7iFD1ccKqywlUHxWHp6ejzezu7ejy3G4VvSienhJPL4r3a/ehTxWhQ5/GORxERBQwDCODXEmdFdc++zWabe345ZVjsOyqsXI3iYiIKKD6+vt7iK4fHfpGJkTjievFBNbnvziOnSfrZG4RERGRPBhGZLRgWjpumjECLgl4YP1+1Fv7MIGUiIhomGEYkdnjCybhgqRoVFls+PX7BzAERs2IiIgCimFEZlGaCDx3y3RoVEp8frQab+w4LXeTiIiIQophZBCYlGbAb66dAABYvekYDp01y9wiIiKi0GEYGSQW5Y3EVRNNsDtdWPr2PlSa2+RuEhERUUgwjAwSCoUCf7hxKtIMOpyua8H1L27H0YogFTcjIiIaRBhGBpG4aA3W/ywPo5NjUGFuw03rdmLb8Rq5m0VERBRUDCODTEZ8FP7v3ouQmx2PZls77nj9G7y3t0zuZhEREQUNw8ggZIhS468/nY0F09LQ7pLw6/e/xZrPvuOyXyIiGpYYRgYpbYQKa2+ehqWXjwYAPLv5OH719wOwt7tkbhkREVFgMYwMYgqFAg/NHYenbpgClVKBD/adxe2v74GlzSF304iIiAKGYWQI+MnsTLy6eCaiNSrsOFmH//jzDpxtbJW7WURERAHBMDJEXDYuGe/dmweTXovvqppx/Qvb8eWxarmbRUREdN4YRoaQSWkGbPj5HIwzxaK6yYY73vgGP3+rAFUWFkgjIqKhi2FkiEkzRmLDkotwz6UXQKVUYNPBSlz5zFa8ueM0nC6utiEioqGHYWQIitJE4L+umYB/Lr0Y0zKMaLa1Y9VHh3H9i9u5rw0REQ05DCND2MQ0Pf7vvovwuwWTEKuNwLdnzPjR81/jd/86AqutXe7mERER9QnDyBCnUipwW14WNv/q+7h2aipcEvDq18XIX7MVnxyulLt5RERE56SQhkBZT4vFAoPBALPZDL1eL3dzBrUtRdV49B+HUFYvlv7OyorDzy8fjcvGJkGhUMjcOiIiCid9/f3NMDIMtdqdePaL43h1WzHsTlGxdVKaHksuH40fTEqBUslQQkREwccwQqiytOGVr07hrd2laHU4AQCjkqLx88tG40fT0qBWcZSOiIiCp6+/vwf02+iFF15AVlYWdDodcnNzsWfPnh6vfeWVV3DJJZcgLi4OcXFxyM/P7/V6ChyTXodHfjgR25dfgV9eMRp6XQRO1ljxq78fwOV/3IK/7SpBmzukEBERyaXfYWT9+vVYtmwZVq1ahX379iEnJwdz585FdbX/aqBbtmzBLbfcgi+//BI7d+5ERkYGrr76apw9e/a8G099Ex+twbKrx2H78ivw8A/GIzFGgzMNrXj0w0O45A9f4k+fH8eZhha5m0lERGGq38M0ubm5mDVrFp5//nkAgMvlQkZGBn7xi19g+fLl53y/0+lEXFwcnn/+eSxatKhPn8lhmsBqtTux/ptSvPzVKZSbRfVWhQKYMyoRN80cgbmTUqBTq2RuJRERDXV9/f0d0Z9varfbUVBQgBUrVnjPKZVK5OfnY+fOnX36Hi0tLXA4HIiPj+/xGpvNBpvN5v3aYrH0p5l0DpEaFW6fk41bc0di08EKvLe3DDtO1uHrE7X4+kQtYnUR+FFOGn48MwNTRxi4CoeIiIKqX2GktrYWTqcTJpOp03mTyYRjx4716Xs8/PDDSEtLQ35+fo/XrF69Go8//nh/mkYDoIlQ4rrp6bhuejrK6lvwfsEZvF9wBmcbW/HW7lK8tbsUY00xuGlGBhZMT0NyrE7uJhMR0TAU0uUUTz31FN59911s2LABOl3Pv9hWrFgBs9nsPcrKykLYyvCUER+FB68ai22/vhxv3ZWLBdPSoI1Q4ruqZjyx6Shyn9yMG/+8Ay9tPYniWqvczSUiomGkXz0jiYmJUKlUqKqq6nS+qqoKKSkpvb73j3/8I5566il8/vnnmDp1aq/XarVaaLXa/jSNAkSpVGDO6ETMGZ0Ic6sD//q2HO8XnMH+0kYUlDSgoKQBq/99DGOSY3D1JBOunpjCoRwiIjovA5rAOnv2bDz33HMAxATWzMxMLF26tMcJrH/4wx/wxBNP4JNPPsH3vve9fjeSE1jlV2FuxedHqvDpkSrsPFmH9g47BKfodbhqogn5E02YnRWPSA0nvxIRURCLnq1fvx6LFy/GSy+9hNmzZ2Pt2rV47733cOzYMZhMJixatAjp6elYvXo1AOD3v/89Vq5cibfffhtz5szxfp+YmBjExMQE9Ieh0DC3OrClqBqfHq7ClqJqWO2+WiUalRIXjjRizqhEzBmTiKnpBkSwuBoRUVgKagXW559/Hk8//TQqKysxbdo0PPvss8jNzQUAXHbZZcjKysIbb7wBAMjKykJJSUm377Fq1So89thjAf1hKPTaHE7sPFmHTw5X4qvvarxLhT1itRHIvSABc0Yn4OLRiRidHMMhHSKiMMFy8BRykiThdF0Lvj5Rix0narHjZB3MrY5O1yTGaDFzZBwuHGnEjJFxmJRmYE0TIqJhimGEZOd0SThSbhHh5GQt9hTXw9bu6nSNRqXEpHQ9LsyMw4yRcbgwMw4pBi4hJiIaDhhGaNBpczjx7Rkz9pU2YF9JA/aVNqC22d7tujSDDpPTDZiUZsCkND0mpeuRotdxeIeIaIhhGKFBT5IklNW3oqC0HvtKxNLhY5UWuPz8jYyP1mBSmh4T0/TekJKVEA2VkgGFiGiwYhihIclqa8e3Z8w4XG7GkXILDpdbcKKmGU4/CUUbocSopBiMNcVgjCkW40yxGGuKxYi4SCgZUoiIZMcwQsNGm8OJosomHC634EiFGYfLLThaYUGbw+X3+ki1CqOTYzDGFIPRyTHITohGVmI0shKiWQOFiCiEGEZoWHO6JJTVt+C7qiYcr27Gd1VN+K6qGSdrmmFv9x9SACDVoENWQjSyk6K9ISU7MQoj4qK4qoeIKMAYRigstTtdKKlvwXF3OCmuteJUrRWna63dlhl3ZdJrkRkfhYz4KGR2OZJitZxAS0TUTwwjRF00WO3eYHK6zhdSSupa0Gxr7/W92ggl0o2RSI+LRJrB/WiMFOeMkUgx6KCJYKVZIqKO+vr7u18b5RENZXHRGsyI1mDGyLhO5yVJQmOLA6X1Ld6jrMPz8sZW2NpdOOXuZfFHoQCSY7VINUQizahDqiESqQbxmGLQIc2oQ3Ksjqt/iIj8YBihsKdQKBAXrUFctAY5GcZurzucLlQ0tuFsY6s4GlpR7nnuPuztLlRZbKiy2FBY5v9zVEoFkmO1SNbrkBSjRVJsh8P9dbL7a85fIaJwwjBCdA5qlRKZCVHITIjy+7okSahttqO8sRUV5lZUmNt8R6P4usrShnaX5D1/LrHaCCTptT2GFs+REK1lbwsRDXkMI0TnSaFQeMOBv54VQKz+qWu2odzchpomG2qabKhu8j2vafacs8He7kKTrR1NNe04VeN/WMhDqRAF4RJjfGEl0fsozsdHa5AQrUVctBraCPa4ENHgwzBCFAIqpQLJeh2S9b3vuyNJEixt7ah1hxNPQOkaWmqabKiz2uCSgNpmO2qb7ThW2XTOdsRoIxDvHpJKiNYgLkqDhBiNO7B4nmu9z6M0/CeCiIKP/9IQDSIKhQKGSDUMkWqMSorp9dp2pwv1LXbUNtlR02xDbYewUtvhsd7qQEOLHU6XhGZbO5pt7Sitb+lTe3RqJRKitUiIEcElPtrzqIax09caxEWrYYzUcFUREfUbwwjREBWhUiI5VqzSOReXS0JTWzvqrDY0tNhR12wXj1Y76pvtqLeK53VWG+qb7ai12mFvd6HN4fJO0u2raI0KxigRTuKiNDBGaWCMVCMuqkOAidYg3n1NfLQGkWoV67gQhTGGEaIwoFQqYIhSwxCl7tP1kiTBane6g4kIKPUtdjRY7WhocaDB2vFr97kWOyQJsNqdsNr7F2C0EcouvSwab3iJi/KEGvEYF6WBMVqNWG0EAwzRMMEwQkTdKBQKxGgjEKON6HEVUVdOl4SmNoc3mDS22NFgdaCx1SGet/iCjDfQWO2wO12wtbv6vNLII0KpgLFDYOkcXLqcixa9M8YoDiMRDUYMI0QUECqlQgzJRGmQjeg+vUeSJLTYnai3+oaNPCGl0RtqHN4g4wk1bQ4X2l2Sd/Juf0RpVN6eFmOXEOPpmTFGqb09NXHRGkRrOIxEFEwMI0QkG4VCgWhtBKK1EciI71sPDCB2cm7w9Lx0GCbq/Nz32Nhih7nVAZcEtNidaOnnMJJapeg8gTfGM+dFg3h3z0vH8BIfpeEO0UT9wDBCREOOTq1yl9yP7PN7PJN4G9y9K97hI/dQkmceTGOLHfXukFNvtcPW7oLDKaHavcy6r7QRSm848fa8RPt6YDquUPIcrLxL4YphhIjCQsdJvFl9HEYCgFa70ztZ1zOcVO8ZTnKHmY7DTI0tdjicEmztLlRa2lBp6fs8GM8QUsegYoxS+3phvL0v4hznwNBwwTBCRNSLSI0K6RqxO3NfeFYidVpp1OV5fYtYUu0JNvVWO9pd0oCGkDxLqY0dVh0ZO0zkjY9WIyFai0R3Vd74KA0iVAwwNLgwjBARBVDHlUh9nQcjSRKabO3eJdSeoNLgHjLyhRlP74wYRnINYCm1QgHERWmQGCO2C/AcCTG+cwkxogpvYoyWc18oJBhGiIhkplAooNepodf1fQjJ5ZJgaXN0W3XU2OKb1NvY6kC91YbaJlHQrs4qasF4emO+q2o+5+dEa1QinMSILQPE/BYtEmN8c10SorWId7/OeS80EAwjRERDkLLDUuq+BhinS0K91Y7aZhvqmsVjbbPYRqCu2Y66ZhFYaptsqG0WNWCsdies9S193kIgSqPqNCk33jNJN8b3PCFG6+2FieKyaQLDCBFR2FApfTtMn4skib2Mat0hpdYdVOqb3dsIWH3bCNRbbai3iom7nnkvZxr6NmykUyu9Q0NJMaKXJTFW490TKcn9WmKMCF4qJYPLcMQwQkRE3SgUCsTq1IjVqZGdeO6eF8+O0x0n6NZ7nvsJL7VNdrQ6nGhzuHCmoW/hRamAd4jIN8/FN+clqcO5hBgNtBEcMhoqGEaIiOi8ddxxuq/DRi32du+u06L3xdcLU+seRqpzDys1toiidZ6hJaDpnN8/VhfRKaB0DjCdz8VwryNZMYwQEZEsojQRyEzo2/5HDqcLDVa7d36LJ5TUubcE6Ph1ndUGh1MUuWtqa8epWus5v782QokE93yWBPfk3ET3qqKOq4s8Q0is7xJYDCNERDToqVVKJOt1SNbrznmtJEmwtLajplNg6dzj0jG8tNidsLW7UG5uQ3kfN2s0Rqm9PSxJsTpvT0tSbOcAkxCjQZSGv2rPhXeIiIiGFYXCV213dHLMOa+32tq981k8K4o8q4vqrXbUWjtM4m0WBerEEmoHTlSfuz2RapW7p0WEFLEc2l1Rt8PzhGgt4qLVYTlkxDBCRERhrT+bNbpcEsytDtHr0iSWRdc0+Xpcapps3sm6Nc022NtdaHU4cbax74XpNCqlewm0exl0tG9JtKc4nWe1UUL08ChMxzBCRETUR0qlQmx+GK3BWFNsr9d6tgbo2tvScWl016PV4YTd2b99jTr2vPgtSucOLfGDeNho8LWIiIhoGOi4NcDIhL6tMGq1O1HnrtviCTD1Vt9E3Tqrr0BdrdU+oJ4XT3jxVdUVvSwLczP73M5AYxghIiIaJCI1KozQRGFE3LmHjLr2vHhqu9RabR2eu4vSNdvPGV5+MDmFYYSIiIj6rr89L57wUt+hh6VjIboRcX3bmToYGEaIiIjCQMfw0pfaLqHEqi1EREQkK4YRIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLIaErv2SpIEALBYLDK3hIiIiPrK83vb83u8J0MijDQ1NQEAMjIyZG4JERER9VdTUxMMBkOPryukc8WVQcDlcqG8vByxsbFQKBQB+74WiwUZGRkoKyuDXq8P2Pcl/3i/Q4v3O7R4v0OL9zu0Bnq/JUlCU1MT0tLSoFT2PDNkSPSMKJVKjBgxImjfX6/X8y9zCPF+hxbvd2jxfocW73doDeR+99Yj4sEJrERERCQrhhEiIiKSVViHEa1Wi1WrVkGr1crdlLDA+x1avN+hxfsdWrzfoRXs+z0kJrASERHR8BXWPSNEREQkP4YRIiIikhXDCBEREcmKYYSIiIhkFdZh5IUXXkBWVhZ0Oh1yc3OxZ88euZs0LHz11VeYP38+0tLSoFAo8OGHH3Z6XZIkrFy5EqmpqYiMjER+fj6OHz8uT2OHgdWrV2PWrFmIjY1FcnIyrrvuOhQVFXW6pq2tDUuWLEFCQgJiYmJw4403oqqqSqYWD21//vOfMXXqVG/xp7y8PPz73//2vs57HTxPPfUUFAoFHnjgAe853u/Aeuyxx6BQKDod48eP974erPsdtmFk/fr1WLZsGVatWoV9+/YhJycHc+fORXV1tdxNG/KsVitycnLwwgsv+H39D3/4A5599lmsW7cOu3fvRnR0NObOnYu2trYQt3R42Lp1K5YsWYJdu3bhs88+g8PhwNVXXw2r1eq95sEHH8Q///lP/P3vf8fWrVtRXl6OG264QcZWD10jRozAU089hYKCAuzduxdXXHEFFixYgMOHDwPgvQ6Wb775Bi+99BKmTp3a6Tzvd+BNmjQJFRUV3uPrr7/2vha0+y2FqdmzZ0tLlizxfu10OqW0tDRp9erVMrZq+AEgbdiwwfu1y+WSUlJSpKefftp7rrGxUdJqtdI777wjQwuHn+rqagmAtHXrVkmSxP1Vq9XS3//+d+81R48elQBIO3fulKuZw0pcXJz0l7/8hfc6SJqamqQxY8ZIn332mfT9739fuv/++yVJ4t/tYFi1apWUk5Pj97Vg3u+w7Bmx2+0oKChAfn6+95xSqUR+fj527twpY8uGv+LiYlRWVna69waDAbm5ubz3AWI2mwEA8fHxAICCggI4HI5O93z8+PHIzMzkPT9PTqcT7777LqxWK/Ly8nivg2TJkiW49tprO91XgH+3g+X48eNIS0vDBRdcgIULF6K0tBRAcO/3kNgoL9Bqa2vhdDphMpk6nTeZTDh27JhMrQoPlZWVAOD33nteo4FzuVx44IEHMGfOHEyePBmAuOcajQZGo7HTtbznA3fw4EHk5eWhra0NMTEx2LBhAyZOnIjCwkLe6wB79913sW/fPnzzzTfdXuPf7cDLzc3FG2+8gXHjxqGiogKPP/44LrnkEhw6dCio9zsswwjRcLVkyRIcOnSo0xgvBd64ceNQWFgIs9mM999/H4sXL8bWrVvlbtawU1ZWhvvvvx+fffYZdDqd3M0JC/PmzfM+nzp1KnJzczFy5Ei89957iIyMDNrnhuUwTWJiIlQqVbcZwFVVVUhJSZGpVeHBc3957wNv6dKl+Ne//oUvv/wSI0aM8J5PSUmB3W5HY2Njp+t5zwdOo9Fg9OjRmDFjBlavXo2cnBz86U9/4r0OsIKCAlRXV+PCCy9EREQEIiIisHXrVjz77LOIiIiAyWTi/Q4yo9GIsWPH4sSJE0H9+x2WYUSj0WDGjBnYvHmz95zL5cLmzZuRl5cnY8uGv+zsbKSkpHS69xaLBbt37+a9HyBJkrB06VJs2LABX3zxBbKzszu9PmPGDKjV6k73vKioCKWlpbznAeJyuWCz2XivA+zKK6/EwYMHUVhY6D1mzpyJhQsXep/zfgdXc3MzTp48idTU1OD+/T6v6a9D2LvvvitptVrpjTfekI4cOSLdc889ktFolCorK+Vu2pDX1NQk7d+/X9q/f78EQFqzZo20f/9+qaSkRJIkSXrqqacko9Eo/eMf/5C+/fZbacGCBVJ2drbU2toqc8uHpvvuu08yGAzSli1bpIqKCu/R0tLivebee++VMjMzpS+++ELau3evlJeXJ+Xl5cnY6qFr+fLl0tatW6Xi4mLp22+/lZYvXy4pFArp008/lSSJ9zrYOq6mkSTe70D71a9+JW3ZskUqLi6Wtm/fLuXn50uJiYlSdXW1JEnBu99hG0YkSZKee+45KTMzU9JoNNLs2bOlXbt2yd2kYeHLL7+UAHQ7Fi9eLEmSWN776KOPSiaTSdJqtdKVV14pFRUVydvoIczfvQYgvf76695rWltbpZ///OdSXFycFBUVJV1//fVSRUWFfI0ewu68805p5MiRkkajkZKSkqQrr7zSG0Qkifc62LqGEd7vwLr55pul1NRUSaPRSOnp6dLNN98snThxwvt6sO63QpIk6fz6VoiIiIgGLiznjBAREdHgwTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrP4/DtZDT0NaIawAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABI40lEQVR4nO3dd3xb5b0/8I8ka3hJ8pRH7NhkTydkuCZAGYY00DSMSynkRwIUKDRpgZRbkltIoL0QWkpuymqAstrLCOUSSpuUFUgImcSJQ6bJcGwn3kuyZVuSpfP749HwkB3bkXRs6/N+vc5L8tGR9fgkxB+e8X0UkiRJICIiIpKJUu4GEBERUXhjGCEiIiJZMYwQERGRrBhGiIiISFYMI0RERCQrhhEiIiKSFcMIERERyYphhIiIiGQVIXcD+sLlcqG8vByxsbFQKBRyN4eIiIj6QJIkNDU1IS0tDUplz/0fQyKMlJeXIyMjQ+5mEBER0QCUlZVhxIgRPb4+JMJIbGwsAPHD6PV6mVtDREREfWGxWJCRkeH9Pd6TIRFGPEMzer2eYYSIiGiIOdcUC05gJSIiIlkxjBAREZGsGEaIiIhIVkNizggREYU3SZLQ3t4Op9Mpd1OoA5VKhYiIiPMuu9HvMPLVV1/h6aefRkFBASoqKrBhwwZcd911vb5ny5YtWLZsGQ4fPoyMjAw88sgjuP322wfYZCIiCid2ux0VFRVoaWmRuynkR1RUFFJTU6HRaAb8PfodRqxWK3JycnDnnXfihhtuOOf1xcXFuPbaa3HvvffirbfewubNm3HXXXchNTUVc+fOHVCjiYgoPLhcLhQXF0OlUiEtLQ0ajYbFLwcJSZJgt9tRU1OD4uJijBkzptfCZr3pdxiZN28e5s2b1+fr161bh+zsbDzzzDMAgAkTJuDrr7/G//zP/zCMEBFRr+x2O1wuFzIyMhAVFSV3c6iLyMhIqNVqlJSUwG63Q6fTDej7BH0C686dO5Gfn9/p3Ny5c7Fz584e32Oz2WCxWDodREQUvgb6f9wUfIH4swn6n25lZSVMJlOncyaTCRaLBa2trX7fs3r1ahgMBu/BUvBERETD16CMmitWrIDZbPYeZWVlcjeJiIiIgiToS3tTUlJQVVXV6VxVVRX0ej0iIyP9vker1UKr1Qa7aUREREFz2WWXYdq0aVi7dq3cTRn0gt4zkpeXh82bN3c699lnnyEvLy/YH01ERERDQL/DSHNzMwoLC1FYWAhALN0tLCxEaWkpADHEsmjRIu/19957L06dOoVf//rXOHbsGF588UW89957ePDBBwPzE5yH174uxqMfHsLxqia5m0JERBS2+h1G9u7di+nTp2P69OkAgGXLlmH69OlYuXIlAKCiosIbTAAgOzsbGzduxGeffYacnBw888wz+Mtf/jIolvX+89ty/G1XCU7VWuVuChER9ZEkSWixt8tySJI0oDY3NDRg0aJFiIuLQ1RUFObNm4fjx497Xy8pKcH8+fMRFxeH6OhoTJo0CZs2bfK+d+HChUhKSkJkZCTGjBmD119/PSD3crDo95yRyy67rNc/jDfeeMPve/bv39/fjwq6WJ0aANDU1i5zS4iIqK9aHU5MXPmJLJ995LdzEaXp/3TL22+/HcePH8dHH30EvV6Phx9+GNdccw2OHDkCtVqNJUuWwG6346uvvkJ0dDSOHDmCmJgYAMCjjz6KI0eO4N///jcSExNx4sSJHlejDlVhvTdNrE78+JZWh8wtISKi4coTQrZv346LLroIAPDWW28hIyMDH374IW666SaUlpbixhtvxJQpUwAAF1xwgff9paWlmD59OmbOnAkAyMrKCvnPEGxhHUb07BkhIhpyItUqHPmtPEP9kWpVv99z9OhRREREIDc313suISEB48aNw9GjRwEAv/zlL3Hffffh008/RX5+Pm688UZMnToVAHDffffhxhtvxL59+3D11Vfjuuuu84aa4WJQ1hkJFb2nZ6SNPSNEREOFQqFAlCZCliNY++LcddddOHXqFG677TYcPHgQM2fOxHPPPQdAbMNSUlKCBx98EOXl5bjyyivx0EMPBaUdcgnrMOIZpmliGCEioiCZMGEC2tvbsXv3bu+5uro6FBUVYeLEid5zGRkZuPfee/HBBx/gV7/6FV555RXva0lJSVi8eDH+93//F2vXrsXLL78c0p8h2MJ7mCaSwzRERBRcY8aMwYIFC3D33XfjpZdeQmxsLJYvX4709HQsWLAAAPDAAw9g3rx5GDt2LBoaGvDll19iwoQJAICVK1dixowZmDRpEmw2G/71r395Xxsu2DMCDtMQEVFwvf7665gxYwZ++MMfIi8vD5IkYdOmTVCrxf8UO51OLFmyBBMmTMAPfvADjB07Fi+++CIAQKPRYMWKFZg6dSouvfRSqFQqvPvuu3L+OAGnkAa6aDqELBYLDAYDzGYz9Hp9wL7v5qNV+OmbezF1hAEfLb04YN+XiIgCo62tDcXFxcjOzh7w9vQUXL39GfX193eY94xwmIaIiEhuYR5GWGeEiIhIbmEdRjiBlYiISH5hHUY8PSN2pwttDqfMrSEiIgpPYR1GYjQR8NSv4YoaIiIieYR1GFEqFYjRegqfcaiGiIhIDmEdRgDf/jScxEpERCSPsA8jvpLw7BkhIiKSQ9iHEe7cS0REJK+wDyMsCU9ERINRVlYW1q5d26drFQoFPvzww6C2J5jCPoz4ao0wjBAREckh7MMI54wQERHJi2GEJeGJiIYWSQLsVnmOPu4t+/LLLyMtLQ0ul6vT+QULFuDOO+/EyZMnsWDBAphMJsTExGDWrFn4/PPPA3aLDh48iCuuuAKRkZFISEjAPffcg+bmZu/rW7ZswezZsxEdHQ2j0Yg5c+agpKQEAHDgwAFcfvnliI2NhV6vx4wZM7B3796Atc2fiKB+9yGAE1iJiIYYRwvwZJo8n/1f5YAm+pyX3XTTTfjFL36BL7/8EldeeSUAoL6+Hh9//DE2bdqE5uZmXHPNNXjiiSeg1Wrx17/+FfPnz0dRUREyMzPPq4lWqxVz585FXl4evvnmG1RXV+Ouu+7C0qVL8cYbb6C9vR3XXXcd7r77brzzzjuw2+3Ys2cPFO4qoAsXLsT06dPx5z//GSqVCoWFhVCr1efVpnMJ+zDi2bmXE1iJiChQ4uLiMG/ePLz99tveMPL+++8jMTERl19+OZRKJXJycrzX/+53v8OGDRvw0UcfYenSpef12W+//Tba2trw17/+FdHRIjg9//zzmD9/Pn7/+99DrVbDbDbjhz/8IUaNGgUAmDBhgvf9paWl+M///E+MHz8eADBmzJjzak9fhH0Y0Ud6VtOwZ4SIaEhQR4keCrk+u48WLlyIu+++Gy+++CK0Wi3eeust/OQnP4FSqURzczMee+wxbNy4ERUVFWhvb0draytKS0vPu4lHjx5FTk6ON4gAwJw5c+ByuVBUVIRLL70Ut99+O+bOnYurrroK+fn5+PGPf4zU1FQAwLJly3DXXXfhb3/7G/Lz83HTTTd5Q0uwcM4Ih2mIiIYWhUIMlchxeDY064P58+dDkiRs3LgRZWVl2LZtGxYuXAgAeOihh7BhwwY8+eST2LZtGwoLCzFlyhTY7fZg3bVOXn/9dezcuRMXXXQR1q9fj7Fjx2LXrl0AgMceewyHDx/Gtddeiy+++AITJ07Ehg0bgtoehhFOYCUioiDQ6XS44YYb8NZbb+Gdd97BuHHjcOGFFwIAtm/fjttvvx3XX389pkyZgpSUFJw+fTognzthwgQcOHAAVqvVe2779u1QKpUYN26c99z06dOxYsUK7NixA5MnT8bbb7/tfW3s2LF48MEH8emnn+KGG27A66+/HpC29STsw4hvAivDCBERBdbChQuxceNGvPbaa95eEUDMw/jggw9QWFiIAwcO4NZbb+228uZ8PlOn02Hx4sU4dOgQvvzyS/ziF7/AbbfdBpPJhOLiYqxYsQI7d+5ESUkJPv30Uxw/fhwTJkxAa2srli5dii1btqCkpATbt2/HN99802lOSTBwzoi7Z6TZ1g6XS4JS2fcuOCIiot5cccUViI+PR1FREW699Vbv+TVr1uDOO+/ERRddhMTERDz88MOwWCwB+cyoqCh88sknuP/++zFr1ixERUXhxhtvxJo1a7yvHzt2DG+++Sbq6uqQmpqKJUuW4Gc/+xna29tRV1eHRYsWoaqqComJibjhhhvw+OOPB6RtPVFIUh8XTcvIYrHAYDDAbDZDr9cH9Hu32p2YsPJjAMDBx672ziEhIiL5tbW1obi4GNnZ2dDpdHI3h/zo7c+or7+/w36YRqdWQq0SvSGcxEpERBR6YR9GFAoFV9QQEdGg9dZbbyEmJsbvMWnSJLmbFxBhP2cEEPNG6q12Fj4jIqJB50c/+hFyc3P9vhbsyqihwjCCjrVGGEaIiGhwiY2NRWxsrNzNCKqwH6YBOtYa4TANEdFgNATWWoStQPzZMIyAtUaIiAYrzzBES0uLzC2hnnj+bM5nyIjDNOjQM8IJrEREg4pKpYLRaER1dTUAUSND0Y+S7BQ8kiShpaUF1dXVMBqNUKlUA/5eDCPgzr1ERINZSkoKAHgDCQ0uRqPR+2c0UAwj8O3cy6W9RESDj0KhQGpqKpKTk+Fw8H8aBxO1Wn1ePSIeDCPgzr1EREOBSqUKyC8+Gnw4gRW+/Wm4cy8REVHoMYyAdUaIiIjkxDACX88Ih2mIiIhCj2EEgD6Sq2mIiIjkwjACX50R9owQERGFHsMIfHNGWuxOOJwumVtDREQUXhhG4OsZAYBm9o4QERGFFMMIALVKiUi1WLvOoRoiIqLQYhhx81Rh5SRWIiKi0GIYceP+NERERPJgGHHjihoiIiJ5MIy46T09IywJT0REFFIMI27sGSEiIpIHw4gb54wQERHJg2HEzbOahj0jREREocUw4qbnzr1ERESyYBhx8+zca2llzwgREVEoMYy4eeaMNNnYM0JERBRKDCNuXE1DREQkD4YRN30k64wQERHJgWHEjT0jRERE8mAYcfPOGWlrhyRJMreGiIgofDCMuHlW09idLtjaXTK3hoiIKHwwjLhFayKgUIjnrMJKREQUOgwjbkqlAjFa1hohIiIKNYaRDliFlYiIKPQGFEZeeOEFZGVlQafTITc3F3v27On1+rVr12LcuHGIjIxERkYGHnzwQbS1tQ2owcHEFTVERESh1+8wsn79eixbtgyrVq3Cvn37kJOTg7lz56K6utrv9W+//TaWL1+OVatW4ejRo3j11Vexfv16/Nd//dd5Nz7QvLVG2DNCREQUMv0OI2vWrMHdd9+NO+64AxMnTsS6desQFRWF1157ze/1O3bswJw5c3DrrbciKysLV199NW655ZZz9qbIQc+eESIiopDrVxix2+0oKChAfn6+7xsolcjPz8fOnTv9vueiiy5CQUGBN3ycOnUKmzZtwjXXXNPj59hsNlgslk5HKMRyzggREVHIRfTn4traWjidTphMpk7nTSYTjh075vc9t956K2pra3HxxRdDkiS0t7fj3nvv7XWYZvXq1Xj88cf707SA4M69REREoRf01TRbtmzBk08+iRdffBH79u3DBx98gI0bN+J3v/tdj+9ZsWIFzGaz9ygrKwt2MwGwZ4SIiEgO/eoZSUxMhEqlQlVVVafzVVVVSElJ8fueRx99FLfddhvuuusuAMCUKVNgtVpxzz334De/+Q2Uyu55SKvVQqvV9qdpAcHVNERERKHXr54RjUaDGTNmYPPmzd5zLpcLmzdvRl5ent/3tLS0dAscKpUKAAbdHjBcTUNERBR6/eoZAYBly5Zh8eLFmDlzJmbPno21a9fCarXijjvuAAAsWrQI6enpWL16NQBg/vz5WLNmDaZPn47c3FycOHECjz76KObPn+8NJbI59AHQWAJMuh6Iy/L2jFjYM0JERBQy/Q4jN998M2pqarBy5UpUVlZi2rRp+Pjjj72TWktLSzv1hDzyyCNQKBR45JFHcPbsWSQlJWH+/Pl44oknAvdTDNSO54DyfUDSeCAuy1uB1dLKnhEiIqJQUUiDbazED4vFAoPBALPZDL1eH7hv/LcbgJObgev+DEy7FftLG3D9izuQbozE9uVXBO5ziIiIwlBff3+H9940kUbx2NoIgKtpiIiI5BDmYSROPLY2AAD0ke7VNLZ2uFyDvsOIiIhoWAjvMKIzise2RgC+XXslCbDaOYmViIgoFMI7jHQZptFGKKFWKQCw1ggREVGohHkY6TxMo1AofCtqOG+EiIgoJMI7jHQZpgFYhZWIiCjUwjuMdOkZAXxVWLmihoiIKDTCPIwYxaN7zgjg6xnhzr1EREShEd5hxDNM09ogltAAiNWyZ4SIiCiUwjuMeIZpJCdgbwbgqzXC/WmIiIhCI7zDiDoSUGnE8y5VWLmahoiIKDTCO4woFN0msXI1DRERUWiFdxgBeqzCyp17iYiIQoNhxLuihj0jREREcmAY8Q7TNAJgnREiIqJQYxjpMkzjrTPCnhEiIqKQYBjpMoHVM2eEPSNEREShwTDSpQqrbwIre0aIiIhCgWGkYxVW+IZpWh1OOJwumRpFREQUPhhGPMM07jkjMe4wAgDNnDdCREQUdAwjXYZp1ColojQqAKzCSkREFAoMI10msAKsNUJERBRKDCNdlvYCHSaxsmeEiIgo6BhGPMM0bWbA5QTQodYIV9QQEREFHcOIp2cEEIEEvp17WWuEiIgo+BhGIjSAOlo892yW5y0Jz54RIiKiYGMYAbpNYvWVhGfPCBERUbAxjADdlvdyNQ0REVHoMIwAPe5PY2llzwgREVGwMYwAgM4gHj1zRtgzQkREFDIMI0CHYRp3z4hnAquNPSNERETBxjACdBimaQTAOiNEREShxDACdKvCyjojREREocMwAnTrGdHrWGeEiIgoVBhGgB6X9lraHJAkSZ42ERERhQmGEcA3TNOl6JnDKcHW7pKpUUREROGBYQTwDdO454xEayKgVIhTrMJKREQUXAwjQLdhGqVSgRgtV9QQERGFAsMI4OsZcViBdjuAjpvlsWeEiIgomBhGAEBrAOAel+myvNfCFTVERERBxTACAEoloNOL510msbJnhIiIKLgYRjxYa4SIiEgWDCMeXaqw6r0l4dkzQkREFEwMIx7enpGuwzTsGSEiIgomhhGPLst7uZqGiIgoNBhGPHqowsrVNERERMHFMOLRpQqrnjv3EhERhQTDiId3mMbTM8I6I0RERKHAMOLRZWlvLFfTEBERhQTDiEfXpb2RrDNCREQUCgwjHt2GaTwTWNkzQkREFEwMIx49DNM029rhckkyNYqIiGj4Yxjx6Li0V5K8q2kkCbDaOVRDREQULAwjHp6eEZcDcLRAp1ZBoxK3hytqiIiIgodhxEMTDSjF0IyvCit37iUiIgo2hhEPhcJPFVauqCEiIgo2hpGOulRhZa0RIiKi4GMY6ajL8l49e0aIiIiCjmGko56qsHLOCBERUdAwjHTUpQqrJ4ywZ4SIiCh4GEY66mGYhj0jREREwcMw0lG3YRp3GGllzwgREVGwMIx01GVpL+uMEBERBR/DSEfdlvZyNQ0REVGwDSiMvPDCC8jKyoJOp0Nubi727NnT6/WNjY1YsmQJUlNTodVqMXbsWGzatGlADQ4q75yRRgBcTUNERBQKEf19w/r167Fs2TKsW7cOubm5WLt2LebOnYuioiIkJyd3u95ut+Oqq65CcnIy3n//faSnp6OkpARGozEQ7Q8s75wR1hkhIiIKlX6HkTVr1uDuu+/GHXfcAQBYt24dNm7ciNdeew3Lly/vdv1rr72G+vp67NixA2q1+OWelZV1fq0Olh6X9rJnhIiIKFj6NUxjt9tRUFCA/Px83zdQKpGfn4+dO3f6fc9HH32EvLw8LFmyBCaTCZMnT8aTTz4Jp9PZ4+fYbDZYLJZOR0h0HKZxuXxLe7mahoiIKGj6FUZqa2vhdDphMpk6nTeZTKisrPT7nlOnTuH999+H0+nEpk2b8Oijj+KZZ57Bf//3f/f4OatXr4bBYPAeGRkZ/WnmwHl6RiABNot3NU2rwwmH0xWaNhAREYWZoK+mcblcSE5Oxssvv4wZM2bg5ptvxm9+8xusW7eux/esWLECZrPZe5SVlQW7mYJaB0REiuetDYjR+kaxOG+EiIgoOPo1ZyQxMREqlQpVVVWdzldVVSElJcXve1JTU6FWq6FSqbznJkyYgMrKStjtdmg0mm7v0Wq10Gq1/Wla4ETGAU2tQFsjIuKzEa1RwWp3oqnNgfjo7m0lIiKi89OvnhGNRoMZM2Zg8+bN3nMulwubN29GXl6e3/fMmTMHJ06cgMvlG+b47rvvkJqa6jeIyK7b8l6uqCEiIgqmfg/TLFu2DK+88grefPNNHD16FPfddx+sVqt3dc2iRYuwYsUK7/X33Xcf6uvrcf/99+O7777Dxo0b8eSTT2LJkiWB+ykCqUsVVm+tkVauqCEiIgqGfi/tvfnmm1FTU4OVK1eisrIS06ZNw8cff+yd1FpaWgql0pdxMjIy8Mknn+DBBx/E1KlTkZ6ejvvvvx8PP/xw4H6KQOpShVUf6dksjz0jREREwdDvMAIAS5cuxdKlS/2+tmXLlm7n8vLysGvXroF8VOh12bmXtUaIiIiCi3vTdNXTzr3sGSEiIgoKhpGuulRh1XPOCBERUVAxjHTVZZgmKVYsMa5ussnUICIiouGNYaSrLsM0qQYdAKDS3CpTg4iIiIY3hpGuvEt7GwEAKQZRkbXC3CZPe4iIiIY5hpGuuiztTXP3jDCMEBERBQfDSFddKrCmuMOIudWBFjtX1BAREQUaw0hXnmEaexPgdCBWp0ase8M89o4QEREFHsNIVzqD73mbGYCvd6SSYYSIiCjgGEa6UkUAWr147l7e6wkj5Y1cUUNERBRoDCP+dJk3kuZeUcOeESIiosBjGPGnSxVWb88IwwgREVHAMYz406UKKwufERERBQ/DiD9dq7AaWfiMiIgoWBhG/PFWYe3cM8IwQkREFHgMI/50qcKaysJnREREQcMw4k+XOSOxOjViWPiMiIgoKBhG/OmyWR7AwmdERETBwjDiT5dhGoDzRoiIiIKFYcSfLsM0QIcwwiqsREREAcUw4k+Xpb0AkOKuwlphYc8IERFRIDGM+NNlaS8ApHHOCBERUVAwjPjjGaZx2gCHGJbhZnlERETBwTDij1YPKFTiuWezPHcV1koO0xAREQUUw4g/CgWgM4jn7qEaT89IY4sDrXanXC0jIiIadhhGetJleW+sNgLRGtFbUsEN84iIiAKGYaQnXZb3KhQK74Z5nMRKREQUOAwjPfGzvNdTa6ScYYSIiChgGEZ64lne26EKa4res7yXwzRERESBwjDSE39VWN3DNOwZISIiChyGkZ70MkzDOSNERESBwzDSEz9VWLlZHhERUeAxjPTE78697v1pOGeEiIgoYBhGeuJnzggLnxEREQUew0hPvMM0jd5Tep2v8BnLwhMREQUGw0hP/AzTKBQKb+9IBTfMIyIiCgiGkZ54h2kaAUnynvbNG2HPCBERUSAwjPTE0zMiOQFbk/e0b0UNe0aIiIgCgWGkJ+pIQKUVz7m8l4iIKGgYRnrjGarpuLyXm+UREREFFMNIb/xUYU3hZnlERDRc1J8Cdr8MvLsQcMj3ey1Ctk8eCnqpwsrN8oiIaMixtwAl24HjnwEnPhNhxKN0JzDqclmaxTDSm16qsDa4C59FuuuOEBERDTqSBNSdAE58LgJIyXagvUMPiDICyPgeMPpKIGG0bM1kGOmNnyqsel0EojQqtNidqLS0ITsxWp62ERERdSVJQEMxcHq7CB6ntwPm0s7X6EeI8DHmKiD7+4BOL09bO2AY6Y2fKqyewmenaqyoMLcyjBARkXw8PR+nv/aFj6byzteoNEBmnggfo/OBpPGAQiFPe3vAMNIbP8M0AJBmiBRhpJGTWImIKISstUDFAfdRCJTuApqrOl+jVAPpM4CsOcDIOUBGLqCNkaW5fcUw0hs/wzSAb0UN96chIqKgkCTAchao+NYXPiq/Fee6UmmBEbN84WPELEATFfo2nweGkd74WdoLAGmswkpERIHkdIjAUbJD9HaU7QZaav1fmzAaSJkKpE4FRswWvSBqXWjbG2AMI73xs7QXAFI8+9NwmIaIiAbC1gyc2SOCR8kO4MxeoL3L/+AqI8T8jtQcd/jIAVImA9pYedocRAwjvfFTgRVgSXgiIuqnlnpRx8OzyqXyoNj7rKPIeDHRNPN74jFlypDv8egrhpHeeIdpzJ1Opxo5TENERL1oqhKho2SHeKw+0v0aY6Y7fOQBIy8CEsYAyvAsjM4w0hvPMI3NDLicgFIUOEvV+wqftTmc0KlZ+IyIKGxJkqhkWrYHKN0hAkjdie7XJY7zTTLNzAMM6aFv6yDFMNIbzzANALSZgah4AIA+MgKRahVaHU5UmtuQxVojREThw9EmltWW7RYBpGw3YK3pcpFCzO8Y2SF8xCTJ0dohgWGkNyo1oIkB7M1iEqs7jCgUCqQaReGzcnMrwwgR0XDlWWJ7Zi9w5hsRPMoLAZej83UqDZA2HciYDYy8GMjM9Q310zkxjJyLzugOI42dTqe6q7BWchIrEdHw0doAlO8HzhYAZ/eJx65FxQAgOlkEj4xcMeE0NQeI0Ia+vcMEw8i5RMYBljPdlvd6NszjihoioiGqtRGoOixWtpS7g4e/uR4KFWCaBIyYKTaVy5gNxGUNupLqQxnDyLmcc3kvV9QQEQ1qLhfQWCJCR9UhoPIQUHUQaCz1f31ctigk5jlSpwLqyNC2OcwwjJzLuUrCs2eEiGjwsNaKZbTVx9yPR0Xvh73J//WGDMA0GUibBqTPFPM+ohNC2mRiGDm3HqqwprmHacpZhZWIKPTsLaJ8evURoOaYCB3VR3suoa7SAMkTANMUscrFNFk8cpLpoMAwci4Jo8RjxYFOp7lZHhFRCNmtYiXL6a9FFdOzBd1XtAAAFGI+R/IEUUo9eYIIHoljxApJGpQYRs4l6xLxePprMe7oro7nmTNSb7Wz8BkRUaDZmoGyXb7wUb4PcLV3viY2VZRM94SO5AmisNgQ27GWGEbOLXUaoIkVE1irDorlWwAMkWoWPiMiOl8uF2AudQ+zuOd4eOZ7dN27xZABZF0sjpFzuKJlGGEYORdVBDAyDzj+KVC8zRtGFAqFqDVSa0UFwwgRUe8kSdTrqDrsm99RfQSoKQIcVv/vMWaKAmKeABI3MrRtppBhGOmLrEtEGDm9Dbhoqfd0qtETRri8l4jIy94C1LhXsVQdEctpq48ALXX+r1dpxPBKsnu4JWmCmFxqzAxtu0k2AwojL7zwAp5++mlUVlYiJycHzz33HGbPnn3O97377ru45ZZbsGDBAnz44YcD+Wh5ZLvnjZTsAJztorcEQIqehc+IKMy1mUV59PJ9onJp5SGxaRyk7tcqlED8KMA0EUie6Ase8Rd4/12l8NTvP/3169dj2bJlWLduHXJzc7F27VrMnTsXRUVFSE5O7vF9p0+fxkMPPYRLLrnkvBosi5SpgM4g/qOrPCCK4MA3iZW1RogoLDjaOlcrPbsPqDvu/9qoRNG7kTxJVC81TRQTTVk8jPzodxhZs2YN7r77btxxxx0AgHXr1mHjxo147bXXsHz5cr/vcTqdWLhwIR5//HFs27YNjY2N59XokFOqxGSpok1i3ognjBhZhZWIhhlJEoXD6k8B9Sfdj6eA2u/EPI+uK1oAwJAJpE8H0i4U8+pMk4CYnv/nlKirfoURu92OgoICrFixwntOqVQiPz8fO3fu7PF9v/3tb5GcnIyf/vSn2LZt2zk/x2azwWazeb+2WCz9aWZwZF3iDiNfARc/AKBjSXj2jBDRECNJImRUFIq5HZ7QUV8M2Hr5Nzc6SYSO9At9j9GJIWs2DU/9CiO1tbVwOp0wmUydzptMJhw7dszve77++mu8+uqrKCws7PPnrF69Go8//nh/mhZ8nnkjpbsApwNQqTlnhIiGBpcLaCgWczoqCsUcj4pvAZu5hzcoxDLa+GwxnyNhlHhMmQoYRnA5LQVcUGcMNTU14bbbbsMrr7yCxMS+J+cVK1Zg2bJl3q8tFgsyMjKC0cS+S54ERMYDrfVinDQzF2lGFj4jokHG6RDLZT2bwlUcEIe/3g6VVgyppE4FEsb4godxJKDWhb7tFLb6FUYSExOhUqlQVVXV6XxVVRVSUlK6XX/y5EmcPn0a8+fP955zuVzigyMiUFRUhFGjRnV7n1arhVar7U/Tgk+pBLLmAEf/CZz+CsjMhSFSDZ1aiTaHC1WWNoxMYK0RIgqh1kb3LrQHfUfNMcBp735thM63IVzqNPGYNJ4l0mlQ6FcY0Wg0mDFjBjZv3ozrrrsOgAgXmzdvxtKlS7tdP378eBw8eLDTuUceeQRNTU3405/+JH9vR39lf1+EkeJtwKX/CYVCgTRDJE7VWlHeyDBCREHQZhFDLPXFvnkdDafFo+Ws//doDWIlS8oUcaROA5LGMXjQoNXvYZply5Zh8eLFmDlzJmbPno21a9fCarV6V9csWrQI6enpWL16NXQ6HSZPntzp/UajEQC6nR8SPPvUlO0G2m1AhBYp7iqslRauqCGi89BcLXo5PIXC6k6IEGKt6f19hkxf6PAcxkzO66Ahpd9h5Oabb0ZNTQ1WrlyJyspKTJs2DR9//LF3UmtpaSmU7s3khp2kcUB0MmCtBs7sBbLmeHfvLW/kJFYi6gNHG1Bb5A4dh30BpLfQEZXom0wa536MvwBIHA1ExoWu7URBMqAJrEuXLvU7LAMAW7Zs6fW9b7zxxkA+cnBQKMT+CIc/EKXhs+YgzSBW1LDwGRF1YreK2hw1Rb6jtkgMt3TdAA4AoBCTR02TxIT5pLHu4JEtii4SDWOsv9tf2ZeIMFK8DbhsubdnhMt7icKMJImqzOYywHwGaCwTczlq3cHDXNbze3VGMZximuQ7kiYAmqhQtZ5oUGEY6a+sS8XjmT2Ao7VD4TPOGSEadlxOETCqDgF1JzsHD/MZwN7U+/ujk8QGcEljxcqVxLFiuDc2lXM6iDpgGOmvhFHiH5KmCqBsD1IN0wFwmIZoyGup7zyPo/qIKH/uaOn9fVGJohCYMUNMJk0cI4JH0jggKj40bSca4hhG+kuhEKtqDr4HnN6G1Nw8AEAdC58RDQ2SJHo4PMXAKg6InWabyv1fH6Fz7y47XlQlNWaI8GHIAPTpHFohCgCGkYHIdoeR4m0wXv4bFj4jGqw8ZdC9waNQPLY2+L/eOFIUBvPO5ZgsJpAq+T8ZRMHEMDIQnnojZwugcLQg1RCJ4lorKswMI0Qh53SIno6G02KlSkOx+/lp8dze3P09ygjR25GaIwqCpUwBkicCOn1o205EABhGBiYuS3TRmsuA0l1I0Ue7wwgnsRIFjcsJ1B4HKr8VvRtVh0XYaCzrYamsm3f/lRzfYZoERAyyLSeIwhjDyEB45o0ceFvMGzFeB4DLe4kCxtEqqpBWHhC7y1Z+K75u7yHwq7TifxLis0VtDu/zLFEcjGXQiQY1hpGBynaHkeJtSM38CQCuqCHqM1uzb5msucy3VNbzteUsILm6v08d7d5zZaoYWkkYLUJHTIrYzJKIhiSGkYHyzBsp348RE8Q/mqfrzrEEkCjcSJIIGGe+Ac4WiG0Uao4BbY3nfm90ki90pE4FUnJELwdDB9GwwzAyUMYM0QXccBoXq78DoMauk3VobLHDGKWRu3VE8rA1A+X7O4SPb4DmKv/X6gyiLodhRIc6HSPEOWMmEJPMwmBEYYJh5HxkXQI0nEaGeS/Gp1yNY5VN2HSwErfmZsrdMqLgcrQBdcfd+618J3o7PM+7Dq8oI8SE0RGzgPSZopfDkMGVK0TkxTByPrIvBfb/DSjehuum34Gn/n0MHxaeZRih4aPdLvZaqTwE1BwFatzBo7HE/5wOANCPAEbMdB+zxOoVdWRo201EQwrDyPnwzBup/BYLFkTj9x8De4rrcbaxFelG/uNLQ0xLvSiDXnlQhI/KgyJ4uBz+r9cZ3WXPx7r3XxkvekD0qSFtNhENfQwj50OfCiSMAeqOI7VxH2ZnxWN3cT0+KizHfZeNkrt1RP55qpJWHnSHD3fwsJzxf73OAJimuEuij3Mf48UEU87pIKIAYBg5X9mXiLHz09tw/fT7sLu4Hh/uP8swQoODrUnU56hy93ZUHRJfO6z+rzeOFKtXUqa6l9BOEfM7GDqIKIgYRs5X1iXA3teA4m2Y9/3fYuU/DqOoqglHKyyYkMoJehRCbWZRmbS8UOzBUl4I1J/0f61n8zfTZHGkThVDLDpDCBtMRCQwjJwvz7yRqoMwSE24fHwSPjlchQ8LzzKMUPBY60RvR8fg0VDs/9rYVBE4UtzBI2UKED8KUPE/fyIaHPiv0fmKSQKSJoiVBqe/xvXTZ+GTw1X4qLAcD88dD6WS3ds0QM52sWql9rhYMlv7ne95a73/9xgzfZu/pU0Tj9GJIWw0EVH/MYwEQvYlIoyc+ByXzbsWsboIVJjbsLu4HnmjEuRuHQ0FTofYf6Vsjziqj4ohFqe9hzcogLiR3YNHVHzo2kxEFCAMI4Ewdi6w52Vg/9+gm/pjXDM5Fev3luEfhWcZRsi/5hrgzB6gbDdQ9g1Qvg9o97O3UUQkkDgaSBzrPsaIx/hRgCYq9O0mIgoChpFAGHUlkHMLcOAd4P07cdMPPsL6vcDGgxV47EeToFOr5G4hycnWJJbOeuZ3lO3xP78jMg4YMRvImC16OZLGigJi3IuFiIY5hpFAUCiAa58Rv2xqjmLG3oeQrv8lzloc2FJUjR9MZhGosNHaILa8rzgggkfFAaDuJACpy4UKsZplxCwgI1cEkITRXEJLRGGJYSRQNNHAj/8KvHwZFKe34Q9po7HQchU+3F/OMDJctTb6VrKU7xdHY4n/a/UjxLyOlKm+UulcRktEBIBhJLCSxgI/ehb4v59iTvnr+L4yGV8cU8Lc6oAhUi136+h8tFncNTzcoaOiEKg/5f/auCz3xFL35NLUHK5oISLqBcNIoE35D6BkB7D3VTyrfRE/aH0S/z5YgZ/M5uZ5Q0ZzDVB5QAy3VH4rHnsqHmYcCaRNdx/TRPCIjAtpc4mIhjqGkWCY+yRwdi8MFQfwvOZZrNmfzTAyWJnPipUsnnkeld8CTRX+rzVkisCRNk2EDy6lJSIKCIaRYFDrgJvehGvdpZhhP47Ly15EeeNMpHEnX3m5nEDVYbGctnSXeDSX+blQASSMEvM7UnNEqfSUHCCay7SJiIKBYSRY4rOhvGEd8O6tuCtiEz7+/H+R9h93y92q8GJrAs7s9YWPM3sBe1PnaxQqIHkikJYjAkfqVFEyXRsjT5uJiMIQw0gwjb8WR7MXY0Lxm7j40CrgiiuB+AvkbtXw1G4XO9KeLRATTM/uA2qOoduSWk0skDELyPgekJkLpM9k8CAikhnDSJCl3rAae5/ehZnKIrS9fRt0P9sshnFo4FwuoO64CBxnC8Scj8qD/kunGzKAzO+JWh6Z3xO9IEoWoSMiGkwYRoLMGBuN97IeR3bJ3UioPQRsuAe45o9ATLLcTRsaJAmwnBWhwxM+Kg4ANkv3ayPjgLQLgfQLgfQZ4nmsKfRtJiKifmEYCYHLZk3DAyeW4E3N76E88g/g+OfA9+4D5vySha+6staKGh5n9/nCh7W6+3URke5VLZ7wcSEQl80KpkREQ5BCkqSudaoHHYvFAoPBALPZDL1eL3dz+q3N4cSs//4cE+0H8WraPxBT9614QWcELlkGzL4HUIfZShtJAhpO++p4VB7seVmtQgWYJnXu8UgaD6iYpYmIBrO+/v7mv+YhoFOrMG9KCt7b244n0q7G6vwSYPPvgNoi4LOVwK4/A99/GJj+/wDVMKzU6mgTk0mrDgGVh0ToqDzof6jFs6w2bboIHukzgJQp4RfWiIjCCHtGQmTHiVrc+pfd0KmV+NcvLsboxCjgwLvAltW+WhfxFwCX/waYdMPQ3am1udrdy3HQFz5qvwMkZ/drVRoxoTRliqjnkTIVME0EtLGhbzcREQVcX39/M4yEiCRJuO3VPfj6RC3Gp8TiwyVzoFOrgHYbsPd14KungZZacXH8KCD7EiAzT6wAMY4cHHMh7FagqVIMpTRVApbyzl/XnfA/vwMQk0tNk0XwSJkqHpPGDc+eICIiAsAwMihVN7Xhmj9tQ22zHYvyRuK3Cyb7XrQ1ieGaHc91H76ITXUvTXWHE9PkwM+XcLmA5irRS9NYKg5zGdBYJh4t5T0Mq3TlHmYxTQZSJrt7OyYD+rTBEaiIiChkGEYGqa3f1WDxa3sAAC/dNgNzJ6V0vqC1ESjZDpTuFFVDywsBl6PzNZoY8Us+OkGsxtEZgUijeNQZxblII6CJBmzNQJvZfTSKo7XR93Vro1g6az7jv05HV+poQJ8qAlJsivtwPzeOBJIniM8lIqKwxzAyiD256She/uoUDJFqbLr/EqT3tmeNvUUU9SrdCZTuFqXN+9RDMQAKJaBPF4XCjBmAMdP3XD9ChBDO5yAioj5iGBnE7O0u3LRuBw6cMWNWVhzeuft7iFD1ccKqywlUHxWHp6ejzezu7ejy3G4VvSienhJPL4r3a/ehTxWhQ5/GORxERBQwDCODXEmdFdc++zWabe345ZVjsOyqsXI3iYiIKKD6+vt7iK4fHfpGJkTjievFBNbnvziOnSfrZG4RERGRPBhGZLRgWjpumjECLgl4YP1+1Fv7MIGUiIhomGEYkdnjCybhgqRoVFls+PX7BzAERs2IiIgCimFEZlGaCDx3y3RoVEp8frQab+w4LXeTiIiIQophZBCYlGbAb66dAABYvekYDp01y9wiIiKi0GEYGSQW5Y3EVRNNsDtdWPr2PlSa2+RuEhERUUgwjAwSCoUCf7hxKtIMOpyua8H1L27H0YogFTcjIiIaRBhGBpG4aA3W/ywPo5NjUGFuw03rdmLb8Rq5m0VERBRUDCODTEZ8FP7v3ouQmx2PZls77nj9G7y3t0zuZhEREQUNw8ggZIhS468/nY0F09LQ7pLw6/e/xZrPvuOyXyIiGpYYRgYpbYQKa2+ehqWXjwYAPLv5OH719wOwt7tkbhkREVFgMYwMYgqFAg/NHYenbpgClVKBD/adxe2v74GlzSF304iIiAKGYWQI+MnsTLy6eCaiNSrsOFmH//jzDpxtbJW7WURERAHBMDJEXDYuGe/dmweTXovvqppx/Qvb8eWxarmbRUREdN4YRoaQSWkGbPj5HIwzxaK6yYY73vgGP3+rAFUWFkgjIqKhi2FkiEkzRmLDkotwz6UXQKVUYNPBSlz5zFa8ueM0nC6utiEioqGHYWQIitJE4L+umYB/Lr0Y0zKMaLa1Y9VHh3H9i9u5rw0REQ05DCND2MQ0Pf7vvovwuwWTEKuNwLdnzPjR81/jd/86AqutXe7mERER9QnDyBCnUipwW14WNv/q+7h2aipcEvDq18XIX7MVnxyulLt5RERE56SQhkBZT4vFAoPBALPZDL1eL3dzBrUtRdV49B+HUFYvlv7OyorDzy8fjcvGJkGhUMjcOiIiCid9/f3NMDIMtdqdePaL43h1WzHsTlGxdVKaHksuH40fTEqBUslQQkREwccwQqiytOGVr07hrd2laHU4AQCjkqLx88tG40fT0qBWcZSOiIiCp6+/vwf02+iFF15AVlYWdDodcnNzsWfPnh6vfeWVV3DJJZcgLi4OcXFxyM/P7/V6ChyTXodHfjgR25dfgV9eMRp6XQRO1ljxq78fwOV/3IK/7SpBmzukEBERyaXfYWT9+vVYtmwZVq1ahX379iEnJwdz585FdbX/aqBbtmzBLbfcgi+//BI7d+5ERkYGrr76apw9e/a8G099Ex+twbKrx2H78ivw8A/GIzFGgzMNrXj0w0O45A9f4k+fH8eZhha5m0lERGGq38M0ubm5mDVrFp5//nkAgMvlQkZGBn7xi19g+fLl53y/0+lEXFwcnn/+eSxatKhPn8lhmsBqtTux/ptSvPzVKZSbRfVWhQKYMyoRN80cgbmTUqBTq2RuJRERDXV9/f0d0Z9varfbUVBQgBUrVnjPKZVK5OfnY+fOnX36Hi0tLXA4HIiPj+/xGpvNBpvN5v3aYrH0p5l0DpEaFW6fk41bc0di08EKvLe3DDtO1uHrE7X4+kQtYnUR+FFOGn48MwNTRxi4CoeIiIKqX2GktrYWTqcTJpOp03mTyYRjx4716Xs8/PDDSEtLQ35+fo/XrF69Go8//nh/mkYDoIlQ4rrp6bhuejrK6lvwfsEZvF9wBmcbW/HW7lK8tbsUY00xuGlGBhZMT0NyrE7uJhMR0TAU0uUUTz31FN59911s2LABOl3Pv9hWrFgBs9nsPcrKykLYyvCUER+FB68ai22/vhxv3ZWLBdPSoI1Q4ruqZjyx6Shyn9yMG/+8Ay9tPYniWqvczSUiomGkXz0jiYmJUKlUqKqq6nS+qqoKKSkpvb73j3/8I5566il8/vnnmDp1aq/XarVaaLXa/jSNAkSpVGDO6ETMGZ0Ic6sD//q2HO8XnMH+0kYUlDSgoKQBq/99DGOSY3D1JBOunpjCoRwiIjovA5rAOnv2bDz33HMAxATWzMxMLF26tMcJrH/4wx/wxBNP4JNPPsH3vve9fjeSE1jlV2FuxedHqvDpkSrsPFmH9g47BKfodbhqogn5E02YnRWPSA0nvxIRURCLnq1fvx6LFy/GSy+9hNmzZ2Pt2rV47733cOzYMZhMJixatAjp6elYvXo1AOD3v/89Vq5cibfffhtz5szxfp+YmBjExMQE9Ieh0DC3OrClqBqfHq7ClqJqWO2+WiUalRIXjjRizqhEzBmTiKnpBkSwuBoRUVgKagXW559/Hk8//TQqKysxbdo0PPvss8jNzQUAXHbZZcjKysIbb7wBAMjKykJJSUm377Fq1So89thjAf1hKPTaHE7sPFmHTw5X4qvvarxLhT1itRHIvSABc0Yn4OLRiRidHMMhHSKiMMFy8BRykiThdF0Lvj5Rix0narHjZB3MrY5O1yTGaDFzZBwuHGnEjJFxmJRmYE0TIqJhimGEZOd0SThSbhHh5GQt9hTXw9bu6nSNRqXEpHQ9LsyMw4yRcbgwMw4pBi4hJiIaDhhGaNBpczjx7Rkz9pU2YF9JA/aVNqC22d7tujSDDpPTDZiUZsCkND0mpeuRotdxeIeIaIhhGKFBT5IklNW3oqC0HvtKxNLhY5UWuPz8jYyP1mBSmh4T0/TekJKVEA2VkgGFiGiwYhihIclqa8e3Z8w4XG7GkXILDpdbcKKmGU4/CUUbocSopBiMNcVgjCkW40yxGGuKxYi4SCgZUoiIZMcwQsNGm8OJosomHC634EiFGYfLLThaYUGbw+X3+ki1CqOTYzDGFIPRyTHITohGVmI0shKiWQOFiCiEGEZoWHO6JJTVt+C7qiYcr27Gd1VN+K6qGSdrmmFv9x9SACDVoENWQjSyk6K9ISU7MQoj4qK4qoeIKMAYRigstTtdKKlvwXF3OCmuteJUrRWna63dlhl3ZdJrkRkfhYz4KGR2OZJitZxAS0TUTwwjRF00WO3eYHK6zhdSSupa0Gxr7/W92ggl0o2RSI+LRJrB/WiMFOeMkUgx6KCJYKVZIqKO+vr7u18b5RENZXHRGsyI1mDGyLhO5yVJQmOLA6X1Ld6jrMPz8sZW2NpdOOXuZfFHoQCSY7VINUQizahDqiESqQbxmGLQIc2oQ3Ksjqt/iIj8YBihsKdQKBAXrUFctAY5GcZurzucLlQ0tuFsY6s4GlpR7nnuPuztLlRZbKiy2FBY5v9zVEoFkmO1SNbrkBSjRVJsh8P9dbL7a85fIaJwwjBCdA5qlRKZCVHITIjy+7okSahttqO8sRUV5lZUmNt8R6P4usrShnaX5D1/LrHaCCTptT2GFs+REK1lbwsRDXkMI0TnSaFQeMOBv54VQKz+qWu2odzchpomG2qabKhu8j2vafacs8He7kKTrR1NNe04VeN/WMhDqRAF4RJjfGEl0fsozsdHa5AQrUVctBraCPa4ENHgwzBCFAIqpQLJeh2S9b3vuyNJEixt7ah1hxNPQOkaWmqabKiz2uCSgNpmO2qb7ThW2XTOdsRoIxDvHpJKiNYgLkqDhBiNO7B4nmu9z6M0/CeCiIKP/9IQDSIKhQKGSDUMkWqMSorp9dp2pwv1LXbUNtlR02xDbYewUtvhsd7qQEOLHU6XhGZbO5pt7Sitb+lTe3RqJRKitUiIEcElPtrzqIax09caxEWrYYzUcFUREfUbwwjREBWhUiI5VqzSOReXS0JTWzvqrDY0tNhR12wXj1Y76pvtqLeK53VWG+qb7ai12mFvd6HN4fJO0u2raI0KxigRTuKiNDBGaWCMVCMuqkOAidYg3n1NfLQGkWoV67gQhTGGEaIwoFQqYIhSwxCl7tP1kiTBane6g4kIKPUtdjRY7WhocaDB2vFr97kWOyQJsNqdsNr7F2C0EcouvSwab3iJi/KEGvEYF6WBMVqNWG0EAwzRMMEwQkTdKBQKxGgjEKON6HEVUVdOl4SmNoc3mDS22NFgdaCx1SGet/iCjDfQWO2wO12wtbv6vNLII0KpgLFDYOkcXLqcixa9M8YoDiMRDUYMI0QUECqlQgzJRGmQjeg+vUeSJLTYnai3+oaNPCGl0RtqHN4g4wk1bQ4X2l2Sd/Juf0RpVN6eFmOXEOPpmTFGqb09NXHRGkRrOIxEFEwMI0QkG4VCgWhtBKK1EciI71sPDCB2cm7w9Lx0GCbq/Nz32Nhih7nVAZcEtNidaOnnMJJapeg8gTfGM+dFg3h3z0vH8BIfpeEO0UT9wDBCREOOTq1yl9yP7PN7PJN4G9y9K97hI/dQkmceTGOLHfXukFNvtcPW7oLDKaHavcy6r7QRSm848fa8RPt6YDquUPIcrLxL4YphhIjCQsdJvFl9HEYCgFa70ztZ1zOcVO8ZTnKHmY7DTI0tdjicEmztLlRa2lBp6fs8GM8QUsegYoxS+3phvL0v4hznwNBwwTBCRNSLSI0K6RqxO3NfeFYidVpp1OV5fYtYUu0JNvVWO9pd0oCGkDxLqY0dVh0ZO0zkjY9WIyFai0R3Vd74KA0iVAwwNLgwjBARBVDHlUh9nQcjSRKabO3eJdSeoNLgHjLyhRlP74wYRnINYCm1QgHERWmQGCO2C/AcCTG+cwkxogpvYoyWc18oJBhGiIhkplAooNepodf1fQjJ5ZJgaXN0W3XU2OKb1NvY6kC91YbaJlHQrs4qasF4emO+q2o+5+dEa1QinMSILQPE/BYtEmN8c10SorWId7/OeS80EAwjRERDkLLDUuq+BhinS0K91Y7aZhvqmsVjbbPYRqCu2Y66ZhFYaptsqG0WNWCsdies9S193kIgSqPqNCk33jNJN8b3PCFG6+2FieKyaQLDCBFR2FApfTtMn4skib2Mat0hpdYdVOqb3dsIWH3bCNRbbai3iom7nnkvZxr6NmykUyu9Q0NJMaKXJTFW490TKcn9WmKMCF4qJYPLcMQwQkRE3SgUCsTq1IjVqZGdeO6eF8+O0x0n6NZ7nvsJL7VNdrQ6nGhzuHCmoW/hRamAd4jIN8/FN+clqcO5hBgNtBEcMhoqGEaIiOi8ddxxuq/DRi32du+u06L3xdcLU+seRqpzDys1toiidZ6hJaDpnN8/VhfRKaB0DjCdz8VwryNZMYwQEZEsojQRyEzo2/5HDqcLDVa7d36LJ5TUubcE6Ph1ndUGh1MUuWtqa8epWus5v782QokE93yWBPfk3ET3qqKOq4s8Q0is7xJYDCNERDToqVVKJOt1SNbrznmtJEmwtLajplNg6dzj0jG8tNidsLW7UG5uQ3kfN2s0Rqm9PSxJsTpvT0tSbOcAkxCjQZSGv2rPhXeIiIiGFYXCV213dHLMOa+32tq981k8K4o8q4vqrXbUWjtM4m0WBerEEmoHTlSfuz2RapW7p0WEFLEc2l1Rt8PzhGgt4qLVYTlkxDBCRERhrT+bNbpcEsytDtHr0iSWRdc0+Xpcapps3sm6Nc022NtdaHU4cbax74XpNCqlewm0exl0tG9JtKc4nWe1UUL08ChMxzBCRETUR0qlQmx+GK3BWFNsr9d6tgbo2tvScWl016PV4YTd2b99jTr2vPgtSucOLfGDeNho8LWIiIhoGOi4NcDIhL6tMGq1O1HnrtviCTD1Vt9E3Tqrr0BdrdU+oJ4XT3jxVdUVvSwLczP73M5AYxghIiIaJCI1KozQRGFE3LmHjLr2vHhqu9RabR2eu4vSNdvPGV5+MDmFYYSIiIj6rr89L57wUt+hh6VjIboRcX3bmToYGEaIiIjCQMfw0pfaLqHEqi1EREQkK4YRIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLIaErv2SpIEALBYLDK3hIiIiPrK83vb83u8J0MijDQ1NQEAMjIyZG4JERER9VdTUxMMBkOPryukc8WVQcDlcqG8vByxsbFQKBQB+74WiwUZGRkoKyuDXq8P2Pcl/3i/Q4v3O7R4v0OL9zu0Bnq/JUlCU1MT0tLSoFT2PDNkSPSMKJVKjBgxImjfX6/X8y9zCPF+hxbvd2jxfocW73doDeR+99Yj4sEJrERERCQrhhEiIiKSVViHEa1Wi1WrVkGr1crdlLDA+x1avN+hxfsdWrzfoRXs+z0kJrASERHR8BXWPSNEREQkP4YRIiIikhXDCBEREcmKYYSIiIhkFdZh5IUXXkBWVhZ0Oh1yc3OxZ88euZs0LHz11VeYP38+0tLSoFAo8OGHH3Z6XZIkrFy5EqmpqYiMjER+fj6OHz8uT2OHgdWrV2PWrFmIjY1FcnIyrrvuOhQVFXW6pq2tDUuWLEFCQgJiYmJw4403oqqqSqYWD21//vOfMXXqVG/xp7y8PPz73//2vs57HTxPPfUUFAoFHnjgAe853u/Aeuyxx6BQKDod48eP974erPsdtmFk/fr1WLZsGVatWoV9+/YhJycHc+fORXV1tdxNG/KsVitycnLwwgsv+H39D3/4A5599lmsW7cOu3fvRnR0NObOnYu2trYQt3R42Lp1K5YsWYJdu3bhs88+g8PhwNVXXw2r1eq95sEHH8Q///lP/P3vf8fWrVtRXl6OG264QcZWD10jRozAU089hYKCAuzduxdXXHEFFixYgMOHDwPgvQ6Wb775Bi+99BKmTp3a6Tzvd+BNmjQJFRUV3uPrr7/2vha0+y2FqdmzZ0tLlizxfu10OqW0tDRp9erVMrZq+AEgbdiwwfu1y+WSUlJSpKefftp7rrGxUdJqtdI777wjQwuHn+rqagmAtHXrVkmSxP1Vq9XS3//+d+81R48elQBIO3fulKuZw0pcXJz0l7/8hfc6SJqamqQxY8ZIn332mfT9739fuv/++yVJ4t/tYFi1apWUk5Pj97Vg3u+w7Bmx2+0oKChAfn6+95xSqUR+fj527twpY8uGv+LiYlRWVna69waDAbm5ubz3AWI2mwEA8fHxAICCggI4HI5O93z8+PHIzMzkPT9PTqcT7777LqxWK/Ly8nivg2TJkiW49tprO91XgH+3g+X48eNIS0vDBRdcgIULF6K0tBRAcO/3kNgoL9Bqa2vhdDphMpk6nTeZTDh27JhMrQoPlZWVAOD33nteo4FzuVx44IEHMGfOHEyePBmAuOcajQZGo7HTtbznA3fw4EHk5eWhra0NMTEx2LBhAyZOnIjCwkLe6wB79913sW/fPnzzzTfdXuPf7cDLzc3FG2+8gXHjxqGiogKPP/44LrnkEhw6dCio9zsswwjRcLVkyRIcOnSo0xgvBd64ceNQWFgIs9mM999/H4sXL8bWrVvlbtawU1ZWhvvvvx+fffYZdDqd3M0JC/PmzfM+nzp1KnJzczFy5Ei89957iIyMDNrnhuUwTWJiIlQqVbcZwFVVVUhJSZGpVeHBc3957wNv6dKl+Ne//oUvv/wSI0aM8J5PSUmB3W5HY2Njp+t5zwdOo9Fg9OjRmDFjBlavXo2cnBz86U9/4r0OsIKCAlRXV+PCCy9EREQEIiIisHXrVjz77LOIiIiAyWTi/Q4yo9GIsWPH4sSJE0H9+x2WYUSj0WDGjBnYvHmz95zL5cLmzZuRl5cnY8uGv+zsbKSkpHS69xaLBbt37+a9HyBJkrB06VJs2LABX3zxBbKzszu9PmPGDKjV6k73vKioCKWlpbznAeJyuWCz2XivA+zKK6/EwYMHUVhY6D1mzpyJhQsXep/zfgdXc3MzTp48idTU1OD+/T6v6a9D2LvvvitptVrpjTfekI4cOSLdc889ktFolCorK+Vu2pDX1NQk7d+/X9q/f78EQFqzZo20f/9+qaSkRJIkSXrqqacko9Eo/eMf/5C+/fZbacGCBVJ2drbU2toqc8uHpvvuu08yGAzSli1bpIqKCu/R0tLivebee++VMjMzpS+++ELau3evlJeXJ+Xl5cnY6qFr+fLl0tatW6Xi4mLp22+/lZYvXy4pFArp008/lSSJ9zrYOq6mkSTe70D71a9+JW3ZskUqLi6Wtm/fLuXn50uJiYlSdXW1JEnBu99hG0YkSZKee+45KTMzU9JoNNLs2bOlXbt2yd2kYeHLL7+UAHQ7Fi9eLEmSWN776KOPSiaTSdJqtdKVV14pFRUVydvoIczfvQYgvf76695rWltbpZ///OdSXFycFBUVJV1//fVSRUWFfI0ewu68805p5MiRkkajkZKSkqQrr7zSG0Qkifc62LqGEd7vwLr55pul1NRUSaPRSOnp6dLNN98snThxwvt6sO63QpIk6fz6VoiIiIgGLiznjBAREdHgwTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrP4/DtZDT0NaIawAAAAASUVORK5CYII="
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABTvklEQVR4nO3deXwTdf4/8FeO5uqR3iel5b5si4J0q3gsVKu4/BBdFxEFWW9xV+26CiuX61HUr4gHirog3iLeu7C4WJVdkMtiVeQ+C/RuadImzdFkfn9MMm1oS5u0Sdryej4e85hkMpl8MnY3Lz6f93xGJgiCACIiIqIeTB7sBhARERF1hIGFiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHUwa7Ad3B6XSitLQU4eHhkMlkwW4OERERdYIgCKivr0dycjLk8rP3ofSJwFJaWorU1NRgN4OIiIh8cOLECfTr1++s+/SJwBIeHg5A/MIRERFBbg0RERF1htFoRGpqqvQ7fjZ9IrC4h4EiIiIYWIiIiHqZzpRzsOiWiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHY2AhIiKiHo+BhYiIiHo8BhYiIiLq8RhYiIiIqMdjYCEiIqIer0/c/JCIiIi6RhAEmG0O1JpsqDHZcNq1rjVZUWOyockhYMHvRgatfQwsREREfZQgCKgz21HdYEVVgxVV9VZUN9hQ3WBFdb1VXDfYUNMghhJrk7PdY6kUcsy/ZkSn7qzsDwwsREREvUyDtQlV9dYWiwXVDTbxcUPz9hqTFXaH4NWx1Uo5YkJViA5TITpULT52LQ6nAKWCgYWIiOic5HQKqLc2wdhoh6HRjlqTGD4q662orLegst6KKmPzY7PN4dXx9doQxIapEBumRly4WlrHhakRG+4ZTHQqRdB6Uc6GgYWIiMgPBEFAVYMVp0434uTpRpyqa8TJ02bUmmwwuIKJsbEJhkY76i12OL3rCIFOpUB8uCt4uMNHWIvnrmASE6aCWqnwz5cMIAYWIiIiLwiC2BtS0yAWpIo1IGIdSKnBFU5cAeVsNSFtUSvl0GtDEKkLQXy4RgwkEWrpcXy4GvER4uNQ9bn1E35ufVsiIqIWHE4BNQ1W1Ll6POrMdtSZm3tA6szi+rTZJl490yCubY7OBRG5DEiM0CAlSot+UTqkRGoRF66GXhsCvTYEEVqlax2CCE0INCG9vyfEXxhYiIioz3I6BVTWW3HytBknTptxslbsATlZZ8aJ2kaU1jWiyduxGJdQlQIxriGXGFcNSFKkBimRWqREaZEapUOiXoMQBac86w4MLERE1GsIggCjpQnVDVbUmmwdLlX11g57Q+QySD0eep1KHJJxDctI27UhUj1ITJgYTtgbElgMLEREFFROp4C6RrvrqhiLa64QK2oabNKcITUmq6tOpPPDMW4KuQxJeg1So3To5xqa6RelRWq0uE6I0EAh73lXxZAnBhYiIupW7l6QOrMNp81i/Ued2YbTJrE+pKrBikpjy4nMvJ8rJEytREyYClE6FWJCVYgKVUmX5bofR4WqEBemRpJeAyWHZXo9BhYiIuoUk7UJlfVWVBgtqDCKPSHi4+aekTqzHXWNdjh8qAuJdgWM2HBxHRPWfFmuew4RDsecuxhYiIjOcXaHE1X1VpQbLag0WlBusKDcaBUfu5ZKoxUN1iavjqtTKRClUyFSF+KxbjlvSHyE+DgmVA2Vkr0g1D4GFiKiPkIQBNSYbCg3WFBa14hyowXGRjvqrU1osDShwbVu+bzeIvaICJ3sEAlVKZAQoUG8a26QhAi167kGsWGuIRlXOOkLk5VRz8HAQkTUgwmCgAZrkzQfiHtda7KizCD2hpQaGlFmsKDMYIHNy4nK3JRyGRIimgNIQoQGiXoNEl3hxL0t7BybrIx6Dv7lEREFiDt8nDbZUWOy4rS5eSKyWrMNtQ02aYKyukY7DK5w4s08ITIZpELTRL0G0aEqhKqUCNMoEaZWIlyjRJg6RHoeplYi2lWkKueVMtSD+RRYli9fjmeffRbl5eXIysrCSy+9hHHjxrW5r91uR0FBAd566y2cOnUKw4YNw9NPP42rrrpK2mfx4sV47LHHPN43bNgw7Nu3z5fmERH5hSAIMNkcMDbaYbTYUW9pkh4bG8XhFeMZ28R183ZfJylTKeWI0oUgUquCXifOEyKGEi2SIzVI0muRpBd7QVgLQn2R14FlzZo1yM/Px4oVK5CdnY1ly5YhLy8P+/fvR3x8fKv958+fj3fffRdvvPEGhg8fjq+++gpTp07F999/j/PPP1/ab9SoUfj666+bG6Zk5w8R+YcgCGi0O6SaDrFXQxxmabU223HadbM6X25Q1xZtiALRZ16Cq1MhRqoBCUGkqw4kUiuueVUMnetkgtDZUitRdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33XcBiD0sn3/+OYqLi336EkajEXq9HgaDARERET4dg4h6J0EQUGuyocJoRUW9BRUGi/S4pkG8sqXB6oDJ2gSTK6CYbE1dCh4hChkiNO77vygRoQ1BuEbZapv4vOV2ccZUrYrhgwjw7vfbq24Mm82GoqIizJs3T9oml8uRm5uLrVu3tvkeq9UKjUbjsU2r1WLz5s0e2w4ePIjk5GRoNBrk5OSgoKAA/fv3b/eYVqtVem40Gr35GkTUw1mbHB43mmu51JjEO+SKc4BYOzX1entkMiBMpUTUGT0d0aEhiA5VS2uxxyNECh5qpRwyGes9iALJq8BSXV0Nh8OBhIQEj+0JCQnt1pvk5eVh6dKluPTSSzFo0CAUFhbi008/hcPhkPbJzs7G6tWrMWzYMJSVleGxxx7DJZdcgt27dyM8PLzVMQsKClrVvBBRz+Ce5dQ9g2nLdU2DDSZbEyx2BxrtDljsTjTaHLDYHdI293ZvxYapEB8uFpq6r3SJDVMjXKNEqEqJUFeBaaha4VoroVMpGDyIegm/F4q88MILuOOOOzB8+HDIZDIMGjQIs2fPxqpVq6R9rr76aulxZmYmsrOzkZaWho8++gi33XZbq2POmzcP+fn50nOj0YjU1FT/fhGic4ggCLA5nLA2OcUgYXOgzjXFuqFRrOmoc11iW2cWH582ifd9qWqw+nxpbUtKucyz1yOseer1mFBx1tMEV5FpXBgnHSPq67wKLLGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwWiwU1NTVITk7G3LlzMXDgwHY/JzIyEkOHDsWhQ4fafF2tVkOtVnvTdKJzliAIqDPbUWpoRGmdBWUe60bUme1SMLE2OWFtEtfeVbe1Fq5RuqZZF2c0jQtXIzZMhTC1EpoQBbQqBdRKca1RyqFVKaANUUATopBqP9j7QURuXgUWlUqFMWPGoLCwENdeey0Asei2sLAQ991331nfq9FokJKSArvdjk8++QR/+MMf2t23oaEBhw8fxi233OJN84j6PKdTQK3Zhqp6KwyNnpfLtryMtt4izt9RWW9FWZ0FjXZHxwc/C51KgUhtCPQ6lVTPEalTIVIrTrXuvsxWDCViOOFVLUTUnbweEsrPz8esWbMwduxYjBs3DsuWLYPJZMLs2bMBADNnzkRKSgoKCgoAANu3b8epU6cwevRonDp1CosXL4bT6cTDDz8sHfOhhx7C5MmTkZaWhtLSUixatAgKhQLTp0/vpq9J1LNZmxyoabBJtR6V9eLdbCvrLa7CUgsq68XXfJ3HIzZMhaQWc3a41zFh4o3k1Eo51EpxrQlRQB0ih1oph0rBAlMiCj6vA8u0adNQVVWFhQsXory8HKNHj8aGDRukQtySkhLI5c1jyRaLBfPnz8eRI0cQFhaGSZMm4Z133kFkZKS0z8mTJzF9+nTU1NQgLi4O48ePx7Zt2xAXF9f1b0gURE0OJ8qNFpw83YhTpxtRZmiU6jzcxajV9VYYLd7dVM49V4d4OW3bl9GGa5SIC1cjJVKLhAgNezyIqFfzeh6WnojzsFCwmKxN4t1sDRacqhNDycnTjTh52oyTp8Wbzzk62SOilMsQG6ZGbLh4tUt8uBrxEa6163FChDjkEqJggSkR9X5+m4eF6FxisTtw8nQjTpw2o6zOgnKDGEDKDBZUuNb1negZCVHIkBKpRb8oHZL0GqnOI9ZVhBrveq7XhnDohYioHQwsdM5yOAWUGy0oqTHjxGkzTtaaceJ0I0pqzThRa0ZlvbXjgwAIUyuRqNcgSa9Bvygd+kVpWyw6xIWpeVM5IqIuYmChPs1id+BErRnHa8w4XmtGSY3JtRaHbDqaITVUpUBqtE6sA9FrkBQhTkzmDigJERqEa0IC9G2IiM5dDCzUJzidAo7XmrGn1IhfSw3YU2bE/vJ6lBksZ31fiEIm9YqkRuuQGqVDarTWtdYhSsdhGiKinoCBhXoda5MDB8obsKfMgF9LjdhTasTeMiNMtrbnGglTK9E/Wof0WB36R4ciLUaHtGgd+sfokKTXQsHhGiKiHo+BhXo0u8OJgxUN+OVUHX46acAvJw3YV26E3dH6yhu1Uo7hieEYmRyBkcl6jEgMx4DYUESHqthLQkTUyzGwUI8hCAKO15ixq+Q0fj5pwM8n6/BrqRHWNu5LE6kLwajkCIxK1mNkUgRGJkdgYGwolLzcl4ioT2JgoaCqabBiy+EabDlYjc2HqnGqrrHVPuFqJTL66ZHRT4+sfpHISNGjX5SWvSZEROcQBhYKqEabAzuP1WLzoWpsPliNPWVGj9dDFDJk9YtEZr9IZKXqkZGiR3pMKC8LJiI6xzGwkN8drTahcG8FvtlXiR+OnW51KfGIpAiMHxyDiwfHYtyAaOhU/LMkIiJP/GWgbmd3OPHDsdP4Zl8FCvdW4ki1yeP1ZL0G44fE4uLBsbhoUCziwtVBaikREfUWDCzULU6bbNh0oApf763ApgNVHlPWhyhkyB4QgwnD43HZsDgMjA1l/QkREXmFgYV8Zmty4pt9Ffi46CS+3V/lcZO/6FAVLh8Wh9wRCbhkSCxngyUioi5hYCGv7Sk1Ym3RCXxRXIpak03aPjwxHBOGx2PiiASMTo3khGxERNRtGFioU06bbPii+BTWFp3Er6XNV/bEhatx3QUpuGFMPwyODw9iC4mIqC9jYKF2CYKAbUdq8c62Y/h6T6V0dU+IQobcEQm4YWw/XDokjpO1ERGR3zGwUCtNDif+vbscb/zvCH4+aZC2j0qOwO/H9MOU0SmIDlUFsYVERHSuYWAhidnWhI92nsDKLUdxolaccVatlOP6Mf0wI7s/RiXrg9xCIiI6VzGwEKrqrXjr+2N4Z9txGBrtAIAoXQhm5qRjZk4aYsI4TwoREQUXA8s57HiNCa9+dxif/ngKNtcNBtNidLj9koH4/QX9oFUpgtxCIiIiEQPLOajeYsfL3x7Cqs1HYXeIc6ec3z8Sd106EFeMTOTlyERE1OMwsJxDnE4BHxedxDNf7Ud1gxUAcOnQOPx5wmCMTY8OcuuIiIjax8ByjvjhWC0e++ce/HJKvOpnYGwoFvxuJH47PD7ILSMiIuoYA0sfV1rXiCX/3ocvfyoFAISrlbg/dwhm5qRDpeT8KURE1DswsPRRFrsDr206glc3HYLF7oRMBtx4YSr+cuUwxPKqHyIi6mUYWPqg/eX1uOudH3CsxgwAGJcejYWTR+K8FM6jQkREvRMDSx/z71/K8Je1P8FscyBJr8Gj14zANRlJkMl45Q8REfVeDCx9hNMpYOnGA3j520MAgIsHx+Dl6RcgilPoExFRH8DA0gcYGu14cE0xvtlXCQC4ffwAzL16OG9KSEREfQYDSy93qLIed75dhCPVJqiVciy5PgNTz+8X7GYRERF1KwaWXmzjngo8uKYYDdYmJOs1eO2Wscjox8JaIiLqexhYeiGnU8BL3xzC818fAACMGxCNV2ZcwMuViYioz2Jg6WWsTQ78+YMf8dWvFQCAWTlpmP+7kQhhvQoREfVhDCy9iCAIWPj5r/jq1wqoFHI8ce15+MOFqcFuFhERkd/59M/y5cuXIz09HRqNBtnZ2dixY0e7+9rtdvz973/HoEGDoNFokJWVhQ0bNnTpmOeqt74/hjU/nIBcBrw2cwzDChERnTO8Dixr1qxBfn4+Fi1ahF27diErKwt5eXmorKxsc//58+fjtddew0svvYQ9e/bg7rvvxtSpU/Hjjz/6fMxz0ZZD1Xh83V4AwNyrh+O3w3jTQiIiOnfIBEEQvHlDdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33Xd9OuaZjEYj9Ho9DAYDIiIivPk6vUJJjRn/b/lm1JntmHp+Cpb+IYsz1xIRUa/nze+3Vz0sNpsNRUVFyM3NbT6AXI7c3Fxs3bq1zfdYrVZoNBqPbVqtFps3b/b5mOeSBmsT7nj7B9SZ7cjqp0fBdRkMK0REdM7xKrBUV1fD4XAgISHBY3tCQgLKy8vbfE9eXh6WLl2KgwcPwul0YuPGjfj0009RVlbm8zGtViuMRqPH0hc5nQL+8lEx9lfUIy5cjdduGQtNiCLYzSIiIgo4v18L+8ILL2DIkCEYPnw4VCoV7rvvPsyePRtyue8fXVBQAL1eLy2pqX2z+PSFwoPSFUGv3TIGiXpNx28iIiLqg7xKDbGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwmkwnHjx/Hvn37EBYWhoEDB/p8zHnz5sFgMEjLiRMnvPkavcK/fynDC4UHAQBPTj0PF/SPCnKLiIiIgserwKJSqTBmzBgUFhZK25xOJwoLC5GTk3PW92o0GqSkpKCpqQmffPIJpkyZ4vMx1Wo1IiIiPJa+ZG+ZEX9Z+xMA4I8XD8ANY/3Qg2S3AKd2AYe+BmoOA46m7v8MIiKibuL1xHH5+fmYNWsWxo4di3HjxmHZsmUwmUyYPXs2AGDmzJlISUlBQUEBAGD79u04deoURo8ejVOnTmHx4sVwOp14+OGHO33Mc0mtyYY73v4BZpsD4wfH4m+Thnf9oKZqoPwXz6X6ACA4mveRhwDRA4CYwUDMINd6iLgOiwdY6EtEREHkdWCZNm0aqqqqsHDhQpSXl2P06NHYsGGDVDRbUlLiUZ9isVgwf/58HDlyBGFhYZg0aRLeeecdREZGdvqY5wq7w4l73yvCydONSIvR4eWbzoeys1PuCwJgrgGqDwI1h8Slcq8YTupL236PNhoISwBOHwOaGsUQU32g9X4hOkAVCijUgFINKDWAUuVaq5u3qyMATYRrrW/x2PVc7XquDhf3ZwgiIqJO8noelp6or8zDsmrzUfz9X3sQqlLgszkXY2hCeNs71hwGyn5qDibuxWJo/+DRA4HEDNeSKa7Dk8TQ4HQCxlMtjnUYqHEFn7oSQHB2/5eVKwFVmCvAhIkhRhUmPg6NB2KHAnFDxbW7nf7gdAJdKAAnIiLfefP7zXsJ9RB2hxP/+N8RAMDfrhnRdlg5fQz45gngl7XtHEUG6FObh3TihonhJGGkGAjaI5cDkaniMui3nq81WcUwY7cATRbxucMqrpssQJPNtbYAViNgMTavLYYzthkAW4N4XGcTYKkTl46owoDYIWJ4ca/DkwG7CbA2iMe01ouL9Ni13d7oWsxiG+1m13PXY6cdiBoApFwApIwBki8AkrIAla7jdhERUcAwsPQQ//q5FKUGC2LD1Lj+gn6eL5prgf89B+x4HXDYxG0pY8VAItWbDBZ7UUK03dswpVo8bndxOsUg0TJYWI2ez42nmoenao+Kr5X+KC7+cPqouOz+RHwuUwDxI4GU85tDTNww8VwQEVFQMLD0AIIg4LVNYu/K7IvTmyeHszcC218D/rcUsLqGewZcBlzxdyB5dHAa21VyuaumpZNDd002MUxU7XeFmIPi2lQl1tVIQ0nhzYv7uSpUXJQasQ4nxLVu+VymAKr2AqeKgFM/iuuGcqDiF3HZ9XZzW8ISxB6syFRA3w/Q9xfX7ueaSNblEBH5CQNLD7DpQBX2ldcjVKXAzdlpgNMB/LwG+OZJwHhS3CkhA7hiMTBo4rn1o6hUib0bccP89xkRScCgCc3PjaWuALNLXJcWi4GxoUJcTv3QTls1YmjRRgHaSNdj13P3Y41e7AVTasV1y0XapgMUId7/d3bYxcJrUzVgrhYfyxSALlossHavQzgBIRH1PgwsPYC7d2X6uP7Ql24CNi4CKnaLL0b0AybMBzL/AMg5LX9ARCSLy4jJ4nNBEIflDCWA4SRQdwIwuJa6E+I2c7VYI9NQLi5dJVcCIa4eIpXrKq2Wz0N0Ym2Qubo5oJyt6LqlkFBXeIkS1+qI5iu+3FeBKVSe2xQhYviRydtZXOHKYXPVN1nbrnly2MTP08UAobGALta1jgFC48SesTODmiCI75fqkFw1SQq1+N9JHdb1891TNFnFYdDGWiAyTSw4Z1E4EQAGlqD7+WQdth6pgVIuw5/CCoF354svqPXApX8Bxt3FfxEHm0wGhMaIS/L5be9jM4vDVI2nxULixjrPxxb3c2OL4l/Xj29Ti8Jg9xVZziaxV8fayRAitVUu9qK4w4CzSfzxM9eKa8EpFisbTGLg6mkUKrHdMnmL89II4CwXM2r0QESKuOhTPB+HJTYPDapCxeMHu4dSuirvoOuKvEPN0xEYTnhelafUivMjRQ90rQe5Hg8UvyPDDJ1DGFiC7LX/ir0rfx5SA/1/F4sbx94m9qroooPWLvKSSgeo0oCoNN+PIQjisI7dLC42k7i0fNzyuTr8jF6KWLHXpL0fMadTDEDmWjE8uUOMtd6zB8TdM9LyKjCHTWyf4HT9oLZ4LC1C+z007u3yELENpprm3iF3D5HdLH5Oe/MGAa6eJ1cdknRlmkFcKvd0fI7P7LkK0Yk1T2edP0gvnmuHtcVVacYzrlBrAGyu8+iwif8dHTbX0tTisb25N649qnBAFwUYTomhrXJP299NoQYi+4tLVJrYI9PysS4m+OHMF06nOPSqCu18rRudExhYguh4jQn//qUMcajDPVV/F/81fN7vgWue653/R0NdI5O5JuRTifUu3U0ud9XX9ND7UtnMzSEGaFHf4y6U1opDUy1Z68UfdqNrOfNxQ0VzEAJ877nqbq1mlh7SfLWfe2Zph12cB6n2KFB7GKg9Ii41h4G642KAqjkoLm0JCRUDjErXPHQHmecwnvtxiLb1JI8ej/XifmebssBiEM9veKI4lK1PcQ2v9hPXZ04VYLeI38tdTO8urK85JP43A8Twpm+n9ywiRQxm3d0D7WgSawdrj4pTSZw+Jhb+15eLtWjhCWLPnXsdluB6nOB5JWGTzXVFpPsfGQ3i37jNJA7vt5x7Sh0hPlaquve7dMTpEM995R7xf2MRSeKUEaGxPbIEgRPHBdGCz3fj/W1HsE7/LIZbfwbihgO3F/atMXminsBhb7+3yj2HT8sf4bYeK9Wtr0qTHoeJP67uUKUIEXuZFCrxsTyk+bFGL/7QKrrw70VHk6uGqkQML3UlwOnjzY/ry7rv3HUXbbQYMnRRze1tb6hPJu/chJUyORCVLv5/Z9yw5nXsULGH5kyCIP63NJaJPXnuteFUczgxnBCDly80keJ3spl8O4ZC1fx3FRYPxI8Qp1iIGy6uu3KblCabeEVk2U9A2c/iumJ3czhsSaYQg2d4kivEuJaIZOC861v/w6ELvPn9ZmAJkpoGKy5a8g3y8Q7uUq4T/8/uzm/FidGIiLrCbhGLwQ0l4g9Vy6E7j+E8QfxXtt189rBmMYj7uYfM2uyFiRB/6OrLxR4KQ4ueLrup7XZq9EDsMM9JIWOHisNaTVbxir32es+Mp8S2tSeyPxA3QvyM+jJxMZa135aWFGqxDVHprmWA+MNtMQD1Fc1XDNaXNz929+K1dSyVa+gxRCc+djo8hxObGjtuEyCGvviRriAzQmybs6lFTVwbE2Ra6sRgUrFHnCjzTCGh4uSiTod4jhoq2g+LciUwv6pba6c4020v8PbW4/itcxvuUq0TN1y7nGGFiLpHiAaIHSwuwSYI4g+9O2iYa8S5i2KHileGtddjoAgRb88RN7T945qqgKp94nBS1T6gcp+4Nle7ep9K2n6vRi8OfYQnNl8V2DKceHt1liCIdWENla7bjrS4sq8zPWmOJrEGytrQPGO34aR4P7jKPeK69ohYc3Z8s7j4QhMJJGWKs3knjRbX0QM9h38cTYCp0tX75A56peLaYQtqoTcDSxCYbU3Y9P0WvBPymrjhoj8BI6cEt1FERP4gk7nmI4oEEkZ173HD4sVlwKWer5mqXSFmrzg80zKchCe2PVzU1bboon2/UEKhbF1fljrOcx+bWazxaRlijKfEocqWdV5n1n6pwsRhsqQssdepoyElhbI5xPUwDCxB8Nm2A3jG8SzC5Y0Q0i6GbOLiYDeJiKjvCHVdOZd+cbBb0n1UOnGG8946y3k34EX8AdbU5EDCpr9iqPwUzOo4yH7/ZteK74iIiM4BDCwBtvfL/0OuYzPsUEAx7S3xcjgiIiI6KwaWABKOb8WIn58GAHw/4AGoB/ah7koiIiI/YmAJlPoK2D6cBSUcWO/MQeb1jwS7RURERL0GA0ugbFwIdWMFDjhTUHz+44gKU3f8HiIiIgLAwBIY9eVw7v4EAPBw09245bJuvLSPiIjoHMDAEgg/rILcacdO51CkZlyC1Ghdx+8hIiIiCQOLvzVZgR9WAQBWN12FazKSgtwgIiKi3oeBxd92fwqYqlAqROMr51ic3z8y2C0iIiLqdRhY/EkQgO0rAADvNl2B2IgwJER0863QiYiIzgEMLP50YjtQVowmuRofOH6L0amRwW4RERFRr8TA4k+u3pXtYRNxGhHIYmAhIiLyCQOLvxhOAnu+BAC8ZrkCAJCVqg9mi4iIiHotBhZ/2bkSEBywpV6E/xoTIJMBmf0ig90qIiKiXomBxR/sjUDRagDAntSbAABD4sMQpuZdmYmIiHzBwOIPv6wFGmsBfX8UOscAALLYu0JEROQzBpbuJgjANrHYFuPuwI8n6wEAozn/ChERkc8YWLrbsc1A5a9AiA7O0bfgp5N1ANjDQkRE1BUMLN3NdSkzsm7EUXMI6i1NUCvlGJYYHtx2ERER9WIMLN3p9DFg/3rx8bi7UFxSBwDISNEjRMFTTURE5Cv+inannf8ABCcw8LdA/PDm4SBOGEdERNQlDCzdxWYCdr0tPs6+GwDw04k6AAwsREREXeVTYFm+fDnS09Oh0WiQnZ2NHTt2nHX/ZcuWYdiwYdBqtUhNTcWDDz4Ii8Uivb548WLIZDKPZfjw4b40LXh++hCwGICoAcCQK2GxO7CnzAgAGM2CWyIioi7xeiazNWvWID8/HytWrEB2djaWLVuGvLw87N+/H/Hx8a32f//99zF37lysWrUKF110EQ4cOIBbb70VMpkMS5culfYbNWoUvv766+aGKXvRJGuCAGx/TXycfRcgl2PvydOwOwREh6qQGq0NbvuIiIh6Oa97WJYuXYo77rgDs2fPxsiRI7FixQrodDqsWrWqzf2///57XHzxxbjpppuQnp6OK6+8EtOnT2/VK6NUKpGYmCgtsbGxvn2jYDjyLVC9H1CFAaNnAGgxHNRPD5lMFsTGERER9X5eBRabzYaioiLk5uY2H0AuR25uLrZu3drmey666CIUFRVJAeXIkSNYv349Jk2a5LHfwYMHkZycjIEDB2LGjBkoKSlptx1WqxVGo9FjCaod/xDXo2cAmggAwE8nDQBYv0JERNQdvBp3qa6uhsPhQEJCgsf2hIQE7Nu3r8333HTTTaiursb48eMhCAKamppw9913429/+5u0T3Z2NlavXo1hw4ahrKwMjz32GC655BLs3r0b4eGt5y8pKCjAY4895k3T/evENnGdNU3aVOzqYRnNwEJERNRlfr9K6LvvvsNTTz2FV155Bbt27cKnn36KdevW4fHHH5f2ufrqq3HDDTcgMzMTeXl5WL9+Perq6vDRRx+1ecx58+bBYDBIy4kTJ/z9NdpnqgHMNeLjOLFQuM5sw9FqEwDOcEtERNQdvOphiY2NhUKhQEVFhcf2iooKJCYmtvmeBQsW4JZbbsHtt98OAMjIyIDJZMKdd96JRx99FHJ568wUGRmJoUOH4tChQ20eU61WQ61We9N0/6neL671/QFVKADgZ9dwUFqMDlGhqmC1jIiIqM/wqodFpVJhzJgxKCwslLY5nU4UFhYiJyenzfeYzeZWoUShUAAABEFo8z0NDQ04fPgwkpKSvGlecFS5AkvcUGkTh4OIiIi6l9fXDufn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUAgMmTJ2Pp0qU4//zzkZ2djUOHDmHBggWYPHmyFFweeughTJ48GWlpaSgtLcWiRYugUCgwffr0bvyqflJ9QFzHDpM2NV8hFBn49hAREfVBXgeWadOmoaqqCgsXLkR5eTlGjx6NDRs2SIW4JSUlHj0q8+fPh0wmw/z583Hq1CnExcVh8uTJePLJJ6V9Tp48ienTp6OmpgZxcXEYP348tm3bhri4uG74in7mDiyuHhZBEDglPxERUTeTCe2Ny/QiRqMRer0eBoMBERERgf3w5zMAQwkwewOQloMTtWZc8sy3UMpl2P1YHjQhisC2h4iIqJfw5veb9xLqCptJDCsAECv2sLh7V0YkRTCsEBERdRMGlq6oPiiudTFAaAyAljc81AepUURERH0PA0tXtFFwW8yCWyIiom7HwNIVZ1zS3ORw4pdT4hws5/ePDFKjiIiI+h4Glq5wTxrn6mE5UNEAi92JMLUSA2PDgtgwIiKivoWBpSvcNSyuHhb3cFBmPz3kct6hmYiIqLswsPjK0QTUHBYfu3pYfuIMt0RERH7BwOKr00cBpx0I0QERKQDACeOIiIj8hIHFV+6C29ghgFwOk7UJByrqAbCHhYiIqLsxsPjqjILbX04Z4BSAJL0GCRGaIDaMiIio72Fg8VWV5z2EeMNDIiIi/2Fg8dUZPSysXyEiIvIfBhZfCEKLS5rFwFJcUgeA9StERET+wMDiC2MpYGsAZAogagAqjRaUGiyQyYCMfryHEBERUXdjYPGFezgoeiCgVOGnk+J0/EPiwxCmVgaxYURERH0TA4svpIJb13DQidMAWHBLRETkLwwsvpAKbt1XCIk9LKN5w0MiIiK/YGDxxRk9LKWGRgDAoDje8JCIiMgfGFh8cUYPi9nqAADWrxAREfkJA4u3zLWAqUp87AosJlsTAECrUgSrVURERH0aA4u33POvRKQA6jAIgoBGm9jDEqpiDwsREZE/MLB464zhIJvDiSanAIA9LERERP7CwOIt912aXQW37voVANAxsBAREfkFA4u3ql1XCLkLbu1iYFEp5QhR8HQSERH5A39hvdWqh0UsuGXvChERkf8wsHjD3gjUlYiPXXdpNrPgloiIyO8YWLxRfRCAAGijgNBYAM2XNLOHhYiIyH8YWLzRsn5FJgPQXHTLwEJEROQ/DCzeOKPgFmguutVxSIiIiMhvGFi8cUbBLdBcdBuqZg8LERGRvzCweEPqYWkOLCZX0a2WPSxERER+w8DSWY4moOaQ+DiueUio0VV0G8oaFiIiIr9hYOmsuuOAwwYotYC+v7S5uYeFgYWIiMhfGFg6y12/EjsYkDefNqmGhUNCREREfsPA0lln3PTQzT1xnI5Ft0RERH7jU2BZvnw50tPTodFokJ2djR07dpx1/2XLlmHYsGHQarVITU3Fgw8+CIvF0qVjBlz1QXHdouAWaBFYQhhYiIiI/MXrwLJmzRrk5+dj0aJF2LVrF7KyspCXl4fKyso293///fcxd+5cLFq0CHv37sXKlSuxZs0a/O1vf/P5mEEhXdJ8Zg+La6ZbNYeEiIiI/MXrwLJ06VLccccdmD17NkaOHIkVK1ZAp9Nh1apVbe7//fff4+KLL8ZNN92E9PR0XHnllZg+fbpHD4q3xww4QWjzkmagueiWNSxERET+41VgsdlsKCoqQm5ubvMB5HLk5uZi69atbb7noosuQlFRkRRQjhw5gvXr12PSpEk+H9NqtcJoNHosflVfDliNgEwOxAzyeMnMewkRERH5nVfdAtXV1XA4HEhISPDYnpCQgH379rX5nptuugnV1dUYP348BEFAU1MT7r77bmlIyJdjFhQU4LHHHvOm6V3jLriNGgAo1R4vSTUsDCxERER+4/erhL777js89dRTeOWVV7Br1y58+umnWLduHR5//HGfjzlv3jwYDAZpOXHiRDe2uA1VruGguGGtXnLf/DCUNSxERER+49WvbGxsLBQKBSoqKjy2V1RUIDExsc33LFiwALfccgtuv/12AEBGRgZMJhPuvPNOPProoz4dU61WQ61Wt/maX0iXNA9p9ZLJNSTEieOIiIj8x6seFpVKhTFjxqCwsFDa5nQ6UVhYiJycnDbfYzabIZd7foxCIf64C4Lg0zEDTpo0zrOHRRAENLLoloiIyO+8/pXNz8/HrFmzMHbsWIwbNw7Lli2DyWTC7NmzAQAzZ85ESkoKCgoKAACTJ0/G0qVLcf755yM7OxuHDh3CggULMHnyZCm4dHTMoHPPwXLGkJDN4USTUwDAieOIiIj8yevAMm3aNFRVVWHhwoUoLy/H6NGjsWHDBqlotqSkxKNHZf78+ZDJZJg/fz5OnTqFuLg4TJ48GU8++WSnjxlUFgPQUC4+PmNIyF2/AnDiOCIiIn+SCYIgBLsRXWU0GqHX62EwGBAREdG9Bz+xE1iZC4QnAX/xvGrpVF0jLl7yDVRKOQ48cXX3fi4REVEf583vN+8l1JF27iEENN/4kJc0ExER+RcDS0ekKflbX9LMWW6JiIgCg4GlI9KU/G30sHCWWyIiooBgYOlI1dmGhDjLLRERUSAwsJyN3QLUHRcftzXLrd0dWDgkRERE5E/8pT0buxnImg4YTgBhrS+xdhfdhnIOFiIiIr9iYDkbXTRw7SvtvuwuutWyh4WIiMivOCTUBY2uottQ1rAQERH5FQNLF7h7WFjDQkRE5F8MLF3AieOIiIgCg4GlC8zuHhYW3RIREfkVA0sXSIGFNz4kIiLyKwaWLjC5Z7pVs4aFiIjInxhYusDMewkREREFBANLF/BeQkRERIHBwNIFUg0LAwsREZFfMbB0gfvmh6GsYSEiIvIrBpYucBfdatnDQkRE5FcMLD4SBAGNLLolIiIKCAYWH9kcTjQ5BQCcOI6IiMjfGFh85K5fAThxHBERkb8xsPjIbBcDi0oph1LB00hERORP/KX1EW98SEREFDgMLD4yseCWiIgoYBhYfMRZbomIiAKHgcVH7qJbBhYiIiL/Y2DxkbvoVschISIiIr9jYPGRu+g2lHOwEBER+R0Di4/cRbda9rAQERH5HQOLjxpdRbehrGEhIiLyOwYWH7l7WFjDQkRE5H8MLD7ixHFERESBw8DiI7O7h4VFt0RERH7HwOIjM2e6JSIiChgGFh+ZXEW3Wg4JERER+Z1PgWX58uVIT0+HRqNBdnY2duzY0e6+l19+OWQyWavlmmuukfa59dZbW71+1VVX+dK0gGEPCxERUeB4/Wu7Zs0a5OfnY8WKFcjOzsayZcuQl5eH/fv3Iz4+vtX+n376KWw2m/S8pqYGWVlZuOGGGzz2u+qqq/Dmm29Kz9VqtbdNCyjeS4iIiChwvO5hWbp0Ke644w7Mnj0bI0eOxIoVK6DT6bBq1ao294+OjkZiYqK0bNy4ETqdrlVgUavVHvtFRUX59o0ChPcSIiIiChyvAovNZkNRURFyc3ObDyCXIzc3F1u3bu3UMVauXIkbb7wRoaGhHtu/++47xMfHY9iwYbjnnntQU1PT7jGsViuMRqPHEmjSkJCaQ0JERET+5lVgqa6uhsPhQEJCgsf2hIQElJeXd/j+HTt2YPfu3bj99ts9tl911VV4++23UVhYiKeffhqbNm3C1VdfDYfD0eZxCgoKoNfrpSU1NdWbr9EtWHRLREQUOAHtHli5ciUyMjIwbtw4j+033nij9DgjIwOZmZkYNGgQvvvuO0ycOLHVcebNm4f8/HzpudFoDGhoEQQBjSy6JSIiChivelhiY2OhUChQUVHhsb2iogKJiYlnfa/JZMKHH36I2267rcPPGThwIGJjY3Ho0KE2X1er1YiIiPBYAsnmcKLJKQDgxHFERESB4FVgUalUGDNmDAoLC6VtTqcThYWFyMnJOet7165dC6vViptvvrnDzzl58iRqamqQlJTkTfMCxl1wCwC6EAYWIiIif/P6KqH8/Hy88cYbeOutt7B3717cc889MJlMmD17NgBg5syZmDdvXqv3rVy5Etdeey1iYmI8tjc0NOCvf/0rtm3bhmPHjqGwsBBTpkzB4MGDkZeX5+PX8i+zXQwsKqUcSgXn3iMiIvI3rwswpk2bhqqqKixcuBDl5eUYPXo0NmzYIBXilpSUQC73/BHfv38/Nm/ejP/85z+tjqdQKPDzzz/jrbfeQl1dHZKTk3HllVfi8ccf77FzsbhvfBjKglsiIqKAkAmCIAS7EV1lNBqh1+thMBgCUs9SfKIO1y7fgpRILbbMneD3zyMiIuqLvPn95niGDzjLLRERUWAxsPiAs9wSEREFFgOLD0xSDwvnYCEiIgoEBhYfSJPGcQ4WIiKigGBg8YHJFVi07GEhIiIKCAYWHzTaeFkzERFRIDGw+MDdw8IaFiIiosBgYPGBe+I4XiVEREQUGAwsPjC7e1hYdEtERBQQDCw+cAeWUA4JERERBQQDiw/c87BoOSREREQUEAwsPmAPCxERUWAxsPiA9xIiIiIKLAYWH/BeQkRERIHFwOIDaUhIzSEhIiKiQGBg8QGLbomIiAKLgcVLgiA03/yQRbdEREQBwcDiJZvDiSanAIATxxEREQUKA4uX3AW3AKALYWAhIiIKBAYWL5ntYmBRKeVQKnj6iIiIAoG/uF5y3/gwlAW3REREAcPA4iWT+8aHLLglIiIKGAYWL3GWWyIiosBjYPESZ7klIiIKPAYWL5mkHhYOCREREQUKA4uXpEnjOAcLERFRwDCweMlddKtlDwsREVHAMLB4iZc1ExERBR4Di5fcE8exhoWIiChwGFi85O5h4VVCREREgcPA4iWze+I4Ft0SEREFDAOLl9yBJZRDQkRERAHDwOIl9zwsWg4JERERBQwDi5fYw0JERBR4DCxeku4lxBoWIiKigPEpsCxfvhzp6enQaDTIzs7Gjh072t338ssvh0wma7Vcc8010j6CIGDhwoVISkqCVqtFbm4uDh486EvT/E66l1AIAwsREVGgeB1Y1qxZg/z8fCxatAi7du1CVlYW8vLyUFlZ2eb+n376KcrKyqRl9+7dUCgUuOGGG6R9nnnmGbz44otYsWIFtm/fjtDQUOTl5cFisfj+zfxEGhJSc0iIiIgoULwOLEuXLsUdd9yB2bNnY+TIkVixYgV0Oh1WrVrV5v7R0dFITEyUlo0bN0Kn00mBRRAELFu2DPPnz8eUKVOQmZmJt99+G6Wlpfj888+79OX8gUW3REREgedVYLHZbCgqKkJubm7zAeRy5ObmYuvWrZ06xsqVK3HjjTciNDQUAHD06FGUl5d7HFOv1yM7O7vdY1qtVhiNRo8lEARBYNEtERFREHgVWKqrq+FwOJCQkOCxPSEhAeXl5R2+f8eOHdi9ezduv/12aZv7fd4cs6CgAHq9XlpSU1O9+Ro+szmccDgFACy6JSIiCqSAXiW0cuVKZGRkYNy4cV06zrx582AwGKTlxIkT3dTCs3MX3AIsuiUiIgokrwJLbGwsFAoFKioqPLZXVFQgMTHxrO81mUz48MMPcdttt3lsd7/Pm2Oq1WpERER4LIHgvvGhSimHUsErwomIiALFq19dlUqFMWPGoLCwUNrmdDpRWFiInJycs7537dq1sFqtuPnmmz22DxgwAImJiR7HNBqN2L59e4fHDDT3jQ9DWXBLREQUUF5Xjubn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUe71u5ciWuvfZaxMTEeGyXyWR44IEH8MQTT2DIkCEYMGAAFixYgOTkZFx77bW+fzM/MLlvfMiCWyIiooDy+pd32rRpqKqqwsKFC1FeXo7Ro0djw4YNUtFsSUkJ5HLPjpv9+/dj8+bN+M9//tPmMR9++GGYTCbceeedqKurw/jx47FhwwZoNBofvpL/SLPcsoeFiIgooGSCIAjBbkRXGY1G6PV6GAwGv9azfL2nAre//QOyUiPxxZyL/fY5RERE5wJvfr9ZOeoF96RxvEKIiIgosBhYvNAoTcvPwEJERBRIDCxecBfdall0S0REFFAMLF7gZc1ERETBwcDiBffEcbysmYiIKLAYWLzg7mHhZc1ERESBxcDiBfedmnnjQyIiosBiYPGCO7CEckiIiIgooBhYvOCeh0XLISEiIqKAYmDxAntYiIiIgoOBxQvSvYRYw0JERBRQDCxeMFtdRbecmp+IiCigGFi8IA0JqTkkREREFEgMLF5g0S0REVFwMLB0kiAILLolIiIKEgaWTrI5nHA4BQAsuiUiIgo0BpZOchfcAiy6JSIiCjQGlk5y3/hQpZRDqeBpIyIiCiT+8naS+8aHoSy4JSIiCjgGlk4yuW98yIJbIiKigGNg6SRpllv2sBAREQUcA0snSbPcctI4IiKigGNg6ST3pHG8QoiIiCjwGFg6qVGalp+BhYiIKNAYWDqJRbdERETBw8DSSe7Lmll0S0REFHgMLJ3knjiOPSxERESBx8DSSexhISIiCh4Glk6SalhYdEtERBRwDCydJF0lxCEhIiKigGNg6ST3PCxaDgkREREFHANLJ5nZw0JERBQ0DCydJN1LiDUsREREAcfA0knSvYQ4NT8REVHAMbB0kjQkxJsfEhERBZxPgWX58uVIT0+HRqNBdnY2duzYcdb96+rqMGfOHCQlJUGtVmPo0KFYv3699PrixYshk8k8luHDh/vSNL+Rbn7IolsiIqKA87q7YM2aNcjPz8eKFSuQnZ2NZcuWIS8vD/v370d8fHyr/W02G6644grEx8fj448/RkpKCo4fP47IyEiP/UaNGoWvv/66uWHKntOTIQiC1MPCmW6JiIgCz+tf36VLl+KOO+7A7NmzAQArVqzAunXrsGrVKsydO7fV/qtWrUJtbS2+//57hISEAADS09NbN0SpRGJiorfNCQibwwmHUwDAolsiIqJg8GpIyGazoaioCLm5uc0HkMuRm5uLrVu3tvmeL7/8Ejk5OZgzZw4SEhJw3nnn4amnnoLD4fDY7+DBg0hOTsbAgQMxY8YMlJSUtNsOq9UKo9HosfiTu+AWYNEtERFRMHgVWKqrq+FwOJCQkOCxPSEhAeXl5W2+58iRI/j444/hcDiwfv16LFiwAM899xyeeOIJaZ/s7GysXr0aGzZswKuvvoqjR4/ikksuQX19fZvHLCgogF6vl5bU1FRvvobX3PUrKqUcSgXrlImIiALN7wUZTqcT8fHxeP3116FQKDBmzBicOnUKzz77LBYtWgQAuPrqq6X9MzMzkZ2djbS0NHz00Ue47bbbWh1z3rx5yM/Pl54bjUa/hpbmafnZu0JERBQMXgWW2NhYKBQKVFRUeGyvqKhot/4kKSkJISEhUCiaf+xHjBiB8vJy2Gw2qFSqVu+JjIzE0KFDcejQoTaPqVaroVarvWl6l5hYcEtERBRUXo1vqFQqjBkzBoWFhdI2p9OJwsJC5OTktPmeiy++GIcOHYLT6ZS2HThwAElJSW2GFQBoaGjA4cOHkZSU5E3z/MbMS5qJiIiCyuuCjPz8fLzxxht46623sHfvXtxzzz0wmUzSVUMzZ87EvHnzpP3vuece1NbW4v7778eBAwewbt06PPXUU5gzZ460z0MPPYRNmzbh2LFj+P777zF16lQoFApMnz69G75i10mz3HLSOCIioqDw+hd42rRpqKqqwsKFC1FeXo7Ro0djw4YNUiFuSUkJ5PLmHJSamoqvvvoKDz74IDIzM5GSkoL7778fjzzyiLTPyZMnMX36dNTU1CAuLg7jx4/Htm3bEBcX1w1fseukSeN4hRARkQeHwwG73R7sZlAPdmZZiK9kgiAI3dCeoDIajdDr9TAYDIiIiOj243+4owRzP/0FuSPi8Y9ZF3b78YmIehtBEFBeXo66urpgN4V6gcjISCQmJkImk3ls9+b3m2McncCiWyIiT+6wEh8fD51O1+qHiAhwzRRvNqOyshIAulSbyl/gTjBbWXRLROTmcDiksBITExPs5lAPp9VqAQCVlZWIj4/3eXiIs6B1gtnOHhYiIjd3zYpOpwtyS6i3cP+tdKXeiYGlE9jDQkTUGoeBqLO642+FgaUTpBoW3viQiIgoKBhYOqF5an4OCREREQUDA0snuOdh0XJIiIiIKCgYWDrBzB4WIiLyA06613kMLJ0g3UuINSxERL3ahg0bMH78eERGRiImJga/+93vcPjwYel198zr0dHRCA0NxdixY7F9+3bp9X/+85+48MILodFoEBsbi6lTp0qvyWQyfP755x6fFxkZidWrVwMAjh07BplMhjVr1uCyyy6DRqPBe++9h5qaGkyfPh0pKSnQ6XTIyMjABx984HEcp9OJZ555BoMHD4ZarUb//v3x5JNPAgAmTJiA++67z2P/qqoqqFQqj3v/9XbsMugE6V5CnJqfiKgVQRDQ6Jr+IdC0IQqvrkAxmUzIz89HZmYmGhoasHDhQkydOhXFxcUwm8247LLLkJKSgi+//BKJiYnYtWuXdPPedevWYerUqXj00Ufx9ttvw2azYf369V63ee7cuXjuuedw/vnnQ6PRwGKxYMyYMXjkkUcQERGBdevW4ZZbbsGgQYMwbtw4AMC8efPwxhtv4Pnnn8f48eNRVlaGffv2AQBuv/123HfffXjuueegVqsBAO+++y5SUlIwYcIEr9vXUzGwdII0JMSbHxIRtdJod2Dkwq+C8tl7/p7n1RxZ119/vcfzVatWIS4uDnv27MH333+Pqqoq7Ny5E9HR0QCAwYMHS/s++eSTuPHGG/HYY49J27Kysrxu8wMPPIDrrrvOY9tDDz0kPf7Tn/6Er776Ch999BHGjRuH+vp6vPDCC3j55Zcxa9YsAMCgQYMwfvx4AMB1112H++67D1988QX+8Ic/AABWr16NW2+9tU9des4hoU6Qbn7Iolsiol7t4MGDmD59OgYOHIiIiAikp6cDEG/cW1xcjPPPP18KK2cqLi7GxIkTu9yGsWPHejx3OBx4/PHHkZGRgejoaISFheGrr75CSUkJAGDv3r2wWq3tfrZGo8Ett9yCVatWAQB27dqF3bt349Zbb+1yW3sSdhl0QBAEqYeFM90SEbWmDVFgz9/zgvbZ3pg8eTLS0tLwxhtvIDk5GU6nE+eddx5sNps0hXy7n9XB6zKZDGfeT7itotrQ0FCP588++yxeeOEFLFu2DBkZGQgNDcUDDzwAm83Wqc8FxGGh0aNH4+TJk3jzzTcxYcIEpKWldfi+3oQ9LB2wOZxwOMU/QBbdEhG1JpPJoFMpg7J4M+RRU1OD/fv3Y/78+Zg4cSJGjBiB06dPS69nZmaiuLgYtbW1bb4/MzPzrEWscXFxKCsrk54fPHgQZrO5w3Zt2bIFU6ZMwc0334ysrCwMHDgQBw4ckF4fMmQItFrtWT87IyMDY8eOxRtvvIH3338ff/zjHzv83N6GgaUD7oJbgEW3RES9WVRUFGJiYvD666/j0KFD+Oabb5Cfny+9Pn36dCQmJuLaa6/Fli1bcOTIEXzyySfYunUrAGDRokX44IMPsGjRIuzduxe//PILnn76aen9EyZMwMsvv4wff/wRP/zwA+6++26EhIR02K4hQ4Zg48aN+P7777F3717cddddqKiokF7XaDR45JFH8PDDD+Ptt9/G4cOHsW3bNqxcudLjOLfffjuWLFkCQRA8rl7qKxhYOuCuX1Ep5VAqeLqIiHoruVyODz/8EEVFRTjvvPPw4IMP4tlnn5VeV6lU+M9//oP4+HhMmjQJGRkZWLJkiXR34csvvxxr167Fl19+idGjR2PChAnYsWOH9P7nnnsOqampuOSSS3DTTTfhoYce6tQNIufPn48LLrgAeXl5uPzyy6XQ1NKCBQvwl7/8BQsXLsSIESMwbdo0VFZWeuwzffp0KJVKTJ8+HRqNpgtnqmeSCWcOuPVCRqMRer0eBoMBERER3XrsgxX1uOL5/yJKF4IfF17ZrccmIuqNLBYLjh49igEDBvTJH8be6tixYxg0aBB27tyJCy64INjN8dDe34w3v9+sIu2AiQW3RETUg9ntdtTU1GD+/Pn4zW9+0+PCSnfhGEcHzFZe0kxERD3Xli1bkJSUhJ07d2LFihXBbo7fsNugA9IlzZw0joiIeqDLL7+81eXUfRF7WDogTRrHK4SIiIiChoGlA43StPwMLERERMHCwNIBFt0SEREFHwNLB1h0S0REFHwMLB0w29nDQkREFGwMLB1w97CwhoWIiCh4GFg64K5h0XJIiIjonJeeno5ly5YFuxnnJAaWDkhXCXFIiIiIKGgYWDrgnoeFPSxERNSbORwOOJ3OYDfDZwwsHTBb2cNCRNQXvP7660hOTm71oz1lyhT88Y9/xOHDhzFlyhQkJCQgLCwMF154Ib7++mufP2/p0qXIyMhAaGgoUlNTce+996KhocFjny1btuDyyy+HTqdDVFQU8vLycPr0aQCA0+nEM888g8GDB0OtVqN///548sknAQDfffcdZDIZ6urqpGMVFxdDJpPh2LFjAIDVq1cjMjISX375JUaOHAm1Wo2SkhLs3LkTV1xxBWJjY6HX63HZZZdh165dHu2qq6vDXXfdhYSEBGg0Gpx33nn417/+BZPJhIiICHz88cce+3/++ecIDQ1FfX29z+erIwwsHTDbXZc1s+iWiKhtggDYTMFZvJiS/oYbbkBNTQ2+/fZbaVttbS02bNiAGTNmoKGhAZMmTUJhYSF+/PFHXHXVVZg8eTJKSkp8Oi1yuRwvvvgifv31V7z11lv45ptv8PDDD0uvFxcXY+LEiRg5ciS2bt2KzZs3Y/LkyXA4xH8oz5s3D0uWLMGCBQuwZ88evP/++0hISPCqDWazGU8//TT+8Y9/4Ndff0V8fDzq6+sxa9YsbN68Gdu2bcOQIUMwadIkKWw4nU5cffXV2LJlC959913s2bMHS5YsgUKhQGhoKG688Ua8+eabHp/z5ptv4ve//z3Cw8N9OledwW6DDrh7WDg1PxFRO+xm4Knk4Hz230oBVWindo2KisLVV1+N999/HxMnTgQAfPzxx4iNjcVvf/tbyOVyZGVlSfs//vjj+Oyzz/Dll1/ivvvu87ppDzzwgPQ4PT0dTzzxBO6++2688sorAIBnnnkGY8eOlZ4DwKhRowAA9fX1eOGFF/Dyyy9j1qxZAIBBgwZh/PjxXrXBbrfjlVde8fheEyZM8Njn9ddfR2RkJDZt2oTf/e53+Prrr7Fjxw7s3bsXQ4cOBQAMHDhQ2v/222/HRRddhLKyMiQlJaGyshLr16/vUm9UZ7CHpQNmaWp+Zjsiot5uxowZ+OSTT2C1WgEA7733Hm688UbI5XI0NDTgoYcewogRIxAZGYmwsDDs3bvX5x6Wr7/+GhMnTkRKSgrCw8Nxyy23oKamBmazGUBzD0tb9u7dC6vV2u7rnaVSqZCZmemxraKiAnfccQeGDBkCvV6PiIgINDQ0SN+zuLgY/fr1k8LKmcaNG4dRo0bhrbfeAgC8++67SEtLw6WXXtqltnaEv8IdkG5+yKJbIqK2hejEno5gfbYXJk+eDEEQsG7dOlx44YX43//+h+effx4A8NBDD2Hjxo34v//7PwwePBharRa///3vYbPZvG7WsWPH8Lvf/Q733HMPnnzySURHR2Pz5s247bbbYLPZoNPpoNVq233/2V4DxOEmAB53abbb7W0eRyaTeWybNWsWampq8MILLyAtLQ1qtRo5OTnS9+zoswGxl2X58uWYO3cu3nzzTcyePbvV53Q3n3pYli9fjvT0dGg0GmRnZ2PHjh1n3b+urg5z5sxBUlIS1Go1hg4divXr13fpmIEgCILUw8KZbomI2iGTicMywVi8/JHUaDS47rrr8N577+GDDz7AsGHDcMEFFwAQC2BvvfVWTJ06FRkZGUhMTJQKWL1VVFQEp9OJ5557Dr/5zW8wdOhQlJZ6hrrMzEwUFha2+f4hQ4ZAq9W2+3pcXBwAoKysTNpWXFzcqbZt2bIFf/7znzFp0iSMGjUKarUa1dXVHu06efIkDhw40O4xbr75Zhw/fhwvvvgi9uzZIw1b+ZPXgWXNmjXIz8/HokWLsGvXLmRlZSEvLw+VlZVt7m+z2XDFFVfg2LFj+Pjjj7F//3688cYbSElJ8fmYgWJzOOFwiumVRbdERH3DjBkzsG7dOqxatQozZsyQtg8ZMgSffvopiouL8dNPP+Gmm27y+TLgwYMHw26346WXXsKRI0fwzjvvYMWKFR77zJs3Dzt37sS9996Ln3/+Gfv27cOrr76K6upqaDQaPPLII3j44Yfx9ttv4/Dhw9i2bRtWrlwpHT81NRWLFy/GwYMHsW7dOjz33HOdatuQIUPwzjvvYO/evdi+fTtmzJjh0aty2WWX4dJLL8X111+PjRs34ujRo/j3v/+NDRs2SPtERUXhuuuuw1//+ldceeWV6Nevn0/nySuCl8aNGyfMmTNHeu5wOITk5GShoKCgzf1fffVVYeDAgYLNZuu2Y57JYDAIAASDwdDJb9E5jbYm4fmN+4Un1+0R7E2Obj02EVFv1djYKOzZs0dobGwMdlN84nA4hKSkJAGAcPjwYWn70aNHhd/+9reCVqsVUlNThZdfflm47LLLhPvvv1/aJy0tTXj++ec79TlLly4VkpKSBK1WK+Tl5Qlvv/22AEA4ffq0tM93330nXHTRRYJarRYiIyOFvLw86XWHwyE88cQTQlpamhASEiL0799feOqpp6T3bt68WcjIyBA0Go1wySWXCGvXrhUACEePHhUEQRDefPNNQa/Xt2rXrl27hLFjxwoajUYYMmSIsHbt2lbfq6amRpg9e7YQExMjaDQa4bzzzhP+9a9/eRynsLBQACB89NFHHZ6L9v5mvPn9lglC568Jc4+7ffzxx7j22mul7bNmzUJdXR2++OKLVu+ZNGkSoqOjodPp8MUXXyAuLg433XQTHnnkESgUCp+OeSaj0Qi9Xg+DwYCIiIjOfh0iIvKBxWLB0aNHMWDAAGg0mmA3h4LknXfewYMPPojS0lKoVKqz7tve34w3v99eFWZUV1fD4XC0ug48ISEB+/bta/M9R44cwTfffIMZM2Zg/fr1OHToEO69917Y7XYsWrTIp2NarVapwhsQvzARERH5n9lsRllZGZYsWYK77rqrw7DSXfx+WbPT6UR8fDxef/11jBkzBtOmTcOjjz7aaizPGwUFBdDr9dKSmprajS0mIiI6u/feew9hYWFtLu65VPqqZ555BsOHD0diYiLmzZsXsM/1qoclNjYWCoUCFRUVHtsrKiqQmJjY5nuSkpIQEhIChaK5aHXEiBEoLy+HzWbz6Zjz5s1Dfn6+9NxoNDK0EBFRwPy///f/kJ2d3eZrISEhAW5NYC1evBiLFy8O+Od61cOiUqkwZswYj8usnE4nCgsLkZOT0+Z7Lr74Yhw6dMij0vrAgQNISkqCSqXy6ZhqtRoREREeCxERUaCEh4dj8ODBbS5paWnBbl6f5PWQUH5+Pt544w289dZb2Lt3L+655x6YTCbMnj0bADBz5kyPLqJ77rkHtbW1uP/++3HgwAGsW7cOTz31FObMmdPpYxIREdG5zevZ0KZNm4aqqiosXLgQ5eXlGD16NDZs2CAVzZaUlEgz8AFAamoqvvrqKzz44IPIzMxESkoK7r//fjzyyCOdPiYREfU8vs5RQuee7vhb8eqy5p6KlzUTEQWO0+nEwYMHoVAoEBcXB5VK5fdp2al3EgQBNpsNVVVVcDgcGDJkiEenht8uayYiIpLL5RgwYADKyspaTTdP1BadTof+/ft7hBVvMbAQEZHXVCoV+vfvj6amJjgcjmA3h3owhUIBpVLZ5V44BhYiIvKJTCZDSEhIn7+Ml3oGv08cR0RERNRVDCxERETU4zGwEBERUY/XJ2pY3Fdm8yaIREREvYf7d7szM6z0icBSX18PALyfEBERUS9UX18PvV5/1n36xMRxTqcTpaWlCA8P7/bJi9w3Vjxx4gQnpQsAnu/A4vkOLJ7vwOL5DixfzrcgCKivr0dycnKHc7T0iR4WuVyOfv36+fUzeJPFwOL5Diye78Di+Q4snu/A8vZ8d9Sz4saiWyIiIurxGFiIiIiox2Ng6YBarcaiRYugVquD3ZRzAs93YPF8BxbPd2DxfAeWv893nyi6JSIior6NPSxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9XgMLB1Yvnw50tPTodFokJ2djR07dgS7SX3Cf//7X0yePBnJycmQyWT4/PPPPV4XBAELFy5EUlIStFotcnNzcfDgweA0tpcrKCjAhRdeiPDwcMTHx+Paa6/F/v37PfaxWCyYM2cOYmJiEBYWhuuvvx4VFRVBanHv9uqrryIzM1OaPCsnJwf//ve/pdd5rv1ryZIlkMlkeOCBB6RtPOfdZ/HixZDJZB7L8OHDpdf9ea4ZWM5izZo1yM/Px6JFi7Br1y5kZWUhLy8PlZWVwW5ar2cymZCVlYXly5e3+fozzzyDF198EStWrMD27dsRGhqKvLw8WCyWALe099u0aRPmzJmDbdu2YePGjbDb7bjyyithMpmkfR588EH885//xNq1a7Fp0yaUlpbiuuuuC2Kre69+/fphyZIlKCoqwg8//IAJEyZgypQp+PXXXwHwXPvTzp078dprryEzM9NjO8959xo1ahTKysqkZfPmzdJrfj3XArVr3Lhxwpw5c6TnDodDSE5OFgoKCoLYqr4HgPDZZ59Jz51Op5CYmCg8++yz0ra6ujpBrVYLH3zwQRBa2LdUVlYKAIRNmzYJgiCe25CQEGHt2rXSPnv37hUACFu3bg1WM/uUqKgo4R//+AfPtR/V19cLQ4YMETZu3Chcdtllwv333y8IAv++u9uiRYuErKysNl/z97lmD0s7bDYbioqKkJubK22Ty+XIzc3F1q1bg9iyvu/o0aMoLy/3OPd6vR7Z2dk8993AYDAAAKKjowEARUVFsNvtHud7+PDh6N+/P893FzkcDnz44YcwmUzIycnhufajOXPm4JprrvE4twD/vv3h4MGDSE5OxsCBAzFjxgyUlJQA8P+57hM3P/SH6upqOBwOJCQkeGxPSEjAvn37gtSqc0N5eTkAtHnu3a+Rb5xOJx544AFcfPHFOO+88wCI51ulUiEyMtJjX55v3/3yyy/IycmBxWJBWFgYPvvsM4wcORLFxcU8137w4YcfYteuXdi5c2er1/j33b2ys7OxevVqDBs2DGVlZXjsscdwySWXYPfu3X4/1wwsROeQOXPmYPfu3R5jztT9hg0bhuLiYhgMBnz88ceYNWsWNm3aFOxm9UknTpzA/fffj40bN0Kj0QS7OX3e1VdfLT3OzMxEdnY20tLS8NFHH0Gr1fr1szkk1I7Y2FgoFIpW1c0VFRVITEwMUqvODe7zy3Pfve677z7861//wrfffot+/fpJ2xMTE2Gz2VBXV+exP8+371QqFQYPHowxY8agoKAAWVlZeOGFF3iu/aCoqAiVlZW44IILoFQqoVQqsWnTJrz44otQKpVISEjgOfejyMhIDB06FIcOHfL73zcDSztUKhXGjBmDwsJCaZvT6URhYSFycnKC2LK+b8CAAUhMTPQ490ajEdu3b+e594EgCLjvvvvw2Wef4ZtvvsGAAQM8Xh8zZgxCQkI8zvf+/ftRUlLC891NnE4nrFYrz7UfTJw4Eb/88guKi4ulZezYsZgxY4b0mOfcfxoaGnD48GEkJSX5/++7y2W7fdiHH34oqNVqYfXq1cKePXuEO++8U4iMjBTKy8uD3bRer76+Xvjxxx+FH3/8UQAgLF26VPjxxx+F48ePC4IgCEuWLBEiIyOFL774Qvj555+FKVOmCAMGDBAaGxuD3PLe55577hH0er3w3XffCWVlZdJiNpulfe6++26hf//+wjfffCP88MMPQk5OjpCTkxPEVvdec+fOFTZt2iQcPXpU+Pnnn4W5c+cKMplM+M9//iMIAs91ILS8SkgQeM6701/+8hfhu+++E44ePSps2bJFyM3NFWJjY4XKykpBEPx7rhlYOvDSSy8J/fv3F1QqlTBu3Dhh27ZtwW5Sn/Dtt98KAFots2bNEgRBvLR5wYIFQkJCgqBWq4WJEycK+/fvD26je6m2zjMA4c0335T2aWxsFO69914hKipK0Ol0wtSpU4WysrLgNboX++Mf/yikpaUJKpVKiIuLEyZOnCiFFUHguQ6EMwMLz3n3mTZtmpCUlCSoVCohJSVFmDZtmnDo0CHpdX+ea5kgCELX+2mIiIiI/Ic1LERERNTjMbAQERFRj8fAQkRERD0eAwsRERH1eAwsRERE1OMxsBAREVGPx8BCREREPR4DCxEREfV4DCxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9Xj/HwN7ZhH5PrzQAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGdCAYAAAAxCSikAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABTvklEQVR4nO3deXwTdf4/8FeO5uqR3iel5b5si4J0q3gsVKu4/BBdFxEFWW9xV+26CiuX61HUr4gHirog3iLeu7C4WJVdkMtiVeQ+C/RuadImzdFkfn9MMm1oS5u0Sdryej4e85hkMpl8MnY3Lz6f93xGJgiCACIiIqIeTB7sBhARERF1hIGFiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHUwa7Ad3B6XSitLQU4eHhkMlkwW4OERERdYIgCKivr0dycjLk8rP3ofSJwFJaWorU1NRgN4OIiIh8cOLECfTr1++s+/SJwBIeHg5A/MIRERFBbg0RERF1htFoRGpqqvQ7fjZ9IrC4h4EiIiIYWIiIiHqZzpRzsOiWiIiIejwGFiIiIurxGFiIiIiox2NgISIioh6PgYWIiIh6PAYWIiIi6vEYWIiIiKjHY2AhIiKiHo+BhYiIiHo8BhYiIiLq8RhYiIiIqMdjYCEiIqIer0/c/JCIiIi6RhAEmG0O1JpsqDHZcNq1rjVZUWOyockhYMHvRgatfQwsREREfZQgCKgz21HdYEVVgxVV9VZUN9hQ3WBFdb1VXDfYUNMghhJrk7PdY6kUcsy/ZkSn7qzsDwwsREREvUyDtQlV9dYWiwXVDTbxcUPz9hqTFXaH4NWx1Uo5YkJViA5TITpULT52LQ6nAKWCgYWIiOic5HQKqLc2wdhoh6HRjlqTGD4q662orLegst6KKmPzY7PN4dXx9doQxIapEBumRly4WlrHhakRG+4ZTHQqRdB6Uc6GgYWIiMgPBEFAVYMVp0434uTpRpyqa8TJ02bUmmwwuIKJsbEJhkY76i12OL3rCIFOpUB8uCt4uMNHWIvnrmASE6aCWqnwz5cMIAYWIiIiLwiC2BtS0yAWpIo1IGIdSKnBFU5cAeVsNSFtUSvl0GtDEKkLQXy4RgwkEWrpcXy4GvER4uNQ9bn1E35ufVsiIqIWHE4BNQ1W1Ll6POrMdtSZm3tA6szi+rTZJl490yCubY7OBRG5DEiM0CAlSot+UTqkRGoRF66GXhsCvTYEEVqlax2CCE0INCG9vyfEXxhYiIioz3I6BVTWW3HytBknTptxslbsATlZZ8aJ2kaU1jWiyduxGJdQlQIxriGXGFcNSFKkBimRWqREaZEapUOiXoMQBac86w4MLERE1GsIggCjpQnVDVbUmmwdLlX11g57Q+QySD0eep1KHJJxDctI27UhUj1ITJgYTtgbElgMLEREFFROp4C6RrvrqhiLa64QK2oabNKcITUmq6tOpPPDMW4KuQxJeg1So3To5xqa6RelRWq0uE6I0EAh73lXxZAnBhYiIupW7l6QOrMNp81i/Ued2YbTJrE+pKrBikpjy4nMvJ8rJEytREyYClE6FWJCVYgKVUmX5bofR4WqEBemRpJeAyWHZXo9BhYiIuoUk7UJlfVWVBgtqDCKPSHi4+aekTqzHXWNdjh8qAuJdgWM2HBxHRPWfFmuew4RDsecuxhYiIjOcXaHE1X1VpQbLag0WlBusKDcaBUfu5ZKoxUN1iavjqtTKRClUyFSF+KxbjlvSHyE+DgmVA2Vkr0g1D4GFiKiPkIQBNSYbCg3WFBa14hyowXGRjvqrU1osDShwbVu+bzeIvaICJ3sEAlVKZAQoUG8a26QhAi167kGsWGuIRlXOOkLk5VRz8HAQkTUgwmCgAZrkzQfiHtda7KizCD2hpQaGlFmsKDMYIHNy4nK3JRyGRIimgNIQoQGiXoNEl3hxL0t7BybrIx6Dv7lEREFiDt8nDbZUWOy4rS5eSKyWrMNtQ02aYKyukY7DK5w4s08ITIZpELTRL0G0aEqhKqUCNMoEaZWIlyjRJg6RHoeplYi2lWkKueVMtSD+RRYli9fjmeffRbl5eXIysrCSy+9hHHjxrW5r91uR0FBAd566y2cOnUKw4YNw9NPP42rrrpK2mfx4sV47LHHPN43bNgw7Nu3z5fmERH5hSAIMNkcMDbaYbTYUW9pkh4bG8XhFeMZ28R183ZfJylTKeWI0oUgUquCXifOEyKGEi2SIzVI0muRpBd7QVgLQn2R14FlzZo1yM/Px4oVK5CdnY1ly5YhLy8P+/fvR3x8fKv958+fj3fffRdvvPEGhg8fjq+++gpTp07F999/j/PPP1/ab9SoUfj666+bG6Zk5w8R+YcgCGi0O6SaDrFXQxxmabU223HadbM6X25Q1xZtiALRZ16Cq1MhRqoBCUGkqw4kUiuueVUMnetkgtDZUitRdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33XcBiD0sn3/+OYqLi336EkajEXq9HgaDARERET4dg4h6J0EQUGuyocJoRUW9BRUGi/S4pkG8sqXB6oDJ2gSTK6CYbE1dCh4hChkiNO77vygRoQ1BuEbZapv4vOV2ccZUrYrhgwjw7vfbq24Mm82GoqIizJs3T9oml8uRm5uLrVu3tvkeq9UKjUbjsU2r1WLz5s0e2w4ePIjk5GRoNBrk5OSgoKAA/fv3b/eYVqtVem40Gr35GkTUw1mbHB43mmu51JjEO+SKc4BYOzX1entkMiBMpUTUGT0d0aEhiA5VS2uxxyNECh5qpRwyGes9iALJq8BSXV0Nh8OBhIQEj+0JCQnt1pvk5eVh6dKluPTSSzFo0CAUFhbi008/hcPhkPbJzs7G6tWrMWzYMJSVleGxxx7DJZdcgt27dyM8PLzVMQsKClrVvBBRz+Ce5dQ9g2nLdU2DDSZbEyx2BxrtDljsTjTaHLDYHdI293ZvxYapEB8uFpq6r3SJDVMjXKNEqEqJUFeBaaha4VoroVMpGDyIegm/F4q88MILuOOOOzB8+HDIZDIMGjQIs2fPxqpVq6R9rr76aulxZmYmsrOzkZaWho8++gi33XZbq2POmzcP+fn50nOj0YjU1FT/fhGic4ggCLA5nLA2OcUgYXOgzjXFuqFRrOmoc11iW2cWH582ifd9qWqw+nxpbUtKucyz1yOseer1mFBx1tMEV5FpXBgnHSPq67wKLLGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwWiwU1NTVITk7G3LlzMXDgwHY/JzIyEkOHDsWhQ4fafF2tVkOtVnvTdKJzliAIqDPbUWpoRGmdBWUe60bUme1SMLE2OWFtEtfeVbe1Fq5RuqZZF2c0jQtXIzZMhTC1EpoQBbQqBdRKca1RyqFVKaANUUATopBqP9j7QURuXgUWlUqFMWPGoLCwENdeey0Asei2sLAQ991331nfq9FokJKSArvdjk8++QR/+MMf2t23oaEBhw8fxi233OJN84j6PKdTQK3Zhqp6KwyNnpfLtryMtt4izt9RWW9FWZ0FjXZHxwc/C51KgUhtCPQ6lVTPEalTIVIrTrXuvsxWDCViOOFVLUTUnbweEsrPz8esWbMwduxYjBs3DsuWLYPJZMLs2bMBADNnzkRKSgoKCgoAANu3b8epU6cwevRonDp1CosXL4bT6cTDDz8sHfOhhx7C5MmTkZaWhtLSUixatAgKhQLTp0/vpq9J1LNZmxyoabBJtR6V9eLdbCvrLa7CUgsq68XXfJ3HIzZMhaQWc3a41zFh4o3k1Eo51EpxrQlRQB0ih1oph0rBAlMiCj6vA8u0adNQVVWFhQsXory8HKNHj8aGDRukQtySkhLI5c1jyRaLBfPnz8eRI0cQFhaGSZMm4Z133kFkZKS0z8mTJzF9+nTU1NQgLi4O48ePx7Zt2xAXF9f1b0gURE0OJ8qNFpw83YhTpxtRZmiU6jzcxajV9VYYLd7dVM49V4d4OW3bl9GGa5SIC1cjJVKLhAgNezyIqFfzeh6WnojzsFCwmKxN4t1sDRacqhNDycnTjTh52oyTp8Wbzzk62SOilMsQG6ZGbLh4tUt8uBrxEa6163FChDjkEqJggSkR9X5+m4eF6FxisTtw8nQjTpw2o6zOgnKDGEDKDBZUuNb1negZCVHIkBKpRb8oHZL0GqnOI9ZVhBrveq7XhnDohYioHQwsdM5yOAWUGy0oqTHjxGkzTtaaceJ0I0pqzThRa0ZlvbXjgwAIUyuRqNcgSa9Bvygd+kVpWyw6xIWpeVM5IqIuYmChPs1id+BErRnHa8w4XmtGSY3JtRaHbDqaITVUpUBqtE6sA9FrkBQhTkzmDigJERqEa0IC9G2IiM5dDCzUJzidAo7XmrGn1IhfSw3YU2bE/vJ6lBksZ31fiEIm9YqkRuuQGqVDarTWtdYhSsdhGiKinoCBhXoda5MDB8obsKfMgF9LjdhTasTeMiNMtrbnGglTK9E/Wof0WB36R4ciLUaHtGgd+sfokKTXQsHhGiKiHo+BhXo0u8OJgxUN+OVUHX46acAvJw3YV26E3dH6yhu1Uo7hieEYmRyBkcl6jEgMx4DYUESHqthLQkTUyzGwUI8hCAKO15ixq+Q0fj5pwM8n6/BrqRHWNu5LE6kLwajkCIxK1mNkUgRGJkdgYGwolLzcl4ioT2JgoaCqabBiy+EabDlYjc2HqnGqrrHVPuFqJTL66ZHRT4+sfpHISNGjX5SWvSZEROcQBhYKqEabAzuP1WLzoWpsPliNPWVGj9dDFDJk9YtEZr9IZKXqkZGiR3pMKC8LJiI6xzGwkN8drTahcG8FvtlXiR+OnW51KfGIpAiMHxyDiwfHYtyAaOhU/LMkIiJP/GWgbmd3OPHDsdP4Zl8FCvdW4ki1yeP1ZL0G44fE4uLBsbhoUCziwtVBaikREfUWDCzULU6bbNh0oApf763ApgNVHlPWhyhkyB4QgwnD43HZsDgMjA1l/QkREXmFgYV8Zmty4pt9Ffi46CS+3V/lcZO/6FAVLh8Wh9wRCbhkSCxngyUioi5hYCGv7Sk1Ym3RCXxRXIpak03aPjwxHBOGx2PiiASMTo3khGxERNRtGFioU06bbPii+BTWFp3Er6XNV/bEhatx3QUpuGFMPwyODw9iC4mIqC9jYKF2CYKAbUdq8c62Y/h6T6V0dU+IQobcEQm4YWw/XDokjpO1ERGR3zGwUCtNDif+vbscb/zvCH4+aZC2j0qOwO/H9MOU0SmIDlUFsYVERHSuYWAhidnWhI92nsDKLUdxolaccVatlOP6Mf0wI7s/RiXrg9xCIiI6VzGwEKrqrXjr+2N4Z9txGBrtAIAoXQhm5qRjZk4aYsI4TwoREQUXA8s57HiNCa9+dxif/ngKNtcNBtNidLj9koH4/QX9oFUpgtxCIiIiEQPLOajeYsfL3x7Cqs1HYXeIc6ec3z8Sd106EFeMTOTlyERE1OMwsJxDnE4BHxedxDNf7Ud1gxUAcOnQOPx5wmCMTY8OcuuIiIjax8ByjvjhWC0e++ce/HJKvOpnYGwoFvxuJH47PD7ILSMiIuoYA0sfV1rXiCX/3ocvfyoFAISrlbg/dwhm5qRDpeT8KURE1DswsPRRFrsDr206glc3HYLF7oRMBtx4YSr+cuUwxPKqHyIi6mUYWPqg/eX1uOudH3CsxgwAGJcejYWTR+K8FM6jQkREvRMDSx/z71/K8Je1P8FscyBJr8Gj14zANRlJkMl45Q8REfVeDCx9hNMpYOnGA3j520MAgIsHx+Dl6RcgilPoExFRH8DA0gcYGu14cE0xvtlXCQC4ffwAzL16OG9KSEREfQYDSy93qLIed75dhCPVJqiVciy5PgNTz+8X7GYRERF1KwaWXmzjngo8uKYYDdYmJOs1eO2Wscjox8JaIiLqexhYeiGnU8BL3xzC818fAACMGxCNV2ZcwMuViYioz2Jg6WWsTQ78+YMf8dWvFQCAWTlpmP+7kQhhvQoREfVhDCy9iCAIWPj5r/jq1wqoFHI8ce15+MOFqcFuFhERkd/59M/y5cuXIz09HRqNBtnZ2dixY0e7+9rtdvz973/HoEGDoNFokJWVhQ0bNnTpmOeqt74/hjU/nIBcBrw2cwzDChERnTO8Dixr1qxBfn4+Fi1ahF27diErKwt5eXmorKxsc//58+fjtddew0svvYQ9e/bg7rvvxtSpU/Hjjz/6fMxz0ZZD1Xh83V4AwNyrh+O3w3jTQiIiOnfIBEEQvHlDdnY2LrzwQrz88ssAAKfTidTUVPzpT3/C3LlzW+2fnJyMRx99FHPmzJG2XX/99dBqtXj33Xd9OuaZjEYj9Ho9DAYDIiIivPk6vUJJjRn/b/lm1JntmHp+Cpb+IYsz1xIRUa/nze+3Vz0sNpsNRUVFyM3NbT6AXI7c3Fxs3bq1zfdYrVZoNBqPbVqtFps3b/b5mOeSBmsT7nj7B9SZ7cjqp0fBdRkMK0REdM7xKrBUV1fD4XAgISHBY3tCQgLKy8vbfE9eXh6WLl2KgwcPwul0YuPGjfj0009RVlbm8zGtViuMRqPH0hc5nQL+8lEx9lfUIy5cjdduGQtNiCLYzSIiIgo4v18L+8ILL2DIkCEYPnw4VCoV7rvvPsyePRtyue8fXVBQAL1eLy2pqX2z+PSFwoPSFUGv3TIGiXpNx28iIiLqg7xKDbGxsVAoFKioqPDYXlFRgcTExDbfExcXh88//xwmkwnHjx/Hvn37EBYWhoEDB/p8zHnz5sFgMEjLiRMnvPkavcK/fynDC4UHAQBPTj0PF/SPCnKLiIiIgserwKJSqTBmzBgUFhZK25xOJwoLC5GTk3PW92o0GqSkpKCpqQmffPIJpkyZ4vMx1Wo1IiIiPJa+ZG+ZEX9Z+xMA4I8XD8ANY/3Qg2S3AKd2AYe+BmoOA46m7v8MIiKibuL1xHH5+fmYNWsWxo4di3HjxmHZsmUwmUyYPXs2AGDmzJlISUlBQUEBAGD79u04deoURo8ejVOnTmHx4sVwOp14+OGHO33Mc0mtyYY73v4BZpsD4wfH4m+Thnf9oKZqoPwXz6X6ACA4mveRhwDRA4CYwUDMINd6iLgOiwdY6EtEREHkdWCZNm0aqqqqsHDhQpSXl2P06NHYsGGDVDRbUlLiUZ9isVgwf/58HDlyBGFhYZg0aRLeeecdREZGdvqY5wq7w4l73yvCydONSIvR4eWbzoeys1PuCwJgrgGqDwI1h8Slcq8YTupL236PNhoISwBOHwOaGsUQU32g9X4hOkAVCijUgFINKDWAUuVaq5u3qyMATYRrrW/x2PVc7XquDhf3ZwgiIqJO8noelp6or8zDsmrzUfz9X3sQqlLgszkXY2hCeNs71hwGyn5qDibuxWJo/+DRA4HEDNeSKa7Dk8TQ4HQCxlMtjnUYqHEFn7oSQHB2/5eVKwFVmCvAhIkhRhUmPg6NB2KHAnFDxbW7nf7gdAJdKAAnIiLfefP7zXsJ9RB2hxP/+N8RAMDfrhnRdlg5fQz45gngl7XtHEUG6FObh3TihonhJGGkGAjaI5cDkaniMui3nq81WcUwY7cATRbxucMqrpssQJPNtbYAViNgMTavLYYzthkAW4N4XGcTYKkTl46owoDYIWJ4ca/DkwG7CbA2iMe01ouL9Ni13d7oWsxiG+1m13PXY6cdiBoApFwApIwBki8AkrIAla7jdhERUcAwsPQQ//q5FKUGC2LD1Lj+gn6eL5prgf89B+x4HXDYxG0pY8VAItWbDBZ7UUK03dswpVo8bndxOsUg0TJYWI2ez42nmoenao+Kr5X+KC7+cPqouOz+RHwuUwDxI4GU85tDTNww8VwQEVFQMLD0AIIg4LVNYu/K7IvTmyeHszcC218D/rcUsLqGewZcBlzxdyB5dHAa21VyuaumpZNDd002MUxU7XeFmIPi2lQl1tVIQ0nhzYv7uSpUXJQasQ4nxLVu+VymAKr2AqeKgFM/iuuGcqDiF3HZ9XZzW8ISxB6syFRA3w/Q9xfX7ueaSNblEBH5CQNLD7DpQBX2ldcjVKXAzdlpgNMB/LwG+OZJwHhS3CkhA7hiMTBo4rn1o6hUib0bccP89xkRScCgCc3PjaWuALNLXJcWi4GxoUJcTv3QTls1YmjRRgHaSNdj13P3Y41e7AVTasV1y0XapgMUId7/d3bYxcJrUzVgrhYfyxSALlossHavQzgBIRH1PgwsPYC7d2X6uP7Ql24CNi4CKnaLL0b0AybMBzL/AMg5LX9ARCSLy4jJ4nNBEIflDCWA4SRQdwIwuJa6E+I2c7VYI9NQLi5dJVcCIa4eIpXrKq2Wz0N0Ym2Qubo5oJyt6LqlkFBXeIkS1+qI5iu+3FeBKVSe2xQhYviRydtZXOHKYXPVN1nbrnly2MTP08UAobGALta1jgFC48SesTODmiCI75fqkFw1SQq1+N9JHdb1891TNFnFYdDGWiAyTSw4Z1E4EQAGlqD7+WQdth6pgVIuw5/CCoF354svqPXApX8Bxt3FfxEHm0wGhMaIS/L5be9jM4vDVI2nxULixjrPxxb3c2OL4l/Xj29Ti8Jg9xVZziaxV8fayRAitVUu9qK4w4CzSfzxM9eKa8EpFisbTGLg6mkUKrHdMnmL89II4CwXM2r0QESKuOhTPB+HJTYPDapCxeMHu4dSuirvoOuKvEPN0xEYTnhelafUivMjRQ90rQe5Hg8UvyPDDJ1DGFiC7LX/ir0rfx5SA/1/F4sbx94m9qroooPWLvKSSgeo0oCoNN+PIQjisI7dLC42k7i0fNzyuTr8jF6KWLHXpL0fMadTDEDmWjE8uUOMtd6zB8TdM9LyKjCHTWyf4HT9oLZ4LC1C+z007u3yELENpprm3iF3D5HdLH5Oe/MGAa6eJ1cdknRlmkFcKvd0fI7P7LkK0Yk1T2edP0gvnmuHtcVVacYzrlBrAGyu8+iwif8dHTbX0tTisb25N649qnBAFwUYTomhrXJP299NoQYi+4tLVJrYI9PysS4m+OHMF06nOPSqCu18rRudExhYguh4jQn//qUMcajDPVV/F/81fN7vgWue653/R0NdI5O5JuRTifUu3U0ud9XX9ND7UtnMzSEGaFHf4y6U1opDUy1Z68UfdqNrOfNxQ0VzEAJ877nqbq1mlh7SfLWfe2Zph12cB6n2KFB7GKg9Ii41h4G642KAqjkoLm0JCRUDjErXPHQHmecwnvtxiLb1JI8ej/XifmebssBiEM9veKI4lK1PcQ2v9hPXZ04VYLeI38tdTO8urK85JP43A8Twpm+n9ywiRQxm3d0D7WgSawdrj4pTSZw+Jhb+15eLtWjhCWLPnXsdluB6nOB5JWGTzXVFpPsfGQ3i37jNJA7vt5x7Sh0hPlaquve7dMTpEM995R7xf2MRSeKUEaGxPbIEgRPHBdGCz3fj/W1HsE7/LIZbfwbihgO3F/atMXminsBhb7+3yj2HT8sf4bYeK9Wtr0qTHoeJP67uUKUIEXuZFCrxsTyk+bFGL/7QKrrw70VHk6uGqkQML3UlwOnjzY/ry7rv3HUXbbQYMnRRze1tb6hPJu/chJUyORCVLv5/Z9yw5nXsULGH5kyCIP63NJaJPXnuteFUczgxnBCDly80keJ3spl8O4ZC1fx3FRYPxI8Qp1iIGy6uu3KblCabeEVk2U9A2c/iumJ3czhsSaYQg2d4kivEuJaIZOC861v/w6ELvPn9ZmAJkpoGKy5a8g3y8Q7uUq4T/8/uzm/FidGIiLrCbhGLwQ0l4g9Vy6E7j+E8QfxXtt189rBmMYj7uYfM2uyFiRB/6OrLxR4KQ4ueLrup7XZq9EDsMM9JIWOHisNaTVbxir32es+Mp8S2tSeyPxA3QvyM+jJxMZa135aWFGqxDVHprmWA+MNtMQD1Fc1XDNaXNz929+K1dSyVa+gxRCc+djo8hxObGjtuEyCGvviRriAzQmybs6lFTVwbE2Ra6sRgUrFHnCjzTCGh4uSiTod4jhoq2g+LciUwv6pba6c4020v8PbW4/itcxvuUq0TN1y7nGGFiLpHiAaIHSwuwSYI4g+9O2iYa8S5i2KHileGtddjoAgRb88RN7T945qqgKp94nBS1T6gcp+4Nle7ep9K2n6vRi8OfYQnNl8V2DKceHt1liCIdWENla7bjrS4sq8zPWmOJrEGytrQPGO34aR4P7jKPeK69ohYc3Z8s7j4QhMJJGWKs3knjRbX0QM9h38cTYCp0tX75A56peLaYQtqoTcDSxCYbU3Y9P0WvBPymrjhoj8BI6cEt1FERP4gk7nmI4oEEkZ173HD4sVlwKWer5mqXSFmrzg80zKchCe2PVzU1bboon2/UEKhbF1fljrOcx+bWazxaRlijKfEocqWdV5n1n6pwsRhsqQssdepoyElhbI5xPUwDCxB8Nm2A3jG8SzC5Y0Q0i6GbOLiYDeJiKjvCHVdOZd+cbBb0n1UOnGG8946y3k34EX8AdbU5EDCpr9iqPwUzOo4yH7/ZteK74iIiM4BDCwBtvfL/0OuYzPsUEAx7S3xcjgiIiI6KwaWABKOb8WIn58GAHw/4AGoB/ah7koiIiI/YmAJlPoK2D6cBSUcWO/MQeb1jwS7RURERL0GA0ugbFwIdWMFDjhTUHz+44gKU3f8HiIiIgLAwBIY9eVw7v4EAPBw09245bJuvLSPiIjoHMDAEgg/rILcacdO51CkZlyC1Ghdx+8hIiIiCQOLvzVZgR9WAQBWN12FazKSgtwgIiKi3oeBxd92fwqYqlAqROMr51ic3z8y2C0iIiLqdRhY/EkQgO0rAADvNl2B2IgwJER0863QiYiIzgEMLP50YjtQVowmuRofOH6L0amRwW4RERFRr8TA4k+u3pXtYRNxGhHIYmAhIiLyCQOLvxhOAnu+BAC8ZrkCAJCVqg9mi4iIiHotBhZ/2bkSEBywpV6E/xoTIJMBmf0ig90qIiKiXomBxR/sjUDRagDAntSbAABD4sMQpuZdmYmIiHzBwOIPv6wFGmsBfX8UOscAALLYu0JEROQzBpbuJgjANrHYFuPuwI8n6wEAozn/ChERkc8YWLrbsc1A5a9AiA7O0bfgp5N1ANjDQkRE1BUMLN3NdSkzsm7EUXMI6i1NUCvlGJYYHtx2ERER9WIMLN3p9DFg/3rx8bi7UFxSBwDISNEjRMFTTURE5Cv+inannf8ABCcw8LdA/PDm4SBOGEdERNQlDCzdxWYCdr0tPs6+GwDw04k6AAwsREREXeVTYFm+fDnS09Oh0WiQnZ2NHTt2nHX/ZcuWYdiwYdBqtUhNTcWDDz4Ii8Uivb548WLIZDKPZfjw4b40LXh++hCwGICoAcCQK2GxO7CnzAgAGM2CWyIioi7xeiazNWvWID8/HytWrEB2djaWLVuGvLw87N+/H/Hx8a32f//99zF37lysWrUKF110EQ4cOIBbb70VMpkMS5culfYbNWoUvv766+aGKXvRJGuCAGx/TXycfRcgl2PvydOwOwREh6qQGq0NbvuIiIh6Oa97WJYuXYo77rgDs2fPxsiRI7FixQrodDqsWrWqzf2///57XHzxxbjpppuQnp6OK6+8EtOnT2/VK6NUKpGYmCgtsbGxvn2jYDjyLVC9H1CFAaNnAGgxHNRPD5lMFsTGERER9X5eBRabzYaioiLk5uY2H0AuR25uLrZu3drmey666CIUFRVJAeXIkSNYv349Jk2a5LHfwYMHkZycjIEDB2LGjBkoKSlptx1WqxVGo9FjCaod/xDXo2cAmggAwE8nDQBYv0JERNQdvBp3qa6uhsPhQEJCgsf2hIQE7Nu3r8333HTTTaiursb48eMhCAKamppw9913429/+5u0T3Z2NlavXo1hw4ahrKwMjz32GC655BLs3r0b4eGt5y8pKCjAY4895k3T/evENnGdNU3aVOzqYRnNwEJERNRlfr9K6LvvvsNTTz2FV155Bbt27cKnn36KdevW4fHHH5f2ufrqq3HDDTcgMzMTeXl5WL9+Perq6vDRRx+1ecx58+bBYDBIy4kTJ/z9NdpnqgHMNeLjOLFQuM5sw9FqEwDOcEtERNQdvOphiY2NhUKhQEVFhcf2iooKJCYmtvmeBQsW4JZbbsHtt98OAMjIyIDJZMKdd96JRx99FHJ568wUGRmJoUOH4tChQ20eU61WQ61We9N0/6neL671/QFVKADgZ9dwUFqMDlGhqmC1jIiIqM/wqodFpVJhzJgxKCwslLY5nU4UFhYiJyenzfeYzeZWoUShUAAABEFo8z0NDQ04fPgwkpKSvGlecFS5AkvcUGkTh4OIiIi6l9fXDufn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUAgMmTJ2Pp0qU4//zzkZ2djUOHDmHBggWYPHmyFFweeughTJ48GWlpaSgtLcWiRYugUCgwffr0bvyqflJ9QFzHDpM2NV8hFBn49hAREfVBXgeWadOmoaqqCgsXLkR5eTlGjx6NDRs2SIW4JSUlHj0q8+fPh0wmw/z583Hq1CnExcVh8uTJePLJJ6V9Tp48ienTp6OmpgZxcXEYP348tm3bhri4uG74in7mDiyuHhZBEDglPxERUTeTCe2Ny/QiRqMRer0eBoMBERERgf3w5zMAQwkwewOQloMTtWZc8sy3UMpl2P1YHjQhisC2h4iIqJfw5veb9xLqCptJDCsAECv2sLh7V0YkRTCsEBERdRMGlq6oPiiudTFAaAyAljc81AepUURERH0PA0tXtFFwW8yCWyIiom7HwNIVZ1zS3ORw4pdT4hws5/ePDFKjiIiI+h4Glq5wTxrn6mE5UNEAi92JMLUSA2PDgtgwIiKivoWBpSvcNSyuHhb3cFBmPz3kct6hmYiIqLswsPjK0QTUHBYfu3pYfuIMt0RERH7BwOKr00cBpx0I0QERKQDACeOIiIj8hIHFV+6C29ghgFwOk7UJByrqAbCHhYiIqLsxsPjqjILbX04Z4BSAJL0GCRGaIDaMiIio72Fg8VWV5z2EeMNDIiIi/2Fg8dUZPSysXyEiIvIfBhZfCEKLS5rFwFJcUgeA9StERET+wMDiC2MpYGsAZAogagAqjRaUGiyQyYCMfryHEBERUXdjYPGFezgoeiCgVOGnk+J0/EPiwxCmVgaxYURERH0TA4svpIJb13DQidMAWHBLRETkLwwsvpAKbt1XCIk9LKN5w0MiIiK/YGDxxRk9LKWGRgDAoDje8JCIiMgfGFh8cUYPi9nqAADWrxAREfkJA4u3zLWAqUp87AosJlsTAECrUgSrVURERH0aA4u33POvRKQA6jAIgoBGm9jDEqpiDwsREZE/MLB464zhIJvDiSanAIA9LERERP7CwOIt912aXQW37voVANAxsBAREfkFA4u3ql1XCLkLbu1iYFEp5QhR8HQSERH5A39hvdWqh0UsuGXvChERkf8wsHjD3gjUlYiPXXdpNrPgloiIyO8YWLxRfRCAAGijgNBYAM2XNLOHhYiIyH8YWLzRsn5FJgPQXHTLwEJEROQ/DCzeOKPgFmguutVxSIiIiMhvGFi8cUbBLdBcdBuqZg8LERGRvzCweEPqYWkOLCZX0a2WPSxERER+w8DSWY4moOaQ+DiueUio0VV0G8oaFiIiIr9hYOmsuuOAwwYotYC+v7S5uYeFgYWIiMhfGFg6y12/EjsYkDefNqmGhUNCREREfsPA0lln3PTQzT1xnI5Ft0RERH7jU2BZvnw50tPTodFokJ2djR07dpx1/2XLlmHYsGHQarVITU3Fgw8+CIvF0qVjBlz1QXHdouAWaBFYQhhYiIiI/MXrwLJmzRrk5+dj0aJF2LVrF7KyspCXl4fKyso293///fcxd+5cLFq0CHv37sXKlSuxZs0a/O1vf/P5mEEhXdJ8Zg+La6ZbNYeEiIiI/MXrwLJ06VLccccdmD17NkaOHIkVK1ZAp9Nh1apVbe7//fff4+KLL8ZNN92E9PR0XHnllZg+fbpHD4q3xww4QWjzkmagueiWNSxERET+41VgsdlsKCoqQm5ubvMB5HLk5uZi69atbb7noosuQlFRkRRQjhw5gvXr12PSpEk+H9NqtcJoNHosflVfDliNgEwOxAzyeMnMewkRERH5nVfdAtXV1XA4HEhISPDYnpCQgH379rX5nptuugnV1dUYP348BEFAU1MT7r77bmlIyJdjFhQU4LHHHvOm6V3jLriNGgAo1R4vSTUsDCxERER+4/erhL777js89dRTeOWVV7Br1y58+umnWLduHR5//HGfjzlv3jwYDAZpOXHiRDe2uA1VruGguGGtXnLf/DCUNSxERER+49WvbGxsLBQKBSoqKjy2V1RUIDExsc33LFiwALfccgtuv/12AEBGRgZMJhPuvPNOPProoz4dU61WQ61Wt/maX0iXNA9p9ZLJNSTEieOIiIj8x6seFpVKhTFjxqCwsFDa5nQ6UVhYiJycnDbfYzabIZd7foxCIf64C4Lg0zEDTpo0zrOHRRAENLLoloiIyO+8/pXNz8/HrFmzMHbsWIwbNw7Lli2DyWTC7NmzAQAzZ85ESkoKCgoKAACTJ0/G0qVLcf755yM7OxuHDh3CggULMHnyZCm4dHTMoHPPwXLGkJDN4USTUwDAieOIiIj8yevAMm3aNFRVVWHhwoUoLy/H6NGjsWHDBqlotqSkxKNHZf78+ZDJZJg/fz5OnTqFuLg4TJ48GU8++WSnjxlUFgPQUC4+PmNIyF2/AnDiOCIiIn+SCYIgBLsRXWU0GqHX62EwGBAREdG9Bz+xE1iZC4QnAX/xvGrpVF0jLl7yDVRKOQ48cXX3fi4REVEf583vN+8l1JF27iEENN/4kJc0ExER+RcDS0ekKflbX9LMWW6JiIgCg4GlI9KU/G30sHCWWyIiooBgYOlI1dmGhDjLLRERUSAwsJyN3QLUHRcftzXLrd0dWDgkRERE5E/8pT0buxnImg4YTgBhrS+xdhfdhnIOFiIiIr9iYDkbXTRw7SvtvuwuutWyh4WIiMivOCTUBY2uottQ1rAQERH5FQNLF7h7WFjDQkRE5F8MLF3AieOIiIgCg4GlC8zuHhYW3RIREfkVA0sXSIGFNz4kIiLyKwaWLjC5Z7pVs4aFiIjInxhYusDMewkREREFBANLF/BeQkRERIHBwNIFUg0LAwsREZFfMbB0gfvmh6GsYSEiIvIrBpYucBfdatnDQkRE5FcMLD4SBAGNLLolIiIKCAYWH9kcTjQ5BQCcOI6IiMjfGFh85K5fAThxHBERkb8xsPjIbBcDi0oph1LB00hERORP/KX1EW98SEREFDgMLD4yseCWiIgoYBhYfMRZbomIiAKHgcVH7qJbBhYiIiL/Y2DxkbvoVschISIiIr9jYPGRu+g2lHOwEBER+R0Di4/cRbda9rAQERH5HQOLjxpdRbehrGEhIiLyOwYWH7l7WFjDQkRE5H8MLD7ixHFERESBw8DiI7O7h4VFt0RERH7HwOIjM2e6JSIiChgGFh+ZXEW3Wg4JERER+Z1PgWX58uVIT0+HRqNBdnY2duzY0e6+l19+OWQyWavlmmuukfa59dZbW71+1VVX+dK0gGEPCxERUeB4/Wu7Zs0a5OfnY8WKFcjOzsayZcuQl5eH/fv3Iz4+vtX+n376KWw2m/S8pqYGWVlZuOGGGzz2u+qqq/Dmm29Kz9VqtbdNCyjeS4iIiChwvO5hWbp0Ke644w7Mnj0bI0eOxIoVK6DT6bBq1ao294+OjkZiYqK0bNy4ETqdrlVgUavVHvtFRUX59o0ChPcSIiIiChyvAovNZkNRURFyc3ObDyCXIzc3F1u3bu3UMVauXIkbb7wRoaGhHtu/++47xMfHY9iwYbjnnntQU1PT7jGsViuMRqPHEmjSkJCaQ0JERET+5lVgqa6uhsPhQEJCgsf2hIQElJeXd/j+HTt2YPfu3bj99ts9tl911VV4++23UVhYiKeffhqbNm3C1VdfDYfD0eZxCgoKoNfrpSU1NdWbr9EtWHRLREQUOAHtHli5ciUyMjIwbtw4j+033nij9DgjIwOZmZkYNGgQvvvuO0ycOLHVcebNm4f8/HzpudFoDGhoEQQBjSy6JSIiChivelhiY2OhUChQUVHhsb2iogKJiYlnfa/JZMKHH36I2267rcPPGThwIGJjY3Ho0KE2X1er1YiIiPBYAsnmcKLJKQDgxHFERESB4FVgUalUGDNmDAoLC6VtTqcThYWFyMnJOet7165dC6vViptvvrnDzzl58iRqamqQlJTkTfMCxl1wCwC6EAYWIiIif/P6KqH8/Hy88cYbeOutt7B3717cc889MJlMmD17NgBg5syZmDdvXqv3rVy5Etdeey1iYmI8tjc0NOCvf/0rtm3bhmPHjqGwsBBTpkzB4MGDkZeX5+PX8i+zXQwsKqUcSgXn3iMiIvI3rwswpk2bhqqqKixcuBDl5eUYPXo0NmzYIBXilpSUQC73/BHfv38/Nm/ejP/85z+tjqdQKPDzzz/jrbfeQl1dHZKTk3HllVfi8ccf77FzsbhvfBjKglsiIqKAkAmCIAS7EV1lNBqh1+thMBgCUs9SfKIO1y7fgpRILbbMneD3zyMiIuqLvPn95niGDzjLLRERUWAxsPiAs9wSEREFFgOLD0xSDwvnYCEiIgoEBhYfSJPGcQ4WIiKigGBg8YHJFVi07GEhIiIKCAYWHzTaeFkzERFRIDGw+MDdw8IaFiIiosBgYPGBe+I4XiVEREQUGAwsPjC7e1hYdEtERBQQDCw+cAeWUA4JERERBQQDiw/c87BoOSREREQUEAwsPmAPCxERUWAxsPiA9xIiIiIKLAYWH/BeQkRERIHFwOIDaUhIzSEhIiKiQGBg8QGLbomIiAKLgcVLgiA03/yQRbdEREQBwcDiJZvDiSanAIATxxEREQUKA4uX3AW3AKALYWAhIiIKBAYWL5ntYmBRKeVQKnj6iIiIAoG/uF5y3/gwlAW3REREAcPA4iWT+8aHLLglIiIKGAYWL3GWWyIiosBjYPESZ7klIiIKPAYWL5mkHhYOCREREQUKA4uXpEnjOAcLERFRwDCweMlddKtlDwsREVHAMLB4iZc1ExERBR4Di5fcE8exhoWIiChwGFi85O5h4VVCREREgcPA4iWze+I4Ft0SEREFDAOLl9yBJZRDQkRERAHDwOIl9zwsWg4JERERBQwDi5fYw0JERBR4DCxeku4lxBoWIiKigPEpsCxfvhzp6enQaDTIzs7Gjh072t338ssvh0wma7Vcc8010j6CIGDhwoVISkqCVqtFbm4uDh486EvT/E66l1AIAwsREVGgeB1Y1qxZg/z8fCxatAi7du1CVlYW8vLyUFlZ2eb+n376KcrKyqRl9+7dUCgUuOGGG6R9nnnmGbz44otYsWIFtm/fjtDQUOTl5cFisfj+zfxEGhJSc0iIiIgoULwOLEuXLsUdd9yB2bNnY+TIkVixYgV0Oh1WrVrV5v7R0dFITEyUlo0bN0Kn00mBRRAELFu2DPPnz8eUKVOQmZmJt99+G6Wlpfj888+79OX8gUW3REREgedVYLHZbCgqKkJubm7zAeRy5ObmYuvWrZ06xsqVK3HjjTciNDQUAHD06FGUl5d7HFOv1yM7O7vdY1qtVhiNRo8lEARBYNEtERFREHgVWKqrq+FwOJCQkOCxPSEhAeXl5R2+f8eOHdi9ezduv/12aZv7fd4cs6CgAHq9XlpSU1O9+Ro+szmccDgFACy6JSIiCqSAXiW0cuVKZGRkYNy4cV06zrx582AwGKTlxIkT3dTCs3MX3AIsuiUiIgokrwJLbGwsFAoFKioqPLZXVFQgMTHxrO81mUz48MMPcdttt3lsd7/Pm2Oq1WpERER4LIHgvvGhSimHUsErwomIiALFq19dlUqFMWPGoLCwUNrmdDpRWFiInJycs7537dq1sFqtuPnmmz22DxgwAImJiR7HNBqN2L59e4fHDDT3jQ9DWXBLREQUUF5Xjubn52PWrFkYO3Ysxo0bh2XLlsFkMmH27NkAgJkzZyIlJQUFBQUe71u5ciWuvfZaxMTEeGyXyWR44IEH8MQTT2DIkCEYMGAAFixYgOTkZFx77bW+fzM/MLlvfMiCWyIiooDy+pd32rRpqKqqwsKFC1FeXo7Ro0djw4YNUtFsSUkJ5HLPjpv9+/dj8+bN+M9//tPmMR9++GGYTCbceeedqKurw/jx47FhwwZoNBofvpL/SLPcsoeFiIgooGSCIAjBbkRXGY1G6PV6GAwGv9azfL2nAre//QOyUiPxxZyL/fY5RERE5wJvfr9ZOeoF96RxvEKIiIgosBhYvNAoTcvPwEJERBRIDCxecBfdall0S0REFFAMLF7gZc1ERETBwcDiBffEcbysmYiIKLAYWLzg7mHhZc1ERESBxcDiBfedmnnjQyIiosBiYPGCO7CEckiIiIgooBhYvOCeh0XLISEiIqKAYmDxAntYiIiIgoOBxQvSvYRYw0JERBRQDCxeMFtdRbecmp+IiCigGFi8IA0JqTkkREREFEgMLF5g0S0REVFwMLB0kiAILLolIiIKEgaWTrI5nHA4BQAsuiUiIgo0BpZOchfcAiy6JSIiCjQGlk5y3/hQpZRDqeBpIyIiCiT+8naS+8aHoSy4JSIiCjgGlk4yuW98yIJbIiKigGNg6SRpllv2sBAREQUcA0snSbPcctI4IiKigGNg6ST3pHG8QoiIiCjwGFg6qVGalp+BhYiIKNAYWDqJRbdERETBw8DSSe7Lmll0S0REFHgMLJ3knjiOPSxERESBx8DSSexhISIiCh4Glk6SalhYdEtERBRwDCydJF0lxCEhIiKigGNg6ST3PCxaDgkREREFHANLJ5nZw0JERBQ0DCydJN1LiDUsREREAcfA0knSvYQ4NT8REVHAMbB0kjQkxJsfEhERBZxPgWX58uVIT0+HRqNBdnY2duzYcdb96+rqMGfOHCQlJUGtVmPo0KFYv3699PrixYshk8k8luHDh/vSNL+Rbn7IolsiIqKA87q7YM2aNcjPz8eKFSuQnZ2NZcuWIS8vD/v370d8fHyr/W02G6644grEx8fj448/RkpKCo4fP47IyEiP/UaNGoWvv/66uWHKntOTIQiC1MPCmW6JiIgCz+tf36VLl+KOO+7A7NmzAQArVqzAunXrsGrVKsydO7fV/qtWrUJtbS2+//57hISEAADS09NbN0SpRGJiorfNCQibwwmHUwDAolsiIqJg8GpIyGazoaioCLm5uc0HkMuRm5uLrVu3tvmeL7/8Ejk5OZgzZw4SEhJw3nnn4amnnoLD4fDY7+DBg0hOTsbAgQMxY8YMlJSUtNsOq9UKo9HosfiTu+AWYNEtERFRMHgVWKqrq+FwOJCQkOCxPSEhAeXl5W2+58iRI/j444/hcDiwfv16LFiwAM899xyeeOIJaZ/s7GysXr0aGzZswKuvvoqjR4/ikksuQX19fZvHLCgogF6vl5bU1FRvvobX3PUrKqUcSgXrlImIiALN7wUZTqcT8fHxeP3116FQKDBmzBicOnUKzz77LBYtWgQAuPrqq6X9MzMzkZ2djbS0NHz00Ue47bbbWh1z3rx5yM/Pl54bjUa/hpbmafnZu0JERBQMXgWW2NhYKBQKVFRUeGyvqKhot/4kKSkJISEhUCiaf+xHjBiB8vJy2Gw2qFSqVu+JjIzE0KFDcejQoTaPqVaroVarvWl6l5hYcEtERBRUXo1vqFQqjBkzBoWFhdI2p9OJwsJC5OTktPmeiy++GIcOHYLT6ZS2HThwAElJSW2GFQBoaGjA4cOHkZSU5E3z/MbMS5qJiIiCyuuCjPz8fLzxxht46623sHfvXtxzzz0wmUzSVUMzZ87EvHnzpP3vuece1NbW4v7778eBAwewbt06PPXUU5gzZ460z0MPPYRNmzbh2LFj+P777zF16lQoFApMnz69G75i10mz3HLSOCIioqDw+hd42rRpqKqqwsKFC1FeXo7Ro0djw4YNUiFuSUkJ5PLmHJSamoqvvvoKDz74IDIzM5GSkoL7778fjzzyiLTPyZMnMX36dNTU1CAuLg7jx4/Htm3bEBcX1w1fseukSeN4hRARkQeHwwG73R7sZlAPdmZZiK9kgiAI3dCeoDIajdDr9TAYDIiIiOj243+4owRzP/0FuSPi8Y9ZF3b78YmIehtBEFBeXo66urpgN4V6gcjISCQmJkImk3ls9+b3m2McncCiWyIiT+6wEh8fD51O1+qHiAhwzRRvNqOyshIAulSbyl/gTjBbWXRLROTmcDiksBITExPs5lAPp9VqAQCVlZWIj4/3eXiIs6B1gtnOHhYiIjd3zYpOpwtyS6i3cP+tdKXeiYGlE9jDQkTUGoeBqLO642+FgaUTpBoW3viQiIgoKBhYOqF5an4OCREREQUDA0snuOdh0XJIiIiIKCgYWDrBzB4WIiLyA06613kMLJ0g3UuINSxERL3ahg0bMH78eERGRiImJga/+93vcPjwYel198zr0dHRCA0NxdixY7F9+3bp9X/+85+48MILodFoEBsbi6lTp0qvyWQyfP755x6fFxkZidWrVwMAjh07BplMhjVr1uCyyy6DRqPBe++9h5qaGkyfPh0pKSnQ6XTIyMjABx984HEcp9OJZ555BoMHD4ZarUb//v3x5JNPAgAmTJiA++67z2P/qqoqqFQqj3v/9XbsMugE6V5CnJqfiKgVQRDQ6Jr+IdC0IQqvrkAxmUzIz89HZmYmGhoasHDhQkydOhXFxcUwm8247LLLkJKSgi+//BKJiYnYtWuXdPPedevWYerUqXj00Ufx9ttvw2azYf369V63ee7cuXjuuedw/vnnQ6PRwGKxYMyYMXjkkUcQERGBdevW4ZZbbsGgQYMwbtw4AMC8efPwxhtv4Pnnn8f48eNRVlaGffv2AQBuv/123HfffXjuueegVqsBAO+++y5SUlIwYcIEr9vXUzGwdII0JMSbHxIRtdJod2Dkwq+C8tl7/p7n1RxZ119/vcfzVatWIS4uDnv27MH333+Pqqoq7Ny5E9HR0QCAwYMHS/s++eSTuPHGG/HYY49J27Kysrxu8wMPPIDrrrvOY9tDDz0kPf7Tn/6Er776Ch999BHGjRuH+vp6vPDCC3j55Zcxa9YsAMCgQYMwfvx4AMB1112H++67D1988QX+8Ic/AABWr16NW2+9tU9des4hoU6Qbn7Iolsiol7t4MGDmD59OgYOHIiIiAikp6cDEG/cW1xcjPPPP18KK2cqLi7GxIkTu9yGsWPHejx3OBx4/PHHkZGRgejoaISFheGrr75CSUkJAGDv3r2wWq3tfrZGo8Ett9yCVatWAQB27dqF3bt349Zbb+1yW3sSdhl0QBAEqYeFM90SEbWmDVFgz9/zgvbZ3pg8eTLS0tLwxhtvIDk5GU6nE+eddx5sNps0hXy7n9XB6zKZDGfeT7itotrQ0FCP588++yxeeOEFLFu2DBkZGQgNDcUDDzwAm83Wqc8FxGGh0aNH4+TJk3jzzTcxYcIEpKWldfi+3oQ9LB2wOZxwOMU/QBbdEhG1JpPJoFMpg7J4M+RRU1OD/fv3Y/78+Zg4cSJGjBiB06dPS69nZmaiuLgYtbW1bb4/MzPzrEWscXFxKCsrk54fPHgQZrO5w3Zt2bIFU6ZMwc0334ysrCwMHDgQBw4ckF4fMmQItFrtWT87IyMDY8eOxRtvvIH3338ff/zjHzv83N6GgaUD7oJbgEW3RES9WVRUFGJiYvD666/j0KFD+Oabb5Cfny+9Pn36dCQmJuLaa6/Fli1bcOTIEXzyySfYunUrAGDRokX44IMPsGjRIuzduxe//PILnn76aen9EyZMwMsvv4wff/wRP/zwA+6++26EhIR02K4hQ4Zg48aN+P7777F3717cddddqKiokF7XaDR45JFH8PDDD+Ptt9/G4cOHsW3bNqxcudLjOLfffjuWLFkCQRA8rl7qKxhYOuCuX1Ep5VAqeLqIiHoruVyODz/8EEVFRTjvvPPw4IMP4tlnn5VeV6lU+M9//oP4+HhMmjQJGRkZWLJkiXR34csvvxxr167Fl19+idGjR2PChAnYsWOH9P7nnnsOqampuOSSS3DTTTfhoYce6tQNIufPn48LLrgAeXl5uPzyy6XQ1NKCBQvwl7/8BQsXLsSIESMwbdo0VFZWeuwzffp0KJVKTJ8+HRqNpgtnqmeSCWcOuPVCRqMRer0eBoMBERER3XrsgxX1uOL5/yJKF4IfF17ZrccmIuqNLBYLjh49igEDBvTJH8be6tixYxg0aBB27tyJCy64INjN8dDe34w3v9+sIu2AiQW3RETUg9ntdtTU1GD+/Pn4zW9+0+PCSnfhGEcHzFZe0kxERD3Xli1bkJSUhJ07d2LFihXBbo7fsNugA9IlzZw0joiIeqDLL7+81eXUfRF7WDogTRrHK4SIiIiChoGlA43StPwMLERERMHCwNIBFt0SEREFHwNLB1h0S0REFHwMLB0w29nDQkREFGwMLB1w97CwhoWIiCh4GFg64K5h0XJIiIjonJeeno5ly5YFuxnnJAaWDkhXCXFIiIiIKGgYWDrgnoeFPSxERNSbORwOOJ3OYDfDZwwsHTBb2cNCRNQXvP7660hOTm71oz1lyhT88Y9/xOHDhzFlyhQkJCQgLCwMF154Ib7++mufP2/p0qXIyMhAaGgoUlNTce+996KhocFjny1btuDyyy+HTqdDVFQU8vLycPr0aQCA0+nEM888g8GDB0OtVqN///548sknAQDfffcdZDIZ6urqpGMVFxdDJpPh2LFjAIDVq1cjMjISX375JUaOHAm1Wo2SkhLs3LkTV1xxBWJjY6HX63HZZZdh165dHu2qq6vDXXfdhYSEBGg0Gpx33nn417/+BZPJhIiICHz88cce+3/++ecIDQ1FfX29z+erIwwsHTDbXZc1s+iWiKhtggDYTMFZvJiS/oYbbkBNTQ2+/fZbaVttbS02bNiAGTNmoKGhAZMmTUJhYSF+/PFHXHXVVZg8eTJKSkp8Oi1yuRwvvvgifv31V7z11lv45ptv8PDDD0uvFxcXY+LEiRg5ciS2bt2KzZs3Y/LkyXA4xH8oz5s3D0uWLMGCBQuwZ88evP/++0hISPCqDWazGU8//TT+8Y9/4Ndff0V8fDzq6+sxa9YsbN68Gdu2bcOQIUMwadIkKWw4nU5cffXV2LJlC959913s2bMHS5YsgUKhQGhoKG688Ua8+eabHp/z5ptv4ve//z3Cw8N9OledwW6DDrh7WDg1PxFRO+xm4Knk4Hz230oBVWindo2KisLVV1+N999/HxMnTgQAfPzxx4iNjcVvf/tbyOVyZGVlSfs//vjj+Oyzz/Dll1/ivvvu87ppDzzwgPQ4PT0dTzzxBO6++2688sorAIBnnnkGY8eOlZ4DwKhRowAA9fX1eOGFF/Dyyy9j1qxZAIBBgwZh/PjxXrXBbrfjlVde8fheEyZM8Njn9ddfR2RkJDZt2oTf/e53+Prrr7Fjxw7s3bsXQ4cOBQAMHDhQ2v/222/HRRddhLKyMiQlJaGyshLr16/vUm9UZ7CHpQNmaWp+Zjsiot5uxowZ+OSTT2C1WgEA7733Hm688UbI5XI0NDTgoYcewogRIxAZGYmwsDDs3bvX5x6Wr7/+GhMnTkRKSgrCw8Nxyy23oKamBmazGUBzD0tb9u7dC6vV2u7rnaVSqZCZmemxraKiAnfccQeGDBkCvV6PiIgINDQ0SN+zuLgY/fr1k8LKmcaNG4dRo0bhrbfeAgC8++67SEtLw6WXXtqltnaEv8IdkG5+yKJbIqK2hejEno5gfbYXJk+eDEEQsG7dOlx44YX43//+h+effx4A8NBDD2Hjxo34v//7PwwePBharRa///3vYbPZvG7WsWPH8Lvf/Q733HMPnnzySURHR2Pz5s247bbbYLPZoNPpoNVq233/2V4DxOEmAB53abbb7W0eRyaTeWybNWsWampq8MILLyAtLQ1qtRo5OTnS9+zoswGxl2X58uWYO3cu3nzzTcyePbvV53Q3n3pYli9fjvT0dGg0GmRnZ2PHjh1n3b+urg5z5sxBUlIS1Go1hg4divXr13fpmIEgCILUw8KZbomI2iGTicMywVi8/JHUaDS47rrr8N577+GDDz7AsGHDcMEFFwAQC2BvvfVWTJ06FRkZGUhMTJQKWL1VVFQEp9OJ5557Dr/5zW8wdOhQlJZ6hrrMzEwUFha2+f4hQ4ZAq9W2+3pcXBwAoKysTNpWXFzcqbZt2bIFf/7znzFp0iSMGjUKarUa1dXVHu06efIkDhw40O4xbr75Zhw/fhwvvvgi9uzZIw1b+ZPXgWXNmjXIz8/HokWLsGvXLmRlZSEvLw+VlZVt7m+z2XDFFVfg2LFj+Pjjj7F//3688cYbSElJ8fmYgWJzOOFwiumVRbdERH3DjBkzsG7dOqxatQozZsyQtg8ZMgSffvopiouL8dNPP+Gmm27y+TLgwYMHw26346WXXsKRI0fwzjvvYMWKFR77zJs3Dzt37sS9996Ln3/+Gfv27cOrr76K6upqaDQaPPLII3j44Yfx9ttv4/Dhw9i2bRtWrlwpHT81NRWLFy/GwYMHsW7dOjz33HOdatuQIUPwzjvvYO/evdi+fTtmzJjh0aty2WWX4dJLL8X111+PjRs34ujRo/j3v/+NDRs2SPtERUXhuuuuw1//+ldceeWV6Nevn0/nySuCl8aNGyfMmTNHeu5wOITk5GShoKCgzf1fffVVYeDAgYLNZuu2Y57JYDAIAASDwdDJb9E5jbYm4fmN+4Un1+0R7E2Obj02EVFv1djYKOzZs0dobGwMdlN84nA4hKSkJAGAcPjwYWn70aNHhd/+9reCVqsVUlNThZdfflm47LLLhPvvv1/aJy0tTXj++ec79TlLly4VkpKSBK1WK+Tl5Qlvv/22AEA4ffq0tM93330nXHTRRYJarRYiIyOFvLw86XWHwyE88cQTQlpamhASEiL0799feOqpp6T3bt68WcjIyBA0Go1wySWXCGvXrhUACEePHhUEQRDefPNNQa/Xt2rXrl27hLFjxwoajUYYMmSIsHbt2lbfq6amRpg9e7YQExMjaDQa4bzzzhP+9a9/eRynsLBQACB89NFHHZ6L9v5mvPn9lglC568Jc4+7ffzxx7j22mul7bNmzUJdXR2++OKLVu+ZNGkSoqOjodPp8MUXXyAuLg433XQTHnnkESgUCp+OeSaj0Qi9Xg+DwYCIiIjOfh0iIvKBxWLB0aNHMWDAAGg0mmA3h4LknXfewYMPPojS0lKoVKqz7tve34w3v99eFWZUV1fD4XC0ug48ISEB+/bta/M9R44cwTfffIMZM2Zg/fr1OHToEO69917Y7XYsWrTIp2NarVapwhsQvzARERH5n9lsRllZGZYsWYK77rqrw7DSXfx+WbPT6UR8fDxef/11jBkzBtOmTcOjjz7aaizPGwUFBdDr9dKSmprajS0mIiI6u/feew9hYWFtLu65VPqqZ555BsOHD0diYiLmzZsXsM/1qoclNjYWCoUCFRUVHtsrKiqQmJjY5nuSkpIQEhIChaK5aHXEiBEoLy+HzWbz6Zjz5s1Dfn6+9NxoNDK0EBFRwPy///f/kJ2d3eZrISEhAW5NYC1evBiLFy8O+Od61cOiUqkwZswYj8usnE4nCgsLkZOT0+Z7Lr74Yhw6dMij0vrAgQNISkqCSqXy6ZhqtRoREREeCxERUaCEh4dj8ODBbS5paWnBbl6f5PWQUH5+Pt544w289dZb2Lt3L+655x6YTCbMnj0bADBz5kyPLqJ77rkHtbW1uP/++3HgwAGsW7cOTz31FObMmdPpYxIREdG5zevZ0KZNm4aqqiosXLgQ5eXlGD16NDZs2CAVzZaUlEgz8AFAamoqvvrqKzz44IPIzMxESkoK7r//fjzyyCOdPiYREfU8vs5RQuee7vhb8eqy5p6KlzUTEQWO0+nEwYMHoVAoEBcXB5VK5fdp2al3EgQBNpsNVVVVcDgcGDJkiEenht8uayYiIpLL5RgwYADKyspaTTdP1BadTof+/ft7hBVvMbAQEZHXVCoV+vfvj6amJjgcjmA3h3owhUIBpVLZ5V44BhYiIvKJTCZDSEhIn7+Ml3oGv08cR0RERNRVDCxERETU4zGwEBERUY/XJ2pY3Fdm8yaIREREvYf7d7szM6z0icBSX18PALyfEBERUS9UX18PvV5/1n36xMRxTqcTpaWlCA8P7/bJi9w3Vjxx4gQnpQsAnu/A4vkOLJ7vwOL5DixfzrcgCKivr0dycnKHc7T0iR4WuVyOfv36+fUzeJPFwOL5Diye78Di+Q4snu/A8vZ8d9Sz4saiWyIiIurxGFiIiIiox2Ng6YBarcaiRYugVquD3ZRzAs93YPF8BxbPd2DxfAeWv893nyi6JSIior6NPSxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9XgMLB1Yvnw50tPTodFokJ2djR07dgS7SX3Cf//7X0yePBnJycmQyWT4/PPPPV4XBAELFy5EUlIStFotcnNzcfDgweA0tpcrKCjAhRdeiPDwcMTHx+Paa6/F/v37PfaxWCyYM2cOYmJiEBYWhuuvvx4VFRVBanHv9uqrryIzM1OaPCsnJwf//ve/pdd5rv1ryZIlkMlkeOCBB6RtPOfdZ/HixZDJZB7L8OHDpdf9ea4ZWM5izZo1yM/Px6JFi7Br1y5kZWUhLy8PlZWVwW5ar2cymZCVlYXly5e3+fozzzyDF198EStWrMD27dsRGhqKvLw8WCyWALe099u0aRPmzJmDbdu2YePGjbDb7bjyyithMpmkfR588EH885//xNq1a7Fp0yaUlpbiuuuuC2Kre69+/fphyZIlKCoqwg8//IAJEyZgypQp+PXXXwHwXPvTzp078dprryEzM9NjO8959xo1ahTKysqkZfPmzdJrfj3XArVr3Lhxwpw5c6TnDodDSE5OFgoKCoLYqr4HgPDZZ59Jz51Op5CYmCg8++yz0ra6ujpBrVYLH3zwQRBa2LdUVlYKAIRNmzYJgiCe25CQEGHt2rXSPnv37hUACFu3bg1WM/uUqKgo4R//+AfPtR/V19cLQ4YMETZu3Chcdtllwv333y8IAv++u9uiRYuErKysNl/z97lmD0s7bDYbioqKkJubK22Ty+XIzc3F1q1bg9iyvu/o0aMoLy/3OPd6vR7Z2dk8993AYDAAAKKjowEARUVFsNvtHud7+PDh6N+/P893FzkcDnz44YcwmUzIycnhufajOXPm4JprrvE4twD/vv3h4MGDSE5OxsCBAzFjxgyUlJQA8P+57hM3P/SH6upqOBwOJCQkeGxPSEjAvn37gtSqc0N5eTkAtHnu3a+Rb5xOJx544AFcfPHFOO+88wCI51ulUiEyMtJjX55v3/3yyy/IycmBxWJBWFgYPvvsM4wcORLFxcU8137w4YcfYteuXdi5c2er1/j33b2ys7OxevVqDBs2DGVlZXjsscdwySWXYPfu3X4/1wwsROeQOXPmYPfu3R5jztT9hg0bhuLiYhgMBnz88ceYNWsWNm3aFOxm9UknTpzA/fffj40bN0Kj0QS7OX3e1VdfLT3OzMxEdnY20tLS8NFHH0Gr1fr1szkk1I7Y2FgoFIpW1c0VFRVITEwMUqvODe7zy3Pfve677z7861//wrfffot+/fpJ2xMTE2Gz2VBXV+exP8+371QqFQYPHowxY8agoKAAWVlZeOGFF3iu/aCoqAiVlZW44IILoFQqoVQqsWnTJrz44otQKpVISEjgOfejyMhIDB06FIcOHfL73zcDSztUKhXGjBmDwsJCaZvT6URhYSFycnKC2LK+b8CAAUhMTPQ490ajEdu3b+e594EgCLjvvvvw2Wef4ZtvvsGAAQM8Xh8zZgxCQkI8zvf+/ftRUlLC891NnE4nrFYrz7UfTJw4Eb/88guKi4ulZezYsZgxY4b0mOfcfxoaGnD48GEkJSX5/++7y2W7fdiHH34oqNVqYfXq1cKePXuEO++8U4iMjBTKy8uD3bRer76+Xvjxxx+FH3/8UQAgLF26VPjxxx+F48ePC4IgCEuWLBEiIyOFL774Qvj555+FKVOmCAMGDBAaGxuD3PLe55577hH0er3w3XffCWVlZdJiNpulfe6++26hf//+wjfffCP88MMPQk5OjpCTkxPEVvdec+fOFTZt2iQcPXpU+Pnnn4W5c+cKMplM+M9//iMIAs91ILS8SkgQeM6701/+8hfhu+++E44ePSps2bJFyM3NFWJjY4XKykpBEPx7rhlYOvDSSy8J/fv3F1QqlTBu3Dhh27ZtwW5Sn/Dtt98KAFots2bNEgRBvLR5wYIFQkJCgqBWq4WJEycK+/fvD26je6m2zjMA4c0335T2aWxsFO69914hKipK0Ol0wtSpU4WysrLgNboX++Mf/yikpaUJKpVKiIuLEyZOnCiFFUHguQ6EMwMLz3n3mTZtmpCUlCSoVCohJSVFmDZtmnDo0CHpdX+ea5kgCELX+2mIiIiI/Ic1LERERNTjMbAQERFRj8fAQkRERD0eAwsRERH1eAwsRERE1OMxsBAREVGPx8BCREREPR4DCxEREfV4DCxERETU4zGwEBERUY/HwEJEREQ9HgMLERER9Xj/HwN7ZhH5PrzQAAAAAElFTkSuQmCC"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "history = nnlm_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Training Swivel"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 39,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "swivel_model = build_model(swivel_module, name='swivel')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 40,
-   "metadata": {},
+   "source": [
+    "swivel_history = train_and_evaluate(data, val_data, swivel_model)"
+   ],
    "outputs": [
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:35:28.659782: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:35:28.659830: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n",
@@ -1614,16 +1613,16 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "Epoch 1/50\n",
       " 6/51 [==>...........................] - ETA: 1s - loss: 1.3236 - accuracy: 0.2742"
      ]
     },
     {
-     "name": "stderr",
      "output_type": "stream",
+     "name": "stderr",
      "text": [
       "2023-07-31 13:35:29.196649: I tensorflow/core/profiler/lib/profiler_session.cc:131] Profiler session initializing.\n",
       "2023-07-31 13:35:29.196700: I tensorflow/core/profiler/lib/profiler_session.cc:146] Profiler session started.\n",
@@ -1645,8 +1644,8 @@
      ]
     },
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "51/51 [==============================] - 2s 29ms/step - loss: 1.0789 - accuracy: 0.4533 - val_loss: 0.8935 - val_accuracy: 0.6139\n",
       "Epoch 2/50\n",
@@ -1750,311 +1749,77 @@
      ]
     }
    ],
-   "source": [
-    "swivel_history = train_and_evaluate(data, val_data, swivel_model)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 41,
-   "metadata": {},
+   "source": [
+    "history = swivel_history\n",
+    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
+    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+   ],
    "outputs": [
     {
+     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "<AxesSubplot: >"
       ]
      },
-     "execution_count": 41,
      "metadata": {},
-     "output_type": "execute_result"
+     "execution_count": 41
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABM1UlEQVR4nO3deXhU9aH/8fcsmckeyM4SVlkVAqKk0bZuUYqWi8v10moFsdLWQqumva20KtVepf31lmItFqUi1WqltYJWKepF0aooyqLsgiBhy8aSPTPJzPn9MUsmIYFMksnJ8nk9z3nOzJlzznznGJnPfLdjMQzDQERERMQkVrMLICIiIr2bwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFTKYyIiIiIqRRGRERExFQKIyIiImIqu9kFaA2v18vRo0dJSEjAYrGYXRwRERFpBcMwqKiooH///litLdd/dIswcvToUbKysswuhoiIiLTBoUOHGDhwYIuvd4swkpCQAPg+TGJiosmlERERkdYoLy8nKysr+D3ekm4RRgJNM4mJiQojIiIi3czZulioA6uIiIiYKuww8s477zBt2jT69++PxWJh9erVZ9z/2LFj3HTTTYwcORKr1cpdd93VxqKKiIhITxR2GKmqqiI7O5slS5a0an+Xy0VaWhr33nsv2dnZYRdQREREeraw+4xMnTqVqVOntnr/IUOG8MgjjwCwfPnycN9OREQEAI/HQ11dndnFkBA2mw273d7uaTe6ZAdWl8uFy+UKPi8vLzexNCIiYrbKykoOHz6MYRhmF0WaiI2NpV+/fjgcjjafo0uGkYULF/LAAw+YXQwREekCPB4Phw8fJjY2lrS0NE1+2UUYhoHb7aakpIQDBw4wYsSIM05sdiZdMozMnz+f/Pz84PPAOGUREel96urqMAyDtLQ0YmJizC6OhIiJiSEqKoqDBw/idruJjo5u03m6ZBhxOp04nU6ziyEiIl2IakS6prbWhjQ6RweUQ0RERKTNwq4ZqaysZN++fcHnBw4cYOvWrSQnJzNo0CDmz5/PkSNHePrpp4P7bN26NXhsSUkJW7duxeFwMHbs2PZ/AhEREenWwg4jH3/8MZdddlnweaBvx6xZs1ixYgXHjh2joKCg0TETJ04MPt60aRPPPfccgwcP5osvvmhjsUVERLq2Sy+9lAkTJrB48WKzi9LlhR1GLr300jMOrVqxYsVp2zQUS0RERFrSJTuwdpZVWw6zpeAUXx/fn8lDk80ujoiISK/Uqzuwvrm7hKc3HGTbkTKziyIiIq1kGAbV7npTlrbW9J88eZKZM2fSt29fYmNjmTp1Knv37g2+fvDgQaZNm0bfvn2Ji4vj3HPPZc2aNcFjb7755uDQ5hEjRvDUU091yLXsKnp1zUhKnG+2uOOVrrPsKSIiXUVNnYex979mynvvfHAKsY7wvzpvvfVW9u7dy8svv0xiYiI//elPufrqq9m5cydRUVHMnTsXt9vNO++8Q1xcHDt37iQ+Ph6A++67j507d/Kvf/2L1NRU9u3bR01NTUd/NFMpjAAnqtwml0RERHqqQAh57733uOiiiwB49tlnycrKYvXq1dx4440UFBRwww03MG7cOACGDRsWPL6goICJEydywQUXAL57vvU0vTqMJMf7a0YURkREuo2YKBs7H5xi2nuHa9euXdjtdnJycoLbUlJSGDVqFLt27QLghz/8IXfccQevv/46eXl53HDDDYwfPx6AO+64gxtuuIHNmzdz1VVXce211wZDTU/Rq/uMqJlGRKT7sVgsxDrspiyRmgX29ttvZ//+/dxyyy1s27aNCy64gEcffRSAqVOncvDgQe6++26OHj3KFVdcwY9//OOIlMMsvTuMxPumnFczjYiIRMqYMWOor6/nww8/DG47fvw4e/bsaTT5Z1ZWFt/73vd48cUX+dGPfsSyZcuCr6WlpTFr1iz+8pe/sHjxYp544olO/QyR1rubaYI1IwojIiISGSNGjGD69OnMmTOHxx9/nISEBO655x4GDBjA9OnTAbjrrruYOnUqI0eO5OTJk7z11luMGTMGgPvvv59JkyZx7rnn4nK5eOWVV4Kv9RS9umYkNc5XM1LhqsdV7zG5NCIi0lM99dRTTJo0ia9//evk5uZiGAZr1qwhKioKAI/Hw9y5cxkzZgxf+9rXGDlyJI899hgADoeD+fPnM378eL761a9is9l4/vnnzfw4Hc5idIPpUcvLy0lKSqKsrIzExMQOO69hGIz4+b+o9xp8MP8KMpPadutjERGJnNraWg4cOMDQoUPbfIt6iZwz/fdp7fd3r64ZsVgs9PU31ZSqE6uIiIgpenUYAc01IiIiYjaFkXiFERERETP1+jCS7O/EqmYaERERc/T6MKJmGhEREXMpjGiuEREREVMpjPhnYdX9aURERMzR68NIcrCZRn1GREREzNDrw0iK7twrIiJiKoWRQM2I+oyIiEgXMmTIEBYvXtyqfS0WC6tXr45oeSJJYUT3pxERETFVrw8jiTF27FYLoOG9IiIiZuj1YcRisQQ7sWp4r4hIN2AY4K4yZ2nlvWWfeOIJ+vfvj9frbbR9+vTp3HbbbXz++edMnz6djIwM4uPjufDCC/m///u/DrtE27Zt4/LLLycmJoaUlBS+853vUFlZGXx9/fr1TJ48mbi4OPr06cPFF1/MwYMHAfjkk0+47LLLSEhIIDExkUmTJvHxxx93WNmaY4/o2buJ5DgHxRUudWIVEekO6qrh4f7mvPfPjoIj7qy73XjjjfzgBz/grbfe4oorrgDgxIkTrF27ljVr1lBZWcnVV1/NQw89hNPp5Omnn2batGns2bOHQYMGtauIVVVVTJkyhdzcXD766COKi4u5/fbbmTdvHitWrKC+vp5rr72WOXPm8Ne//hW3283GjRuxWHytBDfffDMTJ07kj3/8Izabja1btxIVFdWuMp2Nwgih96fR8F4REWm/vn37MnXqVJ577rlgGHnhhRdITU3lsssuw2q1kp2dHdz/l7/8JatWreLll19m3rx57Xrv5557jtraWp5++mni4nzB6Q9/+APTpk3j17/+NVFRUZSVlfH1r3+d4cOHAzBmzJjg8QUFBfz3f/83o0ePBmDEiBHtKk9rKIzQ0IlVzTQiIt1AVKyvhsKs926lm2++mTlz5vDYY4/hdDp59tln+cY3voHVaqWyspJf/OIXvPrqqxw7doz6+npqamooKChodxF37dpFdnZ2MIgAXHzxxXi9Xvbs2cNXv/pVbr31VqZMmcKVV15JXl4e//Vf/0W/fv0AyM/P5/bbb+eZZ54hLy+PG2+8MRhaIqXX9xmBhonP1EwjItINWCy+phIzFn9TRmtMmzYNwzB49dVXOXToEP/+97+5+eabAfjxj3/MqlWrePjhh/n3v//N1q1bGTduHG5353wPPfXUU2zYsIGLLrqIlStXMnLkSD744AMAfvGLX7Bjxw6uueYa3nzzTcaOHcuqVasiWh6FESA1XnONiIhIx4qOjub666/n2Wef5a9//SujRo3i/PPPB+C9997j1ltv5brrrmPcuHFkZmbyxRdfdMj7jhkzhk8++YSqqqrgtvfeew+r1cqoUaOC2yZOnMj8+fN5//33Oe+883juueeCr40cOZK7776b119/neuvv56nnnqqQ8rWEoURIDnQTKM+IyIi0oFuvvlmXn31VZYvXx6sFQFfP4wXX3yRrVu38sknn3DTTTedNvKmPe8ZHR3NrFmz2L59O2+99RY/+MEPuOWWW8jIyODAgQPMnz+fDRs2cPDgQV5//XX27t3LmDFjqKmpYd68eaxfv56DBw/y3nvv8dFHHzXqUxIJ6jOCmmlERCQyLr/8cpKTk9mzZw833XRTcPuiRYu47bbbuOiii0hNTeWnP/0p5eXlHfKesbGxvPbaa9x5551ceOGFxMbGcsMNN7Bo0aLg67t37+bPf/4zx48fp1+/fsydO5fvfve71NfXc/z4cWbOnElRURGpqalcf/31PPDAAx1StpZYDKOVg6b93nnnHX7zm9+wadMmjh07xqpVq7j22mvPeMz69evJz89nx44dZGVlce+993Lrrbe2+j3Ly8tJSkqirKyMxMTEcIrbKh9/cYL/XLqBwSmxvP3fl3X4+UVEpO1qa2s5cOAAQ4cOJTo62uziSBNn+u/T2u/vsJtpqqqqyM7OZsmSJa3a/8CBA1xzzTVcdtllbN26lbvuuovbb7+d1157Ldy3jhhNeiYiImKesJtppk6dytSpU1u9/9KlSxk6dCi//e1vAV/HmnfffZff/e53TJkyJdy3j4jA0N5K//1pnHabySUSERHxefbZZ/nud7/b7GuDBw9mx44dnVyijhfxPiMbNmwgLy+v0bYpU6Zw1113tXiMy+XC5WroTNpR7WgtCdyfpt5rcKLKTb+kmIi+n4iISGv9x3/8Bzk5Oc2+FumZUTtLxMNIYWEhGRkZjbZlZGRQXl5OTU0NMTGnf/EvXLgw4p1lQgXuT1Nc4eJ4pcKIiIh0HQkJCSQkJJhdjIjqkkN758+fT1lZWXA5dOhQxN8zJT4wvFf9RkREuqIwx1tIJ+mI/y4RrxnJzMykqKio0baioiISExObrRUBcDqdOJ3OSBetkZRgJ1bNNSIi0pXYbL5+fG63u8XvDTFPdXU10L4mo4iHkdzcXNasWdNo2xtvvEFubm6k3zosgRE1J1QzIiLSpdjtdmJjYykpKSEqKgqrtUtW6vc6hmFQXV1NcXExffr0CYbGtgg7jFRWVrJv377g8wMHDrB161aSk5MZNGgQ8+fP58iRIzz99NMAfO973+MPf/gDP/nJT7jtttt48803+dvf/sarr77a5kJHQuDOvWqmERHpWiwWC/369ePAgQMcPHjQ7OJIE3369CEzM7Nd5wg7jHz88cdcdlnDxGD5+fkAzJo1ixUrVnDs2LFGdx0cOnQor776KnfffTePPPIIAwcO5E9/+lOXGdYboGYaEZGuy+FwMGLEiE67kZy0TlRUVLtqRALCDiOXXnrpGTurrFixotljtmzZEu5bdarA/WnUTCMi0jVZrVbNwNpDqeHNT800IiIi5lAY8UvRlPAiIiKmUBjxC8wzomYaERGRzqUw4hcY2lvpqqe2zmNyaURERHoPhRG/xGg7UTYLoNoRERGRzqQw4he4Pw0ojIiIiHQmhZEQgeG9pZprREREpNMojIRIUc2IiIhIp1MYCRGYa0RhREREpPMojIQI9Bkp1VwjIiIinUZhJERDM436jIiIiHQWhZEQgYnPNAuriIhI51EYCRFoptH9aURERDqPwkiIVHVgFRER6XQKIyEC84wc1zwjIiIinUZhJESgmabK7dH9aURERDqJwkgI3Z9GRESk8ymMhAi9P41G1IiIiHQOhZEmgv1GNNeIiIhIp1AYaSIwokY1IyIiIp1DYaSJZN0sT0REpFMpjDSREmymURgRERHpDAojTaQEm2nUZ0RERKQzKIw0oWYaERGRzqUw0kSK7k8jIiLSqRRGmgg202hor4iISKdQGGkiMM/ICQ3tFRER6RQKI00EakZ0fxoREZHOoTDSRIKz4f406jciIiISeQojTVgsluBcI2qqERERiTyFkWYEhveWqhOriIhIxLUpjCxZsoQhQ4YQHR1NTk4OGzdubHHfuro6HnzwQYYPH050dDTZ2dmsXbu2zQXuDIF+I6oZERERibyww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcXGz+9977708/vjjPProo+zcuZPvfe97XHfddWzZsqXdhY+UFE18JiIi0mnCDiOLFi1izpw5zJ49m7Fjx7J06VJiY2NZvnx5s/s/88wz/OxnP+Pqq69m2LBh3HHHHVx99dX89re/bXfhIyUwvFfNNCIiIpEXVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3G5XERHRzfaFhMTw7vvvtvi+7hcLsrLyxstnUnNNCIiIp0nrDBSWlqKx+MhIyOj0faMjAwKCwubPWbKlCksWrSIvXv34vV6eeONN3jxxRc5duxYi++zcOFCkpKSgktWVlY4xWw3TQkvIiLSeSI+muaRRx5hxIgRjB49GofDwbx585g9ezZWa8tvPX/+fMrKyoLLoUOHIlO4A+/Au4uhaEejzckKIyIiIp3GHs7Oqamp2Gw2ioqKGm0vKioiMzOz2WPS0tJYvXo1tbW1HD9+nP79+3PPPfcwbNiwFt/H6XTidDrDKVrbbHwCdv0T7NGQcW5wc7CZRn1GREREIi6smhGHw8GkSZNYt25dcJvX62XdunXk5uae8djo6GgGDBhAfX09//jHP5g+fXrbStyRkv2B6MTnjTYHJj07rj4jIiIiERdWzQhAfn4+s2bN4oILLmDy5MksXryYqqoqZs+eDcDMmTMZMGAACxcuBODDDz/kyJEjTJgwgSNHjvCLX/wCr9fLT37yk479JG2RPNy3PrG/8WZ/zUi1//400VG2zi6ZiIhIrxF2GJkxYwYlJSXcf//9FBYWMmHCBNauXRvs1FpQUNCoP0htbS333nsv+/fvJz4+nquvvppnnnmGPn36dNiHaLMUfxg53rhmJMFpx2Gz4vZ4OV7lZkCfGBMKJyIi0jtYDMMwzC7E2ZSXl5OUlERZWRmJiYkdeOKjsGgMWGxwbxHYooIvfenhdRSW1/LyvIsZP7BPx72niIhIL9Ha7+/efW+ahH4QFQuGB04VNHpJI2pEREQ6R+8OIxZLQyfWJk01gRE16sQqIiISWb07jAAkD/WtTxtRo+G9IiIinUFhpKURNYHhvWqmERERiSiFETXTiIiImEphJDC8t8VmGoURERGRSFIYCTTTnCqA+obgkRKvZhoREZHOoDCSkOkf3uttNLw3OLS3Uh1YRUREIklhJHR4b0hTjZppREREOofCCISEkYYRNSkh96epcXvMKJWIiEivoDACzY6oifffnwbguOYaERERiRiFEWh2RI3FYgn2G1FTjYiISOQojECLE59prhEREZHIUxiBhmaaJsN7dbM8ERGRyFMYAf/w3rjThvfq/jQiIiKRpzACLQ/vDUx8pmYaERGRiFEYCQjcvTdkRI2aaURERCJPYSQg5fROrKnxmoVVREQk0hRGApJPH96bHOdrptHQXhERkchRGAloZuIzNdOIiIhEnsJIQKCZpuxQcHhvquYZERERiTiFkYD4jJDhvQeBhpqRmjrdn0ZERCRSFEYCQof3+ptqdH8aERGRyFMYCZXS+O69FotFU8KLiIhEmMJIqGZH1OhmeSIiIpGkMBKqmRE1gVlYSzXXiIiISEQojIRqZuKzFNWMiIiIRJTCSKjk04f3qplGREQkshRGQsWngyPeN7z35BcAwQ6sJRVqphEREYkEhZFQFkvDDfP8TTWDk+MA2F9aZVapREREerQ2hZElS5YwZMgQoqOjycnJYePGjWfcf/HixYwaNYqYmBiysrK4++67qa2tbVOBI67JiJoRGfEA7CuuxDAMs0olIiLSY4UdRlauXEl+fj4LFixg8+bNZGdnM2XKFIqLi5vd/7nnnuOee+5hwYIF7Nq1iyeffJKVK1fys5/9rN2Fj4gmI2qGpMRhs1qodNVTWN5FA5SIiEg3FnYYWbRoEXPmzGH27NmMHTuWpUuXEhsby/Lly5vd//333+fiiy/mpptuYsiQIVx11VV885vfPGttimmajKhx2K0MSYkFYG9RpVmlEhER6bHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDsMRdddBGbNm0Kho/9+/ezZs0arr766hbfx+VyUV5e3mjpNM1MfDYiPQGAvcUKIyIiIh0trDBSWlqKx+MhIyOj0faMjAwKCwubPeamm27iwQcf5Mtf/jJRUVEMHz6cSy+99IzNNAsXLiQpKSm4ZGVlhVPM9gk005QdhnrfCJrQfiMiIiLSsSI+mmb9+vU8/PDDPPbYY2zevJkXX3yRV199lV/+8pctHjN//nzKysqCy6FDhyJdzAaNhvf67t57TnogjFR0XjlERER6CXs4O6empmKz2SgqKmq0vaioiMzMzGaPue+++7jlllu4/fbbARg3bhxVVVV85zvf4ec//zlW6+l5yOl04nQ6wylaxwncvbfwU19TTdrIYBj5rMg3osZisZhTNhERkR4orJoRh8PBpEmTWLduXXCb1+tl3bp15ObmNntMdXX1aYHDZrMBdN2hsk1G1AxPi8digbKaOkp1914REZEOFVbNCEB+fj6zZs3iggsuYPLkySxevJiqqipmz54NwMyZMxkwYAALFy4EYNq0aSxatIiJEyeSk5PDvn37uO+++5g2bVowlHQ5TUbUREfZGJQcy8Hj1ewtriAtwaRaGxERkR4o7DAyY8YMSkpKuP/++yksLGTChAmsXbs22Km1oKCgUU3Ivffei8Vi4d577+XIkSOkpaUxbdo0HnrooY77FB2t2RE18Rw8Xs3nxZVcNDzVpIKJiIj0PBajy7aVNCgvLycpKYmysjISExMj/4YHN8BTX4OkQXD3NgB+9a/dLH37c2bmDubB6edFvgwiIiLdXGu/v3VvmuakhN691ze8N9CJVROfiYiIdCyFkebEpYEjATCCd+8dEQgjmmtERESkQymMNKeZu/cO94eR0koXp6o1okZERKSjKIy0JNBU4x/eG++0M6BPDKCZWEVERDqSwkhLmhlRc46aakRERDqcwkhLAhOf+ZtpIKTfiDqxioiIdBiFkZYEm2kawkhDzYjuUSMiItJRFEZakhwyvLeuFtDde0VERCJBYaQlcakNw3tP+e/em5YAwLGyWipq60wsnIiISM+hMNISiwVSGt8wLyk2inT/fWk+L6kyq2QiIiI9isLImTR3j5qMQCdW9RsRERHpCAojZ9LsiBpfU436jYiIiHQMhZEzaTLxGTTMxKq5RkRERDqGwsiZBJtpmplrRMN7RUREOoTCyJkEmmnKDjcM7/WHkcMna6hxe8wqmYiISI+hMHImcangTCT07r0p8U6S4xwYBnxeoqYaERGR9lIYOROLJaQT6+n3qFEnVhERkfZTGDmbZkbUaFp4ERGRjqMwcjbBETX7gpt0wzwREZGOozByNmmjfeviXcFNmmtERESk4yiMnE3mON+6cDt4vUDDLKwHT1TjqteIGhERkfZQGDmb5OFgj4a6Kjh5AID0BCcJ0XY8XoMvSqtNLqCIiEj3pjByNjY7pI/1PS7cBoDFYtHkZyIiIh1EYaQ1gk0124KbzlEnVhERkQ6hMNIazYQRdWIVERHpGAojrREII0Xbg5vOydDEZyIiIh1BYaQ1Ms71rcuPQNVxoGGukf2lldR7vGaVTEREpNtTGGkNZwL0Hep7XORrqumfFEOsw0adx+DgCY2oERERaSuFkdYKnW8EsFot6sQqIiLSARRGWitzvG8dOqImLdBvRMN7RURE2kphpLUyz/OtQ8OIOrGKiIi0W5vCyJIlSxgyZAjR0dHk5OSwcePGFve99NJLsVgspy3XXHNNmwttikAzTekeqHcBDcN79yqMiIiItFnYYWTlypXk5+ezYMECNm/eTHZ2NlOmTKG4uLjZ/V988UWOHTsWXLZv347NZuPGG29sd+E7VeIAiOkL3noo2Q00jKjZV1yJx2uYWToREZFuK+wwsmjRIubMmcPs2bMZO3YsS5cuJTY2luXLlze7f3JyMpmZmcHljTfeIDY2tvuFEYsFMgJNNb5OrFnJsTjsVlz1Xo6crDGxcCIiIt1XWGHE7XazadMm8vLyGk5gtZKXl8eGDRtadY4nn3ySb3zjG8TFxbW4j8vlory8vNHSJTTpxGqzWhiepnvUiIiItEdYYaS0tBSPx0NGRkaj7RkZGRQWFp71+I0bN7J9+3Zuv/32M+63cOFCkpKSgktWVlY4xYycM92jRv1GRERE2qRTR9M8+eSTjBs3jsmTJ59xv/nz51NWVhZcDh061EklPIvAiJqibWD4+oiE9hsRERGR8NnD2Tk1NRWbzUZRUVGj7UVFRWRmZp7x2KqqKp5//nkefPDBs76P0+nE6XSGU7TOkToKrFFQWwZlh6DPoGAYUc2IiIhI24RVM+JwOJg0aRLr1q0LbvN6vaxbt47c3NwzHvv3v/8dl8vFt771rbaVtCuwOyB9tO+xv6lmRGCukaIKDEMjakRERMIVdjNNfn4+y5Yt489//jO7du3ijjvuoKqqitmzZwMwc+ZM5s+ff9pxTz75JNdeey0pKSntL7WZMhpPCz84JQ671UKV28OxsloTCyYiItI9hdVMAzBjxgxKSkq4//77KSwsZMKECaxduzbYqbWgoACrtXHG2bNnD++++y6vv/56x5TaTJnj4BOg8FMAomxWhqbGsbe4kr3FlfTvE2Nu+URERLqZsMMIwLx585g3b16zr61fv/60baNGjeo5TRjNTQufHs/e4kr2FVdyycg0kwomIiLSPeneNOEKTHx26qCvIyuhI2o014iIiEi4FEbCFZsMSf55T4p2AHBOhu8eNZ8VaUSNiIhIuBRG2iKjcVPN6ExfGNl1rFz3qBEREQmTwkhbNJmJdXhaPLEOG9VuD5+XqHZEREQkHAojbdEkjNisFsYNSAJg66FTJhVKRESke1IYaYvAiJriXeCpByA7qw8Anx4+ZU6ZREREuimFkbboMwQcCeBxwfG9AGQP7APAJ4fKzCuXiIhIN6Qw0hZW62nzjYwf6Gum2V1YjqveY1bJREREuh2FkbZqMqJmYN8YUuIc1HkMdh3TfCMiIiKtpTDSVk06sVoslmDtyCfqxCoiItJqCiNtFRpG/FPdjw/0G1EnVhERkVZTGGmr9DFgsUJ1KVQWATDBP6JGNSMiIiKtpzDSVlExkDrS97hJJ9b9pVWU19aZVTIREZFuRWGkPYJNNZ8CkBLvZGDfGAwDth/WEF8REZHWUBhpj+CImu3BTcH5RhRGREREWkVhpD2ajKiBhqYazcQqIiLSOgoj7REII8f3gbsKaJgWXp1YRUREWkdhpD3i0yE+AzB896kBzhuQhMUCR8tqKa6oNbd8IiIi3YDCSHs16cQa77QzIj0egE91nxoREZGzUhhpr2b7jfQB1G9ERESkNRRG2qu5ETWBfiMaUSMiInJWCiPtlTnety7aAV7f3XqzA/eoOXwKwz9VvIiIiDRPYaS9UoaDPQbqquDEAQBGZybisFk5VV3HoRM1JhdQRESka1MYaS+rDTLG+h4X+fqNOOxWxvRPBGCr+o2IiIickcJIR2imE2ugqeZTzTciIiJyRgojHaHZMNIH8PUbERERkZYpjHSEzGzf+vDH4PUCkJ3lqxnZfqSceo/XrJKJiIh0eQojHaH/BHDEQ80JKPIN8R2WGk+8005NnYd9JZXmlk9ERKQLUxjpCLYoGHyR7/GBtwGwWi2MG+Af4qt+IyIiIi1SGOkoQy/xrfe/Hdw0Pisw34gmPxMREWmJwkhHGeYPIwffh3o3ABMCnVhVMyIiItKiNoWRJUuWMGTIEKKjo8nJyWHjxo1n3P/UqVPMnTuXfv364XQ6GTlyJGvWrGlTgbus9HMhNsU3+dmRTQCM908Lv6ewgto6j4mFExER6brCDiMrV64kPz+fBQsWsHnzZrKzs5kyZQrFxcXN7u92u7nyyiv54osveOGFF9izZw/Lli1jwIAB7S58l2K1wtCv+h77+430T4omNd5Jvddgx9FyEwsnIiLSdYUdRhYtWsScOXOYPXs2Y8eOZenSpcTGxrJ8+fJm91++fDknTpxg9erVXHzxxQwZMoRLLrmE7Ozsdhe+y2nSb8RisTRMfqb5RkRERJoVVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3n55ZfJzc1l7ty5ZGRkcN555/Hwww/j8bTcbOFyuSgvL2+0dAuBfiOHPwJ3FQDj/f1GPlUnVhERkWaFFUZKS0vxeDxkZGQ02p6RkUFhYWGzx+zfv58XXngBj8fDmjVruO+++/jtb3/L//zP/7T4PgsXLiQpKSm4ZGVlhVNM8/QdCkmDwFsHB33hLDD5mTqxioiINC/io2m8Xi/p6ek88cQTTJo0iRkzZvDzn/+cpUuXtnjM/PnzKSsrCy6HDh2KdDE7hsUCwwL9RtYDDTUj+0urKKupM6dcIiIiXVhYYSQ1NRWbzUZRUVGj7UVFRWRmZjZ7TL9+/Rg5ciQ2my24bcyYMRQWFuJ2u5s9xul0kpiY2GjpNoZe6lv7+40kxzkYlBwLwDY11YiIiJwmrDDicDiYNGkS69atC27zer2sW7eO3NzcZo+5+OKL2bdvH15vw/1ZPvvsM/r164fD4WhjsbuwwIiawm1QfQKA8QMDk5+dMqlQIiIiXVfYzTT5+fksW7aMP//5z+zatYs77riDqqoqZs+eDcDMmTOZP39+cP877riDEydOcOedd/LZZ5/x6quv8vDDDzN37tyO+xRdSUIGpI0BDDjwDtBwB1+NqBERETmdPdwDZsyYQUlJCffffz+FhYVMmDCBtWvXBju1FhQUYLU2ZJysrCxee+017r77bsaPH8+AAQO48847+elPf9pxn6KrGXYJlOzyzTdy7rVk+yc/++SQmmlERESashiGYZhdiLMpLy8nKSmJsrKy7tF/ZPcaeP6bkDwcfriZanc95y14Da8BH/7sCjISo80uoYiISMS19vtb96aJhCEXg8UKJz6HssPEOuyMzEgANMRXRESkKYWRSIhOgv7n+x77R9WMD87EqqYaERGRUAojkRKYjdV/n5pgvxF1YhUREWlEYSRSQu9TYxjBETWfHDqF19vlu+mIiIh0GoWRSMnKAXs0VBZC6WeMykwgzmGjvLaebUfUVCMiIhKgMBIpUdG+QAKw/22ibFYuHZUOwOs7m7+Pj4iISG+kMBJJTfqNXHWuby6WN3YWtXSEiIhIr6MwEklDL/Wtv/g3eD1cOiodu9XCZ0WVfFFaZWbJREREugyFkUjqPwGcSVBbBsc+ISkmii8NSwFUOyIiIhKgMBJJVhsM+bLvsb+p5sqxvqYa9RsRERHxURiJtGEhQ3xpCCObDp6ktNJlVqlERES6DIWRSAvMN1LwAdS76N8nhvMGJOI14M1dxeaWTUREpAtQGIm0tFEQnwn1NXBoIwBXjc0E1FQjIiICCiORZ7HA0K/6HjfpN/LvvaVUu+vNKpmIiEiXoDDSGQJhxN9vZHRmAlnJMbjqvbzzWamJBRMRETGfwkhnCHRiPbIJasuxWCxcOcbXVKMhviIi0tspjHSGPoOg71AwPHDwfaBhNtZ1u4uo93jNLJ2IiIipFEY6S5Op4S8Y3Jc+sVGcqq7j44MnTSyYiIiIuRRGOsvQxvON2G1WrhjtnwBth5pqRESk91IY6SxDLwEsULwDSvcBDaNq3thViGEYJhZORETEPAojnSUuBUZc5Xv88ZMAfHVkKk67lUMnathdWGFi4URERMyjMNKZJn/Ht97yLLiriHXY+cqIVECjakREpPdSGOlMwy+H5GHgKoNP/wZoNlYRERGFkc5ktcKFt/seb1wGhsHlY9KxWGD7kXKOnqoxt3wiIiImUBjpbBNuAnuMryNrwQZS451cMLgvoKYaERHpnRRGOltMXxj/X77HG5cBDU01CiMiItIbKYyYYfIc33rXy1BRGBzi+8H+45TV1JlYMBERkc6nMGKGzHGQ9SXw1sOmFQxJjWNkRjz1XoP1e4rNLp2IiEinUhgxS6B25OOnwFMXrB3RbKwiItLbKIyYZcx/QFw6VBbCrn8G+42s31OMq95jcuFEREQ6T5vCyJIlSxgyZAjR0dHk5OSwcePGFvddsWIFFoul0RIdHd3mAvcYdgdcMNv3+KM/MW5AEhmJTqrcHt7//Li5ZRMREelEYYeRlStXkp+fz4IFC9i8eTPZ2dlMmTKF4uKW+zokJiZy7Nix4HLw4MF2FbrHmHQrWGxw8D2sJTsb7lWjUTUiItKLhB1GFi1axJw5c5g9ezZjx45l6dKlxMbGsnz58haPsVgsZGZmBpeMjIx2FbrHSOwPY6b5Hm9cxpUhQ3y9Xt04T0REeoewwojb7WbTpk3k5eU1nMBqJS8vjw0bNrR4XGVlJYMHDyYrK4vp06ezY8eOM76Py+WivLy80dJjBTqyfrqS3P52Epx2SipcfLBfTTUiItI7hBVGSktL8Xg8p9VsZGRkUFjY/L1VRo0axfLly3nppZf4y1/+gtfr5aKLLuLw4cMtvs/ChQtJSkoKLllZWeEUs3sZfDGkjYG6ahzbn2f6xP4ALFm/z+SCiYiIdI6Ij6bJzc1l5syZTJgwgUsuuYQXX3yRtLQ0Hn/88RaPmT9/PmVlZcHl0KFDkS6meSyWhtqRjcv43leHYrdaeG/fcTYdPGlu2URERDpBWGEkNTUVm81GUVHjDpZFRUVkZma26hxRUVFMnDiRffta/uXvdDpJTExstPRo42eAMxFOfM7AEx9y/fkDAHj0zb0mF0xERCTywgojDoeDSZMmsW7duuA2r9fLunXryM3NbdU5PB4P27Zto1+/fuGVtCdzxvtuoAfw0Z/4/qXnYLXA+j0lfHr4lKlFExERibSwm2ny8/NZtmwZf/7zn9m1axd33HEHVVVVzJ7tmzNj5syZzJ8/P7j/gw8+yOuvv87+/fvZvHkz3/rWtzh48CC33357x32KnuBC//XY8y+G2EqZPiFQO6K+IyIi0rPZwz1gxowZlJSUcP/991NYWMiECRNYu3ZtsFNrQUEBVmtDxjl58iRz5syhsLCQvn37MmnSJN5//33Gjh3bcZ+iJ0gdAcMug/1vwcfLmXvZf7N66xHe2FnErmPljOnXw5uqRESk17IYhtHlJ7QoLy8nKSmJsrKynt1/ZPer8PxNEJMM+TuZ+/ddvPrpMa4Z148lN59vdulERETC0trvb92bpisZ+TVIGgQ1J+Cd/+UHl58DwJrtx9hXXGFy4URERCJDYaQrsdrgql/6Hr/7O0Z793PV2AwMA/6gviMiItJDKYx0NedeC2OvBcMDq7/PDy8ZDMDLnxzlQGmVqUUTERGJBIWRrujq/4XYFCjewXn7/8Rlo9LwGvDYW6odERGRnkdhpCuKT4Orf+N7/O//5ScT3ACs2nKEQyeqTSyYiIhIx1MY6arOvd53R19vPWM+vIdLhveh3mvwx7c/N7tkIiIiHUphpKuyWOCaRRDTFwq38T9pbwDwwseHOVZWY3LhREREOo7CSFcWnw5Tfc01WZ/+gf8cWIbb4+Xxt/ebXDAREZGOozDS1Y37Txh1DXjr+IX3D9ip568bCyiuqDW7ZCIiIh1CYaSrs1jg64sgug/xJ3bwQMo6XPVelr2j2hEREekZFEa6g4RMmPprAL5Z8xwjLIf5ywcFHK90mVwwERGR9lMY6S7Gz4CRX8PqrWNJ3J9w17l5aM0us0slIiLSbgoj3YXFAl//HTiTGFn/GXPsa3hx8xFe2nrE7JKJiIi0i8JId5LYH762EIAfR/2D0ZYC7l21XROhiYhIt6Yw0t1MuAnOuRK74eavMb8m1X2Iu1Zupd7jNbtkIiIibaIw0t1YLHD9E5Axjr7ekzzveIjigt08qrv6iohIN6Uw0h3FJsPM1ZA2mgzLCZ6Leph/vLmBj784YXbJREREwqYw0l3FpcLMlyB5OFnWEp6Jeohf/vVNymrqzC6ZiIhIWBRGurOETJj1T7x9BjPUWsRva+7jVy/8G8MwzC6ZiIhIqymMdHdJA7DO+ifuuP6cYz3KzL0/5JUPdphdKhERkVZTGOkJ+g7GcdsrVDlSGWM9xNC1t1Bw5KjZpRIREWkVhZGeImU40d9+hTJrEudZ9lP91HXUVZeZXSoREZGzUhjpQWwZY3B9cxWniGd0/W4K//gf4K4yu1giIiJnpDDSw6SPmMSOy1dQbsSQVbGVyj/mQanmIBERka5LYaQHuvirV/LMOb/jhBFP/MmdeJZ+BT553uxiiYiINEthpIf69jf+i3szH+cD7xhs9dWw6ruw6g5wVZpdNBERkUYURnqo6Cgbv7nta/yu329YVPefeLDAJ8/BE5fAsU/NLp6IiEiQwkgPFue08+Rtufx7wG3c5LqXIpLh+D74Ux5sXAaaHE1ERLoAhZEeLt5pZ8XsydQM+BJfq32YdyyTwOOCNT+Gld+Cat3PRkREzKUw0gskxUTx9G2T6ddvIDNr8vmtdTaGNQp2vwJLvwIH3jG7iCIi0ospjPQSfWId/OX2HEZlJPJo9ZXMtj1MXdIQKD8Mf54Gf/0mlOwxu5giItILtSmMLFmyhCFDhhAdHU1OTg4bN25s1XHPP/88FouFa6+9ti1vK+2UHOfg2Tk5nJMez/qKAVxd+xCV42aCxQZ71sBjX4J/3gkVhWYXVUREepGww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcfEZj/viiy/48Y9/zFe+8pU2F1baLzXeyXO35zA0NY69ZRau/vx6imeuh9FfB8MLm1bA7yfCmw+Bq8Ls4oqISC8QdhhZtGgRc+bMYfbs2YwdO5alS5cSGxvL8uXLWzzG4/Fw880388ADDzBs2LB2FVjaLz0xmufm5DAoOZaCE9Vct7KUbV9+DGavhYEXQl01vPP/fKFk4zLw1JldZBER6cHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDicQ8++CDp6el8+9vfbtX7uFwuysvLGy3SsfolxfDcHF8NyZFTNdyw9H3+XjIQvv0G/NczkDwcqkp8o26W5MC2FxRKREQkIsIKI6WlpXg8HjIyMhptz8jIoLCw+X4G7777Lk8++STLli1r9fssXLiQpKSk4JKVlRVOMaWVBvaNZfXci8kbk4673st/v/Ap9760HffIr8PcD+Hq/4W4NDjxOfzj2/C7c2HdL+FUgdlFFxGRHiSio2kqKiq45ZZbWLZsGampqa0+bv78+ZSVlQWXQ4cORbCUvVtSTBRP3HIB+VeOxGKBv3xQwDee2EBRlQcmz4EfboFLfwbxGVBZBP/+X1g8Hp69Efb8C7wesz+CiIh0cxbDaP00nG63m9jYWF544YVGI2JmzZrFqVOneOmllxrtv3XrViZOnIjNZgtu83q9gK95Z8+ePQwfPvys71teXk5SUhJlZWUkJia2trgSprd2F3Pn81sor60nLcHJYzefz4VDkn0veup8I24+Xg771zcclDgQJs2CibdAYj9Tyi0iIl1Ta7+/wwojADk5OUyePJlHH30U8IWLQYMGMW/ePO65555G+9bW1rJvX+Pb1997771UVFTwyCOPMHLkSBwOR4d9GGm/L0qr+N5fNrG7sAK71cJ9Xx/LzNzBWCyWhp2Ofw6bnoItz0KNfwZXiw1Gfg3Ou963dsab8wFERKTLiFgYWblyJbNmzeLxxx9n8uTJLF68mL/97W/s3r2bjIwMZs6cyYABA1i4cGGzx996662cOnWK1atXd/iHkY5R7a7np//Yxj8/OQrA9RMH8NB144hx2BrvWFcLu/7pqy0peL9huz0azsmDsdfCyCkQrf9mIiK9UWu/v+3hnnjGjBmUlJRw//33U1hYyIQJE1i7dm2wU2tBQQFWqyZ27c5iHXZ+/40JZA9MYuG/dvPiliPsPFbOr24Yz4SsPg07RkXD+Bt9S/Eu+PRvsHM1nNjvm2p+9ytgc8DwK+Dca2HUVIhOMulTiYhIVxV2zYgZVDNing2fH2fec5s5XuXGYoFbvjSYH08ZRWJ0VPMHGAYUbYedL8GO1XB8b8Nr1igYfhkMuxQGXwQZ48AWdh4WEZFuImLNNGZQGDFXaaWLh1/dxYtbjgCQnuBkwbRzuXpcZuO+JE0Zhq/GZOdqXzgp2d34dUcCDMrxBZPBF0P/iWB3Ru6DiIhIp1IYkQ73/r5Sfr56OwdKqwC4bFQaD04/j6zk2NadoHg3fLYWDr4PBR+Aq6zx6/Zo3wywgy+CftmQNhr6DgGrrdnTiYhI16YwIhFRW+fhsfWfs3T957g9XqKjrNyVN5Jvf3koUbYw+gp5PVC0wxdMDr7nW1eXnr6fPQbSRkL6WEgfA2ljfOukgXCmWhkRETGdwohE1L7iSn6+ahsfHvAN7R2dmcBD153HpMHJbTuhYUDpXl8wKfgAindCyR7wuJrf35EAqSMgZTiknONbkof5nquTrIh0dYbhm7/J4/YvIY+99Q3bvB7f8+DS5Hm9C+proK7Gd1+xulr/ugbq/Y/r/ec0PCHn8Jz+/MoH4JwrOvRjKoxIxBmGwT82H+GhV3dystp335qrxmZw95UjGdOvA/47eT1w4gCU7PL1PQksx/f6/gdqSVy6P6QMhz5DID7dN4NsQoZvHZcGthY64IqIObxe/5doNbgrfV+yQZaQmlD/OvC86Zeq4Q157P+SDX5h1/q+oOtr/V/WIds9Lt+Xtsfl2x4IBsFtbt/5LDawWsFi9T+2+dYWq287Fv9xrpB14Nzuhm3eLnivrxuehHH/2aGnVBiRTnOiys2v/rWLv286TOCv6Zrx/bjrihGMyEjo+Desd/vul3N8X8iy37euKm7dOWJTID7TF1Ti0iA2GWKS/eu+viV0myNezULSM3g9/i9kV8Ov5/rahl/U9SG/rOtCfnHX1/p/qTfz6zz0eSAAGIbvseFtCAmGf3u9C9xVUFflW7urfY97NYtvKgSbw/djyRble2y1gdUesoQ8t9h8nf6jYn1TLUTF+B7bo/3bYnyLzdHkeH+ACj2fxQoZ5/l+tHUghRHpdHuLKli8bi+vfnoM8H13T8/uz515IxmaGtc5hagt9wcVf1gpOwyVxVBZ6F8X+/5BDJfVDs5EcCaErP1LdMhzRzw44vxLC4+jYv3/8yvcdFmhX9iBL+vAL+PgL25vk+f+taeu8S/r4K/rkOr4wJcyRstrr/9c3rqQavy6xtX4ZwsG3nrw1Id8lpoz1yp2FVFxvi9Zi6XhegDBXzvB5zTz5Wpt/EUb/MKO8a3tMb4vbrt/CW6P9n1p252N16GPrbaQ2peQgBX6N4HRzHmcYHeErP2PA4EjcO4e+G+CwoiYZtexchb/32e8tqMIAJvVwnUTB/DDy0cwKKWVI28ixev1TWFfUei78V9lsa82peYkVJ/wvVZ90rcObGup30p7WKwt/KMYeO7wzcsS+IUUeGy1hzy3+9ahv3hsUaf/gmr2y47Tn7eq3BYaVZk3fW4Yjb+EA1+eoV/Ghqf5f4yD/0j7f8UF29CbqeIOfRwMDCFrT8hjwxtSxhbWhrfxObrDF3ZHsEb5/96cIb+kQ35V22Mafl0Hf2GHfvE3+aUe/JVtCWnCsIY0Y/jXtqiGkB4VGxLa43zvqYkzewyFETHd9iNl/O6Nz1i329d0YrdauPGCgXz7y8M4J72b3LvGMHxV1DUnwVXhX8pDHocstWX+KueqhnbvwHN3Jbgq21YrI+ay2v2/mqMaqsaDX8hN+g1Ybc2Hq9Bt1ij/cPWzBCSrzR86Hb7gaWsSUBtVvTdXjR+ybhp8AzUBGjYvEaYwIl3GloKT/O7/9vLOZyXBbRefk8ItXxpC3ph07OEMCe7OAm3lZ+tIF/iF7q1raKMPVtfXh2wP6WnfbFu+//UWazKarltR/uaaE4Kv+QWrt6P8tR+OxjUgFkvDKIBGowjqfDUaHrfvc9qi/Ofynyf0ceCLPfSL1dbkeaCGyWJtpuzekMf+6xJaXR84j82pWYJF2kFhRLqcj744weNv7+fN3UV4/X91/ZOiuSlnEDMuHERagmZfFRHpSRRGpMs6fLKa5z4sYOVHhzhe5QYgymZh6nn9mJk7mEmD+555mnkREekWFEaky3PVe1iz7RjPbDjI5oJTwe1j+iVy46SBfD27H+kJ0eYVUERE2kVhRLqV7UfKeGbDQV765Ai1dV4ArBa4aHgq/zGhP1POzSQpRhOViYh0Jwoj0i2VVdexeusRXtp6pFFticNm5bLRaUyfMIDLR6cTHaVRACIiXZ3CiHR7Bcer+eenR1m95Qh7iyuD2+Oddq46N4Orz+vHxeekEuNQMBER6YoURqTHMAyD3YUVvPzJUV7eepQjp2qCrznsVnKHpXD56HQuH51OVrLJk6qJiEiQwoj0SF6vweaCk/zzk6P8367iRsEE4Jz0eC4fnc5lo9K5YEhfonrLHCYiIl2Qwoj0eIZhsLe4kjd3F/Pm7mI2HTyJx9vw55wQbefL56SSOzyF3GEpnJMeryHDIiKdSGFEep2y6jre2VvCW7uLWf9ZCSf8c5gEpMY7g8Ekd3gKQ1JiFU5ERCJIYUR6NY/X4JPDp3h/Xykb9h/n4y9O4qr3NtonMzGa3OEp5AxN5vzBfRmeFo/NqnAiItJRFEZEQrjqPWwtOMWG/cfZ8PlxthScwu1pHE7inXbGD0xi4qA+TMjqy4SsPpqiXkSkHRRGRM6gts7DpoMn2fD5cT4+eIJPD5dR7T79jroD+sT4w0kfzhuQxNj+iSRGa/I1EZHWUBgRCYPHa/BZUQVbD51ia8Epthw6yd7iSpr7v2NQciznDUjk3P6+cHJu/0RNWy8i0gyFEZF2qqitY9vhMrYcOsUnh06x42j5aUOJA9ITnJzbP5FRmYmMyoxnRHoC56THa6ZYEenVFEZEIuBklZudx8rZcbSM7Ud86/2lVc3WoFgtMCQljhEZ8YzKSGBERgKjMhMYkhKHw675T0Sk51MYEekk1e56dh2rYOfRMvYUVfBZUSWfFVVwqrqu2f2tFshKjmVoahxDU+MYlhrH0NR4hqbF0S8xGqtG9IhID6EwImIiwzAoqXDxWVEle4oq2FtU4V9XUumqb/E4p93K0NQ4BqfEMijZt2T51wP6xuC0q9lHRLoPhRGRLigQUvaXVnHAv+wvqeJAaSUFJ6qp87T8v6PF4psbJRBOsvrGkpUcw0D/Oj0hWvOkiEiXojAi0s3Ue7wcOVXD/pIqCk5UB5dD/nVzQ49DRdksDOjTEE4G9o1lYN8Y+iXF0C8pmozEaPVVEZFO1drvb3tbTr5kyRJ+85vfUFhYSHZ2No8++iiTJ09udt8XX3yRhx9+mH379lFXV8eIESP40Y9+xC233NKWtxbpsew2K4NT4hicEnfaa4ZhcLzKHQwngYBy+GQNh05Wc/RULXUegy+OV/PF8epmz2+x+KbE75cU7V98ISXTH1QyEqNJT3AS52zTPwsiIm0W9r86K1euJD8/n6VLl5KTk8PixYuZMmUKe/bsIT09/bT9k5OT+fnPf87o0aNxOBy88sorzJ49m/T0dKZMmdIhH0Kkp7NYLKTGO0mNd3L+oL6nvV7v8VJYXsvhkzW+gOIPKodPVnOsrJbCslrcHi8lFS5KKlx8erisxfeKd9pJT3SSnuAMBpSMxGjSEpykJfi2pyVEkxht1719RKRDhN1Mk5OTw4UXXsgf/vAHALxeL1lZWfzgBz/gnnvuadU5zj//fK655hp++ctftmp/NdOItE+gZqWwrJajp2ooLK/l6KlaCstqOFpWS0mFi6Ly2rM2BYVy2K2kxYcGFKc/MDlIjnOSEu8gJc5BSryTPjFRGiUk0gtFpJnG7XazadMm5s+fH9xmtVrJy8tjw4YNZz3eMAzefPNN9uzZw69//etw3lpE2iG0ZuW8AUkt7lfpqqeovJai8oaAUlzuoqjCRUmFb1txhYuK2nrc9b4+Li1NBBfKaoHkOAfJcQ5S4pwk+4OK77kvvCTHOUiJ923rG+tQZ1yRXiSsMFJaWorH4yEjI6PR9oyMDHbv3t3icWVlZQwYMACXy4XNZuOxxx7jyiuvbHF/l8uFy+UKPi8vLw+nmCLSRvFOO/Fp8QxPiz/jfrV1nmAwKalwUVLpoqS8lpJKNyeqXJyocnO80s3xKjdlNXV4DSitdFNa6QYqz1oOiwWSYqJIjnXQJzaKvrEO+sY56Bsb5V/7lj6xUb4lxkFSTBTRUVY1HYl0Q53SUy0hIYGtW7dSWVnJunXryM/PZ9iwYVx66aXN7r9w4UIeeOCBziiaiLRBdJSNLP8cKGdT5/FyssoXTHwBxRdWTlT5wkkwvPi3naquwzDgVHVdixPHtcRht9InJoqkGF9ISfKHFN/jhnVScB/f64nRduw2jTQSMUtYfUbcbjexsbG88MILXHvttcHts2bN4tSpU7z00kutOs/tt9/OoUOHeO2115p9vbmakaysLPUZEekF6jxeTlb7QsnJKjcnq92crK7zBxXf45NVbk5U+2pdyqrrOFVTh8fbvlkKYh024p12EqLtJERH+dd2EpxRwW1JMXaSYqNIjG4cahJjonQfIpFmRKTPiMPhYNKkSaxbty4YRrxeL+vWrWPevHmtPo/X620UNppyOp04nc5wiiYiPUSUzUp6QnRYd0I2DINKVz1lNb7alMD6VE1DYCmrqWv0emAJzIhb7fZQ7fZQXNHyv01n4rBbSYqJIsEfaOL9QSY+GGp8gSbwPDT4BB7HOezq6Cu9UtjNNPn5+cyaNYsLLriAyZMns3jxYqqqqpg9ezYAM2fOZMCAASxcuBDwNblccMEFDB8+HJfLxZo1a3jmmWf44x//2LGfRER6LYvF4q/NiGLg6SOfz6jO46Wytp6K2nrKa+uoqK2notYXUgKPfa/VU+4PMOW1DWGm3N8nxl3fMHS67Z8D4h2+IBPvbFgHwkuc0xdqfNujiHPaiHP4tsc5bb61w06sf7s6AUt3EXYYmTFjBiUlJdx///0UFhYyYcIE1q5dG+zUWlBQgNXa0PZaVVXF97//fQ4fPkxMTAyjR4/mL3/5CzNmzOi4TyEi0kZRNquvU2yco03Hh9bKlNXUUVlb3zjI+B9XhgSbCpf/uasuGITqvQaGgW//M9y/KBzRUVZfqAkJNvH+ZqemYSfWYSfOYSPW6V87fAEnsI6JsqlzsESMpoMXETGZYRi46r2NamKqXA2hpcrtDzQu3/ZKf6CpctVT5fZQ5aqn2uV/3e1pd/+Z5lgsEBvlCyvxTjuxjkBNTEONTJx/e6zT5tvXYSfGYSPWYfOv/a/7++fEOuy6RUEPF9Hp4EVEpONYLBaio2xER9lIS2hff7lAsKn2h5RAgAkEm8qQMON7Xuffx0O1O2Tt9lDtDze+8+ILPm5Pu5qimnLYrI2amJo2N8U6fE1OMaFrp42YqIaam/hAM5U/ECngdD8KIyIiPUhosEluY9NTKK/XoLbeQ6WrnmqXhyp/YPGtfdsqXfVUu+updHmocdcHOwNX+x/X1Pme17gbgo673guA2+PFXe3lZJjDuM8kymZpFG5Ca2Ri/M1RgRqbWIedmKjTa2+io2whx9j8+6gfTqQojIiISIusVov/C9oOCR133jqP1xdk/KGmyl87E6jJCQSZKrcv4FT5w0yVq56aOn/TlDskHLnqcfkDTp3HaNM8Na3htFuDISY2JNDE+vvbxEb5w4vD1uhxIPBER51+rK/Wx9ar57pRGBERkU4XZbOSFGslKTaqw84ZCDiBWptAf5pAgAnU2ISGm2DtTeC1Ov/juvpG2wK9K131Xlz1HVuTE+CwWRv627TQkbhpR+PGNT1NApL/XN0h5CiMiIhIjxCJgAON++FUhzZD+WtnqutCHrsbgk9tSPNUMOQEm60azhPocBxosjpFxwYdh782J65JWGnchGXnuokDGDew5XtXRZLCiIiIyBl0dD+cUIZh4PZ4fU1QgVobf+1OYFugI3FwHdI0VV3XcEww5Lh8ASkYcuq9uOu9Z222mjioj8KIiIhIb2OxWHDabTjtNvqc/VZPrRYIOdUhwSbQxyYQVkJDTnWdh5EZHdgpKEwKIyIiIj1MaMhp64R+nanr92oRERGRHk1hREREREylMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRUCiMiIiJiKoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIipusVdew3DAKC8vNzkkoiIiEhrBb63A9/jLekWYaSiogKArKwsk0siIiIi4aqoqCApKanF1y3G2eJKF+D1ejl69CgJCQlYLJYOO295eTlZWVkcOnSIxMTEDjuvNE/Xu3PpencuXe/Opevd+dpyzQ3DoKKigv79+2O1ttwzpFvUjFitVgYOHBix8ycmJuqPuRPpencuXe/OpevduXS9O1+41/xMNSIB6sAqIiIiplIYEREREVP16jDidDpZsGABTqfT7KL0CrrenUvXu3PpencuXe/OF8lr3i06sIqIiEjP1atrRkRERMR8CiMiIiJiKoURERERMZXCiIiIiJiqV4eRJUuWMGTIEKKjo8nJyWHjxo1mF6lHeOedd5g2bRr9+/fHYrGwevXqRq8bhsH9999Pv379iImJIS8vj71795pT2B5g4cKFXHjhhSQkJJCens61117Lnj17Gu1TW1vL3LlzSUlJIT4+nhtuuIGioiKTSty9/fGPf2T8+PHBiZ9yc3P517/+FXxd1zpyfvWrX2GxWLjrrruC23S9O9YvfvELLBZLo2X06NHB1yN1vXttGFm5ciX5+fksWLCAzZs3k52dzZQpUyguLja7aN1eVVUV2dnZLFmypNnX/9//+3/8/ve/Z+nSpXz44YfExcUxZcoUamtrO7mkPcPbb7/N3Llz+eCDD3jjjTeoq6vjqquuoqqqKrjP3XffzT//+U/+/ve/8/bbb3P06FGuv/56E0vdfQ0cOJBf/epXbNq0iY8//pjLL7+c6dOns2PHDkDXOlI++ugjHn/8ccaPH99ou653xzv33HM5duxYcHn33XeDr0Xsehu91OTJk425c+cGn3s8HqN///7GwoULTSxVzwMYq1atCj73er1GZmam8Zvf/Ca47dSpU4bT6TT++te/mlDCnqe4uNgAjLffftswDN/1jYqKMv7+978H99m1a5cBGBs2bDCrmD1K3759jT/96U+61hFSUVFhjBgxwnjjjTeMSy65xLjzzjsNw9DfdiQsWLDAyM7Obva1SF7vXlkz4na72bRpE3l5ecFtVquVvLw8NmzYYGLJer4DBw5QWFjY6NonJSWRk5Oja99BysrKAEhOTgZg06ZN1NXVNbrmo0ePZtCgQbrm7eTxeHj++eepqqoiNzdX1zpC5s6dyzXXXNPouoL+tiNl79699O/fn2HDhnHzzTdTUFAARPZ6d4sb5XW00tJSPB4PGRkZjbZnZGSwe/duk0rVOxQWFgI0e+0Dr0nbeb1e7rrrLi6++GLOO+88wHfNHQ4Hffr0abSvrnnbbdu2jdzcXGpra4mPj2fVqlWMHTuWrVu36lp3sOeff57Nmzfz0Ucfnfaa/rY7Xk5ODitWrGDUqFEcO3aMBx54gK985Sts3749ote7V4YRkZ5q7ty5bN++vVEbr3S8UaNGsXXrVsrKynjhhReYNWsWb7/9ttnF6nEOHTrEnXfeyRtvvEF0dLTZxekVpk6dGnw8fvx4cnJyGDx4MH/729+IiYmJ2Pv2ymaa1NRUbDbbaT2Ai4qKyMzMNKlUvUPg+urad7x58+bxyiuv8NZbbzFw4MDg9szMTNxuN6dOnWq0v6552zkcDs455xwmTZrEwoULyc7O5pFHHtG17mCbNm2iuLiY888/H7vdjt1u5+233+b3v/89drudjIwMXe8I69OnDyNHjmTfvn0R/fvulWHE4XAwadIk1q1bF9zm9XpZt24dubm5Jpas5xs6dCiZmZmNrn15eTkffvihrn0bGYbBvHnzWLVqFW+++SZDhw5t9PqkSZOIiopqdM337NlDQUGBrnkH8Xq9uFwuXesOdsUVV7Bt2za2bt0aXC644AJuvvnm4GNd78iqrKzk888/p1+/fpH9+25X99du7PnnnzecTqexYsUKY+fOncZ3vvMdo0+fPkZhYaHZRev2KioqjC1bthhbtmwxAGPRokXGli1bjIMHDxqGYRi/+tWvjD59+hgvvfSS8emnnxrTp083hg4datTU1Jhc8u7pjjvuMJKSkoz169cbx44dCy7V1dXBfb73ve8ZgwYNMt58803j448/NnJzc43c3FwTS9193XPPPcbbb79tHDhwwPj000+Ne+65x7BYLMbrr79uGIaudaSFjqYxDF3vjvajH/3IWL9+vXHgwAHjvffeM/Ly8ozU1FSjuLjYMIzIXe9eG0YMwzAeffRRY9CgQYbD4TAmT55sfPDBB2YXqUd46623DOC0ZdasWYZh+Ib33nfffUZGRobhdDqNK664wtizZ4+5he7GmrvWgPHUU08F96mpqTG+//3vG3379jViY2ON6667zjh27Jh5he7GbrvtNmPw4MGGw+Ew0tLSjCuuuCIYRAxD1zrSmoYRXe+ONWPGDKNfv36Gw+EwBgwYYMyYMcPYt29f8PVIXW+LYRhG++pWRERERNquV/YZERERka5DYURERERMpTAiIiIiplIYEREREVMpjIiIiIipFEZERETEVAojIiIiYiqFERERETGVwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFT/X+aPmnAN4NmKQAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABM1UlEQVR4nO3deXhU9aH/8fcsmckeyM4SVlkVAqKk0bZuUYqWi8v10moFsdLWQqumva20KtVepf31lmItFqUi1WqltYJWKepF0aooyqLsgiBhy8aSPTPJzPn9MUsmIYFMksnJ8nk9z3nOzJlzznznGJnPfLdjMQzDQERERMQkVrMLICIiIr2bwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFTKYyIiIiIqRRGRERExFQKIyIiImIqu9kFaA2v18vRo0dJSEjAYrGYXRwRERFpBcMwqKiooH///litLdd/dIswcvToUbKysswuhoiIiLTBoUOHGDhwYIuvd4swkpCQAPg+TGJiosmlERERkdYoLy8nKysr+D3ekm4RRgJNM4mJiQojIiIi3czZulioA6uIiIiYKuww8s477zBt2jT69++PxWJh9erVZ9z/2LFj3HTTTYwcORKr1cpdd93VxqKKiIhITxR2GKmqqiI7O5slS5a0an+Xy0VaWhr33nsv2dnZYRdQREREeraw+4xMnTqVqVOntnr/IUOG8MgjjwCwfPnycN9OREQEAI/HQ11dndnFkBA2mw273d7uaTe6ZAdWl8uFy+UKPi8vLzexNCIiYrbKykoOHz6MYRhmF0WaiI2NpV+/fjgcjjafo0uGkYULF/LAAw+YXQwREekCPB4Phw8fJjY2lrS0NE1+2UUYhoHb7aakpIQDBw4wYsSIM05sdiZdMozMnz+f/Pz84PPAOGUREel96urqMAyDtLQ0YmJizC6OhIiJiSEqKoqDBw/idruJjo5u03m6ZBhxOp04nU6ziyEiIl2IakS6prbWhjQ6RweUQ0RERKTNwq4ZqaysZN++fcHnBw4cYOvWrSQnJzNo0CDmz5/PkSNHePrpp4P7bN26NXhsSUkJW7duxeFwMHbs2PZ/AhEREenWwg4jH3/8MZdddlnweaBvx6xZs1ixYgXHjh2joKCg0TETJ04MPt60aRPPPfccgwcP5osvvmhjsUVERLq2Sy+9lAkTJrB48WKzi9LlhR1GLr300jMOrVqxYsVp2zQUS0RERFrSJTuwdpZVWw6zpeAUXx/fn8lDk80ujoiISK/Uqzuwvrm7hKc3HGTbkTKziyIiIq1kGAbV7npTlrbW9J88eZKZM2fSt29fYmNjmTp1Knv37g2+fvDgQaZNm0bfvn2Ji4vj3HPPZc2aNcFjb7755uDQ5hEjRvDUU091yLXsKnp1zUhKnG+2uOOVrrPsKSIiXUVNnYex979mynvvfHAKsY7wvzpvvfVW9u7dy8svv0xiYiI//elPufrqq9m5cydRUVHMnTsXt9vNO++8Q1xcHDt37iQ+Ph6A++67j507d/Kvf/2L1NRU9u3bR01NTUd/NFMpjAAnqtwml0RERHqqQAh57733uOiiiwB49tlnycrKYvXq1dx4440UFBRwww03MG7cOACGDRsWPL6goICJEydywQUXAL57vvU0vTqMJMf7a0YURkREuo2YKBs7H5xi2nuHa9euXdjtdnJycoLbUlJSGDVqFLt27QLghz/8IXfccQevv/46eXl53HDDDYwfPx6AO+64gxtuuIHNmzdz1VVXce211wZDTU/Rq/uMqJlGRKT7sVgsxDrspiyRmgX29ttvZ//+/dxyyy1s27aNCy64gEcffRSAqVOncvDgQe6++26OHj3KFVdcwY9//OOIlMMsvTuMxPumnFczjYiIRMqYMWOor6/nww8/DG47fvw4e/bsaTT5Z1ZWFt/73vd48cUX+dGPfsSyZcuCr6WlpTFr1iz+8pe/sHjxYp544olO/QyR1rubaYI1IwojIiISGSNGjGD69OnMmTOHxx9/nISEBO655x4GDBjA9OnTAbjrrruYOnUqI0eO5OTJk7z11luMGTMGgPvvv59JkyZx7rnn4nK5eOWVV4Kv9RS9umYkNc5XM1LhqsdV7zG5NCIi0lM99dRTTJo0ia9//evk5uZiGAZr1qwhKioKAI/Hw9y5cxkzZgxf+9rXGDlyJI899hgADoeD+fPnM378eL761a9is9l4/vnnzfw4Hc5idIPpUcvLy0lKSqKsrIzExMQOO69hGIz4+b+o9xp8MP8KMpPadutjERGJnNraWg4cOMDQoUPbfIt6iZwz/fdp7fd3r64ZsVgs9PU31ZSqE6uIiIgpenUYAc01IiIiYjaFkXiFERERETP1+jCS7O/EqmYaERERc/T6MKJmGhEREXMpjGiuEREREVMpjPhnYdX9aURERMzR68NIcrCZRn1GREREzNDrw0iK7twrIiJiKoWRQM2I+oyIiEgXMmTIEBYvXtyqfS0WC6tXr45oeSJJYUT3pxERETFVrw8jiTF27FYLoOG9IiIiZuj1YcRisQQ7sWp4r4hIN2AY4K4yZ2nlvWWfeOIJ+vfvj9frbbR9+vTp3HbbbXz++edMnz6djIwM4uPjufDCC/m///u/DrtE27Zt4/LLLycmJoaUlBS+853vUFlZGXx9/fr1TJ48mbi4OPr06cPFF1/MwYMHAfjkk0+47LLLSEhIIDExkUmTJvHxxx93WNmaY4/o2buJ5DgHxRUudWIVEekO6qrh4f7mvPfPjoIj7qy73XjjjfzgBz/grbfe4oorrgDgxIkTrF27ljVr1lBZWcnVV1/NQw89hNPp5Omnn2batGns2bOHQYMGtauIVVVVTJkyhdzcXD766COKi4u5/fbbmTdvHitWrKC+vp5rr72WOXPm8Ne//hW3283GjRuxWHytBDfffDMTJ07kj3/8Izabja1btxIVFdWuMp2Nwgih96fR8F4REWm/vn37MnXqVJ577rlgGHnhhRdITU3lsssuw2q1kp2dHdz/l7/8JatWreLll19m3rx57Xrv5557jtraWp5++mni4nzB6Q9/+APTpk3j17/+NVFRUZSVlfH1r3+d4cOHAzBmzJjg8QUFBfz3f/83o0ePBmDEiBHtKk9rKIzQ0IlVzTQiIt1AVKyvhsKs926lm2++mTlz5vDYY4/hdDp59tln+cY3voHVaqWyspJf/OIXvPrqqxw7doz6+npqamooKChodxF37dpFdnZ2MIgAXHzxxXi9Xvbs2cNXv/pVbr31VqZMmcKVV15JXl4e//Vf/0W/fv0AyM/P5/bbb+eZZ54hLy+PG2+8MRhaIqXX9xmBhonP1EwjItINWCy+phIzFn9TRmtMmzYNwzB49dVXOXToEP/+97+5+eabAfjxj3/MqlWrePjhh/n3v//N1q1bGTduHG5353wPPfXUU2zYsIGLLrqIlStXMnLkSD744AMAfvGLX7Bjxw6uueYa3nzzTcaOHcuqVasiWh6FESA1XnONiIhIx4qOjub666/n2Wef5a9//SujRo3i/PPPB+C9997j1ltv5brrrmPcuHFkZmbyxRdfdMj7jhkzhk8++YSqqqrgtvfeew+r1cqoUaOC2yZOnMj8+fN5//33Oe+883juueeCr40cOZK7776b119/neuvv56nnnqqQ8rWEoURIDnQTKM+IyIi0oFuvvlmXn31VZYvXx6sFQFfP4wXX3yRrVu38sknn3DTTTedNvKmPe8ZHR3NrFmz2L59O2+99RY/+MEPuOWWW8jIyODAgQPMnz+fDRs2cPDgQV5//XX27t3LmDFjqKmpYd68eaxfv56DBw/y3nvv8dFHHzXqUxIJ6jOCmmlERCQyLr/8cpKTk9mzZw833XRTcPuiRYu47bbbuOiii0hNTeWnP/0p5eXlHfKesbGxvPbaa9x5551ceOGFxMbGcsMNN7Bo0aLg67t37+bPf/4zx48fp1+/fsydO5fvfve71NfXc/z4cWbOnElRURGpqalcf/31PPDAAx1StpZYDKOVg6b93nnnHX7zm9+wadMmjh07xqpVq7j22mvPeMz69evJz89nx44dZGVlce+993Lrrbe2+j3Ly8tJSkqirKyMxMTEcIrbKh9/cYL/XLqBwSmxvP3fl3X4+UVEpO1qa2s5cOAAQ4cOJTo62uziSBNn+u/T2u/vsJtpqqqqyM7OZsmSJa3a/8CBA1xzzTVcdtllbN26lbvuuovbb7+d1157Ldy3jhhNeiYiImKesJtppk6dytSpU1u9/9KlSxk6dCi//e1vAV/HmnfffZff/e53TJkyJdy3j4jA0N5K//1pnHabySUSERHxefbZZ/nud7/b7GuDBw9mx44dnVyijhfxPiMbNmwgLy+v0bYpU6Zw1113tXiMy+XC5WroTNpR7WgtCdyfpt5rcKLKTb+kmIi+n4iISGv9x3/8Bzk5Oc2+FumZUTtLxMNIYWEhGRkZjbZlZGRQXl5OTU0NMTGnf/EvXLgw4p1lQgXuT1Nc4eJ4pcKIiIh0HQkJCSQkJJhdjIjqkkN758+fT1lZWXA5dOhQxN8zJT4wvFf9RkREuqIwx1tIJ+mI/y4RrxnJzMykqKio0baioiISExObrRUBcDqdOJ3OSBetkZRgJ1bNNSIi0pXYbL5+fG63u8XvDTFPdXU10L4mo4iHkdzcXNasWdNo2xtvvEFubm6k3zosgRE1J1QzIiLSpdjtdmJjYykpKSEqKgqrtUtW6vc6hmFQXV1NcXExffr0CYbGtgg7jFRWVrJv377g8wMHDrB161aSk5MZNGgQ8+fP58iRIzz99NMAfO973+MPf/gDP/nJT7jtttt48803+dvf/sarr77a5kJHQuDOvWqmERHpWiwWC/369ePAgQMcPHjQ7OJIE3369CEzM7Nd5wg7jHz88cdcdlnDxGD5+fkAzJo1ixUrVnDs2LFGdx0cOnQor776KnfffTePPPIIAwcO5E9/+lOXGdYboGYaEZGuy+FwMGLEiE67kZy0TlRUVLtqRALCDiOXXnrpGTurrFixotljtmzZEu5bdarA/WnUTCMi0jVZrVbNwNpDqeHNT800IiIi5lAY8UvRlPAiIiKmUBjxC8wzomYaERGRzqUw4hcY2lvpqqe2zmNyaURERHoPhRG/xGg7UTYLoNoRERGRzqQw4he4Pw0ojIiIiHQmhZEQgeG9pZprREREpNMojIRIUc2IiIhIp1MYCRGYa0RhREREpPMojIQI9Bkp1VwjIiIinUZhJERDM436jIiIiHQWhZEQgYnPNAuriIhI51EYCRFoptH9aURERDqPwkiIVHVgFRER6XQKIyEC84wc1zwjIiIinUZhJESgmabK7dH9aURERDqJwkgI3Z9GRESk8ymMhAi9P41G1IiIiHQOhZEmgv1GNNeIiIhIp1AYaSIwokY1IyIiIp1DYaSJZN0sT0REpFMpjDSREmymURgRERHpDAojTaQEm2nUZ0RERKQzKIw0oWYaERGRzqUw0kSK7k8jIiLSqRRGmgg202hor4iISKdQGGkiMM/ICQ3tFRER6RQKI00EakZ0fxoREZHOoTDSRIKz4f406jciIiISeQojTVgsluBcI2qqERERiTyFkWYEhveWqhOriIhIxLUpjCxZsoQhQ4YQHR1NTk4OGzdubHHfuro6HnzwQYYPH050dDTZ2dmsXbu2zQXuDIF+I6oZERERibyww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcXGz+9977708/vjjPProo+zcuZPvfe97XHfddWzZsqXdhY+UFE18JiIi0mnCDiOLFi1izpw5zJ49m7Fjx7J06VJiY2NZvnx5s/s/88wz/OxnP+Pqq69m2LBh3HHHHVx99dX89re/bXfhIyUwvFfNNCIiIpEXVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3G5XERHRzfaFhMTw7vvvtvi+7hcLsrLyxstnUnNNCIiIp0nrDBSWlqKx+MhIyOj0faMjAwKCwubPWbKlCksWrSIvXv34vV6eeONN3jxxRc5duxYi++zcOFCkpKSgktWVlY4xWw3TQkvIiLSeSI+muaRRx5hxIgRjB49GofDwbx585g9ezZWa8tvPX/+fMrKyoLLoUOHIlO4A+/Au4uhaEejzckKIyIiIp3GHs7Oqamp2Gw2ioqKGm0vKioiMzOz2WPS0tJYvXo1tbW1HD9+nP79+3PPPfcwbNiwFt/H6XTidDrDKVrbbHwCdv0T7NGQcW5wc7CZRn1GREREIi6smhGHw8GkSZNYt25dcJvX62XdunXk5uae8djo6GgGDBhAfX09//jHP5g+fXrbStyRkv2B6MTnjTYHJj07rj4jIiIiERdWzQhAfn4+s2bN4oILLmDy5MksXryYqqoqZs+eDcDMmTMZMGAACxcuBODDDz/kyJEjTJgwgSNHjvCLX/wCr9fLT37yk479JG2RPNy3PrG/8WZ/zUi1//400VG2zi6ZiIhIrxF2GJkxYwYlJSXcf//9FBYWMmHCBNauXRvs1FpQUNCoP0htbS333nsv+/fvJz4+nquvvppnnnmGPn36dNiHaLMUfxg53rhmJMFpx2Gz4vZ4OV7lZkCfGBMKJyIi0jtYDMMwzC7E2ZSXl5OUlERZWRmJiYkdeOKjsGgMWGxwbxHYooIvfenhdRSW1/LyvIsZP7BPx72niIhIL9Ha7+/efW+ahH4QFQuGB04VNHpJI2pEREQ6R+8OIxZLQyfWJk01gRE16sQqIiISWb07jAAkD/WtTxtRo+G9IiIinUFhpKURNYHhvWqmERERiSiFETXTiIiImEphJDC8t8VmGoURERGRSFIYCTTTnCqA+obgkRKvZhoREZHOoDCSkOkf3uttNLw3OLS3Uh1YRUREIklhJHR4b0hTjZppREREOofCCISEkYYRNSkh96epcXvMKJWIiEivoDACzY6oifffnwbguOYaERERiRiFEWh2RI3FYgn2G1FTjYiISOQojECLE59prhEREZHIUxiBhmaaJsN7dbM8ERGRyFMYAf/w3rjThvfq/jQiIiKRpzACLQ/vDUx8pmYaERGRiFEYCQjcvTdkRI2aaURERCJPYSQg5fROrKnxmoVVREQk0hRGApJPH96bHOdrptHQXhERkchRGAloZuIzNdOIiIhEnsJIQKCZpuxQcHhvquYZERERiTiFkYD4jJDhvQeBhpqRmjrdn0ZERCRSFEYCQof3+ptqdH8aERGRyFMYCZXS+O69FotFU8KLiIhEmMJIqGZH1OhmeSIiIpGkMBKqmRE1gVlYSzXXiIiISEQojIRqZuKzFNWMiIiIRJTCSKjk04f3qplGREQkshRGQsWngyPeN7z35BcAwQ6sJRVqphEREYkEhZFQFkvDDfP8TTWDk+MA2F9aZVapREREerQ2hZElS5YwZMgQoqOjycnJYePGjWfcf/HixYwaNYqYmBiysrK4++67qa2tbVOBI67JiJoRGfEA7CuuxDAMs0olIiLSY4UdRlauXEl+fj4LFixg8+bNZGdnM2XKFIqLi5vd/7nnnuOee+5hwYIF7Nq1iyeffJKVK1fys5/9rN2Fj4gmI2qGpMRhs1qodNVTWN5FA5SIiEg3FnYYWbRoEXPmzGH27NmMHTuWpUuXEhsby/Lly5vd//333+fiiy/mpptuYsiQIVx11VV885vfPGttimmajKhx2K0MSYkFYG9RpVmlEhER6bHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDsMRdddBGbNm0Kho/9+/ezZs0arr766hbfx+VyUV5e3mjpNM1MfDYiPQGAvcUKIyIiIh0trDBSWlqKx+MhIyOj0faMjAwKCwubPeamm27iwQcf5Mtf/jJRUVEMHz6cSy+99IzNNAsXLiQpKSm4ZGVlhVPM9gk005QdhnrfCJrQfiMiIiLSsSI+mmb9+vU8/PDDPPbYY2zevJkXX3yRV199lV/+8pctHjN//nzKysqCy6FDhyJdzAaNhvf67t57TnogjFR0XjlERER6CXs4O6empmKz2SgqKmq0vaioiMzMzGaPue+++7jlllu4/fbbARg3bhxVVVV85zvf4ec//zlW6+l5yOl04nQ6wylaxwncvbfwU19TTdrIYBj5rMg3osZisZhTNhERkR4orJoRh8PBpEmTWLduXXCb1+tl3bp15ObmNntMdXX1aYHDZrMBdN2hsk1G1AxPi8digbKaOkp1914REZEOFVbNCEB+fj6zZs3iggsuYPLkySxevJiqqipmz54NwMyZMxkwYAALFy4EYNq0aSxatIiJEyeSk5PDvn37uO+++5g2bVowlHQ5TUbUREfZGJQcy8Hj1ewtriAtwaRaGxERkR4o7DAyY8YMSkpKuP/++yksLGTChAmsXbs22Km1oKCgUU3Ivffei8Vi4d577+XIkSOkpaUxbdo0HnrooY77FB2t2RE18Rw8Xs3nxZVcNDzVpIKJiIj0PBajy7aVNCgvLycpKYmysjISExMj/4YHN8BTX4OkQXD3NgB+9a/dLH37c2bmDubB6edFvgwiIiLdXGu/v3VvmuakhN691ze8N9CJVROfiYiIdCyFkebEpYEjATCCd+8dEQgjmmtERESkQymMNKeZu/cO94eR0koXp6o1okZERKSjKIy0JNBU4x/eG++0M6BPDKCZWEVERDqSwkhLmhlRc46aakRERDqcwkhLAhOf+ZtpIKTfiDqxioiIdBiFkZYEm2kawkhDzYjuUSMiItJRFEZakhwyvLeuFtDde0VERCJBYaQlcakNw3tP+e/em5YAwLGyWipq60wsnIiISM+hMNISiwVSGt8wLyk2inT/fWk+L6kyq2QiIiI9isLImTR3j5qMQCdW9RsRERHpCAojZ9LsiBpfU436jYiIiHQMhZEzaTLxGTTMxKq5RkRERDqGwsiZBJtpmplrRMN7RUREOoTCyJkEmmnKDjcM7/WHkcMna6hxe8wqmYiISI+hMHImcangTCT07r0p8U6S4xwYBnxeoqYaERGR9lIYOROLJaQT6+n3qFEnVhERkfZTGDmbZkbUaFp4ERGRjqMwcjbBETX7gpt0wzwREZGOozByNmmjfeviXcFNmmtERESk4yiMnE3mON+6cDt4vUDDLKwHT1TjqteIGhERkfZQGDmb5OFgj4a6Kjh5AID0BCcJ0XY8XoMvSqtNLqCIiEj3pjByNjY7pI/1PS7cBoDFYtHkZyIiIh1EYaQ1gk0124KbzlEnVhERkQ6hMNIazYQRdWIVERHpGAojrREII0Xbg5vOydDEZyIiIh1BYaQ1Ms71rcuPQNVxoGGukf2lldR7vGaVTEREpNtTGGkNZwL0Hep7XORrqumfFEOsw0adx+DgCY2oERERaSuFkdYKnW8EsFot6sQqIiLSARRGWitzvG8dOqImLdBvRMN7RURE2kphpLUyz/OtQ8OIOrGKiIi0W5vCyJIlSxgyZAjR0dHk5OSwcePGFve99NJLsVgspy3XXHNNmwttikAzTekeqHcBDcN79yqMiIiItFnYYWTlypXk5+ezYMECNm/eTHZ2NlOmTKG4uLjZ/V988UWOHTsWXLZv347NZuPGG29sd+E7VeIAiOkL3noo2Q00jKjZV1yJx2uYWToREZFuK+wwsmjRIubMmcPs2bMZO3YsS5cuJTY2luXLlze7f3JyMpmZmcHljTfeIDY2tvuFEYsFMgJNNb5OrFnJsTjsVlz1Xo6crDGxcCIiIt1XWGHE7XazadMm8vLyGk5gtZKXl8eGDRtadY4nn3ySb3zjG8TFxbW4j8vlory8vNHSJTTpxGqzWhiepnvUiIiItEdYYaS0tBSPx0NGRkaj7RkZGRQWFp71+I0bN7J9+3Zuv/32M+63cOFCkpKSgktWVlY4xYycM92jRv1GRERE2qRTR9M8+eSTjBs3jsmTJ59xv/nz51NWVhZcDh061EklPIvAiJqibWD4+oiE9hsRERGR8NnD2Tk1NRWbzUZRUVGj7UVFRWRmZp7x2KqqKp5//nkefPDBs76P0+nE6XSGU7TOkToKrFFQWwZlh6DPoGAYUc2IiIhI24RVM+JwOJg0aRLr1q0LbvN6vaxbt47c3NwzHvv3v/8dl8vFt771rbaVtCuwOyB9tO+xv6lmRGCukaIKDEMjakRERMIVdjNNfn4+y5Yt489//jO7du3ijjvuoKqqitmzZwMwc+ZM5s+ff9pxTz75JNdeey0pKSntL7WZMhpPCz84JQ671UKV28OxsloTCyYiItI9hdVMAzBjxgxKSkq4//77KSwsZMKECaxduzbYqbWgoACrtXHG2bNnD++++y6vv/56x5TaTJnj4BOg8FMAomxWhqbGsbe4kr3FlfTvE2Nu+URERLqZsMMIwLx585g3b16zr61fv/60baNGjeo5TRjNTQufHs/e4kr2FVdyycg0kwomIiLSPeneNOEKTHx26qCvIyuhI2o014iIiEi4FEbCFZsMSf55T4p2AHBOhu8eNZ8VaUSNiIhIuBRG2iKjcVPN6ExfGNl1rFz3qBEREQmTwkhbNJmJdXhaPLEOG9VuD5+XqHZEREQkHAojbdEkjNisFsYNSAJg66FTJhVKRESke1IYaYvAiJriXeCpByA7qw8Anx4+ZU6ZREREuimFkbboMwQcCeBxwfG9AGQP7APAJ4fKzCuXiIhIN6Qw0hZW62nzjYwf6Gum2V1YjqveY1bJREREuh2FkbZqMqJmYN8YUuIc1HkMdh3TfCMiIiKtpTDSVk06sVoslmDtyCfqxCoiItJqCiNtFRpG/FPdjw/0G1EnVhERkVZTGGmr9DFgsUJ1KVQWATDBP6JGNSMiIiKtpzDSVlExkDrS97hJJ9b9pVWU19aZVTIREZFuRWGkPYJNNZ8CkBLvZGDfGAwDth/WEF8REZHWUBhpj+CImu3BTcH5RhRGREREWkVhpD2ajKiBhqYazcQqIiLSOgoj7REII8f3gbsKaJgWXp1YRUREWkdhpD3i0yE+AzB896kBzhuQhMUCR8tqKa6oNbd8IiIi3YDCSHs16cQa77QzIj0egE91nxoREZGzUhhpr2b7jfQB1G9ERESkNRRG2qu5ETWBfiMaUSMiInJWCiPtlTnety7aAV7f3XqzA/eoOXwKwz9VvIiIiDRPYaS9UoaDPQbqquDEAQBGZybisFk5VV3HoRM1JhdQRESka1MYaS+rDTLG+h4X+fqNOOxWxvRPBGCr+o2IiIickcJIR2imE2ugqeZTzTciIiJyRgojHaHZMNIH8PUbERERkZYpjHSEzGzf+vDH4PUCkJ3lqxnZfqSceo/XrJKJiIh0eQojHaH/BHDEQ80JKPIN8R2WGk+8005NnYd9JZXmlk9ERKQLUxjpCLYoGHyR7/GBtwGwWi2MG+Af4qt+IyIiIi1SGOkoQy/xrfe/Hdw0Pisw34gmPxMREWmJwkhHGeYPIwffh3o3ABMCnVhVMyIiItKiNoWRJUuWMGTIEKKjo8nJyWHjxo1n3P/UqVPMnTuXfv364XQ6GTlyJGvWrGlTgbus9HMhNsU3+dmRTQCM908Lv6ewgto6j4mFExER6brCDiMrV64kPz+fBQsWsHnzZrKzs5kyZQrFxcXN7u92u7nyyiv54osveOGFF9izZw/Lli1jwIAB7S58l2K1wtCv+h77+430T4omNd5Jvddgx9FyEwsnIiLSdYUdRhYtWsScOXOYPXs2Y8eOZenSpcTGxrJ8+fJm91++fDknTpxg9erVXHzxxQwZMoRLLrmE7Ozsdhe+y2nSb8RisTRMfqb5RkRERJoVVhhxu91s2rSJvLy8hhNYreTl5bFhw4Zmj3n55ZfJzc1l7ty5ZGRkcN555/Hwww/j8bTcbOFyuSgvL2+0dAuBfiOHPwJ3FQDj/f1GPlUnVhERkWaFFUZKS0vxeDxkZGQ02p6RkUFhYWGzx+zfv58XXngBj8fDmjVruO+++/jtb3/L//zP/7T4PgsXLiQpKSm4ZGVlhVNM8/QdCkmDwFsHB33hLDD5mTqxioiINC/io2m8Xi/p6ek88cQTTJo0iRkzZvDzn/+cpUuXtnjM/PnzKSsrCy6HDh2KdDE7hsUCwwL9RtYDDTUj+0urKKupM6dcIiIiXVhYYSQ1NRWbzUZRUVGj7UVFRWRmZjZ7TL9+/Rg5ciQ2my24bcyYMRQWFuJ2u5s9xul0kpiY2GjpNoZe6lv7+40kxzkYlBwLwDY11YiIiJwmrDDicDiYNGkS69atC27zer2sW7eO3NzcZo+5+OKL2bdvH15vw/1ZPvvsM/r164fD4WhjsbuwwIiawm1QfQKA8QMDk5+dMqlQIiIiXVfYzTT5+fksW7aMP//5z+zatYs77riDqqoqZs+eDcDMmTOZP39+cP877riDEydOcOedd/LZZ5/x6quv8vDDDzN37tyO+xRdSUIGpI0BDDjwDtBwB1+NqBERETmdPdwDZsyYQUlJCffffz+FhYVMmDCBtWvXBju1FhQUYLU2ZJysrCxee+017r77bsaPH8+AAQO48847+elPf9pxn6KrGXYJlOzyzTdy7rVk+yc/++SQmmlERESashiGYZhdiLMpLy8nKSmJsrKy7tF/ZPcaeP6bkDwcfriZanc95y14Da8BH/7sCjISo80uoYiISMS19vtb96aJhCEXg8UKJz6HssPEOuyMzEgANMRXRESkKYWRSIhOgv7n+x77R9WMD87EqqYaERGRUAojkRKYjdV/n5pgvxF1YhUREWlEYSRSQu9TYxjBETWfHDqF19vlu+mIiIh0GoWRSMnKAXs0VBZC6WeMykwgzmGjvLaebUfUVCMiIhKgMBIpUdG+QAKw/22ibFYuHZUOwOs7m7+Pj4iISG+kMBJJTfqNXHWuby6WN3YWtXSEiIhIr6MwEklDL/Wtv/g3eD1cOiodu9XCZ0WVfFFaZWbJREREugyFkUjqPwGcSVBbBsc+ISkmii8NSwFUOyIiIhKgMBJJVhsM+bLvsb+p5sqxvqYa9RsRERHxURiJtGEhQ3xpCCObDp6ktNJlVqlERES6DIWRSAvMN1LwAdS76N8nhvMGJOI14M1dxeaWTUREpAtQGIm0tFEQnwn1NXBoIwBXjc0E1FQjIiICCiORZ7HA0K/6HjfpN/LvvaVUu+vNKpmIiEiXoDDSGQJhxN9vZHRmAlnJMbjqvbzzWamJBRMRETGfwkhnCHRiPbIJasuxWCxcOcbXVKMhviIi0tspjHSGPoOg71AwPHDwfaBhNtZ1u4uo93jNLJ2IiIipFEY6S5Op4S8Y3Jc+sVGcqq7j44MnTSyYiIiIuRRGOsvQxvON2G1WrhjtnwBth5pqRESk91IY6SxDLwEsULwDSvcBDaNq3thViGEYJhZORETEPAojnSUuBUZc5Xv88ZMAfHVkKk67lUMnathdWGFi4URERMyjMNKZJn/Ht97yLLiriHXY+cqIVECjakREpPdSGOlMwy+H5GHgKoNP/wZoNlYRERGFkc5ktcKFt/seb1wGhsHlY9KxWGD7kXKOnqoxt3wiIiImUBjpbBNuAnuMryNrwQZS451cMLgvoKYaERHpnRRGOltMXxj/X77HG5cBDU01CiMiItIbKYyYYfIc33rXy1BRGBzi+8H+45TV1JlYMBERkc6nMGKGzHGQ9SXw1sOmFQxJjWNkRjz1XoP1e4rNLp2IiEinUhgxS6B25OOnwFMXrB3RbKwiItLbKIyYZcx/QFw6VBbCrn8G+42s31OMq95jcuFEREQ6T5vCyJIlSxgyZAjR0dHk5OSwcePGFvddsWIFFoul0RIdHd3mAvcYdgdcMNv3+KM/MW5AEhmJTqrcHt7//Li5ZRMREelEYYeRlStXkp+fz4IFC9i8eTPZ2dlMmTKF4uKW+zokJiZy7Nix4HLw4MF2FbrHmHQrWGxw8D2sJTsb7lWjUTUiItKLhB1GFi1axJw5c5g9ezZjx45l6dKlxMbGsnz58haPsVgsZGZmBpeMjIx2FbrHSOwPY6b5Hm9cxpUhQ3y9Xt04T0REeoewwojb7WbTpk3k5eU1nMBqJS8vjw0bNrR4XGVlJYMHDyYrK4vp06ezY8eOM76Py+WivLy80dJjBTqyfrqS3P52Epx2SipcfLBfTTUiItI7hBVGSktL8Xg8p9VsZGRkUFjY/L1VRo0axfLly3nppZf4y1/+gtfr5aKLLuLw4cMtvs/ChQtJSkoKLllZWeEUs3sZfDGkjYG6ahzbn2f6xP4ALFm/z+SCiYiIdI6Ij6bJzc1l5syZTJgwgUsuuYQXX3yRtLQ0Hn/88RaPmT9/PmVlZcHl0KFDkS6meSyWhtqRjcv43leHYrdaeG/fcTYdPGlu2URERDpBWGEkNTUVm81GUVHjDpZFRUVkZma26hxRUVFMnDiRffta/uXvdDpJTExstPRo42eAMxFOfM7AEx9y/fkDAHj0zb0mF0xERCTywgojDoeDSZMmsW7duuA2r9fLunXryM3NbdU5PB4P27Zto1+/fuGVtCdzxvtuoAfw0Z/4/qXnYLXA+j0lfHr4lKlFExERibSwm2ny8/NZtmwZf/7zn9m1axd33HEHVVVVzJ7tmzNj5syZzJ8/P7j/gw8+yOuvv87+/fvZvHkz3/rWtzh48CC33357x32KnuBC//XY8y+G2EqZPiFQO6K+IyIi0rPZwz1gxowZlJSUcP/991NYWMiECRNYu3ZtsFNrQUEBVmtDxjl58iRz5syhsLCQvn37MmnSJN5//33Gjh3bcZ+iJ0gdAcMug/1vwcfLmXvZf7N66xHe2FnErmPljOnXw5uqRESk17IYhtHlJ7QoLy8nKSmJsrKynt1/ZPer8PxNEJMM+TuZ+/ddvPrpMa4Z148lN59vdulERETC0trvb92bpisZ+TVIGgQ1J+Cd/+UHl58DwJrtx9hXXGFy4URERCJDYaQrsdrgql/6Hr/7O0Z793PV2AwMA/6gviMiItJDKYx0NedeC2OvBcMDq7/PDy8ZDMDLnxzlQGmVqUUTERGJBIWRrujq/4XYFCjewXn7/8Rlo9LwGvDYW6odERGRnkdhpCuKT4Orf+N7/O//5ScT3ACs2nKEQyeqTSyYiIhIx1MY6arOvd53R19vPWM+vIdLhveh3mvwx7c/N7tkIiIiHUphpKuyWOCaRRDTFwq38T9pbwDwwseHOVZWY3LhREREOo7CSFcWnw5Tfc01WZ/+gf8cWIbb4+Xxt/ebXDAREZGOozDS1Y37Txh1DXjr+IX3D9ip568bCyiuqDW7ZCIiIh1CYaSrs1jg64sgug/xJ3bwQMo6XPVelr2j2hEREekZFEa6g4RMmPprAL5Z8xwjLIf5ywcFHK90mVwwERGR9lMY6S7Gz4CRX8PqrWNJ3J9w17l5aM0us0slIiLSbgoj3YXFAl//HTiTGFn/GXPsa3hx8xFe2nrE7JKJiIi0i8JId5LYH762EIAfR/2D0ZYC7l21XROhiYhIt6Yw0t1MuAnOuRK74eavMb8m1X2Iu1Zupd7jNbtkIiIibaIw0t1YLHD9E5Axjr7ekzzveIjigt08qrv6iohIN6Uw0h3FJsPM1ZA2mgzLCZ6Leph/vLmBj784YXbJREREwqYw0l3FpcLMlyB5OFnWEp6Jeohf/vVNymrqzC6ZiIhIWBRGurOETJj1T7x9BjPUWsRva+7jVy/8G8MwzC6ZiIhIqymMdHdJA7DO+ifuuP6cYz3KzL0/5JUPdphdKhERkVZTGOkJ+g7GcdsrVDlSGWM9xNC1t1Bw5KjZpRIREWkVhZGeImU40d9+hTJrEudZ9lP91HXUVZeZXSoREZGzUhjpQWwZY3B9cxWniGd0/W4K//gf4K4yu1giIiJnpDDSw6SPmMSOy1dQbsSQVbGVyj/mQanmIBERka5LYaQHuvirV/LMOb/jhBFP/MmdeJZ+BT553uxiiYiINEthpIf69jf+i3szH+cD7xhs9dWw6ruw6g5wVZpdNBERkUYURnqo6Cgbv7nta/yu329YVPefeLDAJ8/BE5fAsU/NLp6IiEiQwkgPFue08+Rtufx7wG3c5LqXIpLh+D74Ux5sXAaaHE1ERLoAhZEeLt5pZ8XsydQM+BJfq32YdyyTwOOCNT+Gld+Cat3PRkREzKUw0gskxUTx9G2T6ddvIDNr8vmtdTaGNQp2vwJLvwIH3jG7iCIi0ospjPQSfWId/OX2HEZlJPJo9ZXMtj1MXdIQKD8Mf54Gf/0mlOwxu5giItILtSmMLFmyhCFDhhAdHU1OTg4bN25s1XHPP/88FouFa6+9ti1vK+2UHOfg2Tk5nJMez/qKAVxd+xCV42aCxQZ71sBjX4J/3gkVhWYXVUREepGww8jKlSvJz89nwYIFbN68mezsbKZMmUJxcfEZj/viiy/48Y9/zFe+8pU2F1baLzXeyXO35zA0NY69ZRau/vx6imeuh9FfB8MLm1bA7yfCmw+Bq8Ls4oqISC8QdhhZtGgRc+bMYfbs2YwdO5alS5cSGxvL8uXLWzzG4/Fw880388ADDzBs2LB2FVjaLz0xmufm5DAoOZaCE9Vct7KUbV9+DGavhYEXQl01vPP/fKFk4zLw1JldZBER6cHCCiNut5tNmzaRl5fXcAKrlby8PDZs2NDicQ8++CDp6el8+9vfbtX7uFwuysvLGy3SsfolxfDcHF8NyZFTNdyw9H3+XjIQvv0G/NczkDwcqkp8o26W5MC2FxRKREQkIsIKI6WlpXg8HjIyMhptz8jIoLCw+X4G7777Lk8++STLli1r9fssXLiQpKSk4JKVlRVOMaWVBvaNZfXci8kbk4673st/v/Ap9760HffIr8PcD+Hq/4W4NDjxOfzj2/C7c2HdL+FUgdlFFxGRHiSio2kqKiq45ZZbWLZsGampqa0+bv78+ZSVlQWXQ4cORbCUvVtSTBRP3HIB+VeOxGKBv3xQwDee2EBRlQcmz4EfboFLfwbxGVBZBP/+X1g8Hp69Efb8C7wesz+CiIh0cxbDaP00nG63m9jYWF544YVGI2JmzZrFqVOneOmllxrtv3XrViZOnIjNZgtu83q9gK95Z8+ePQwfPvys71teXk5SUhJlZWUkJia2trgSprd2F3Pn81sor60nLcHJYzefz4VDkn0veup8I24+Xg771zcclDgQJs2CibdAYj9Tyi0iIl1Ta7+/wwojADk5OUyePJlHH30U8IWLQYMGMW/ePO65555G+9bW1rJvX+Pb1997771UVFTwyCOPMHLkSBwOR4d9GGm/L0qr+N5fNrG7sAK71cJ9Xx/LzNzBWCyWhp2Ofw6bnoItz0KNfwZXiw1Gfg3Ou963dsab8wFERKTLiFgYWblyJbNmzeLxxx9n8uTJLF68mL/97W/s3r2bjIwMZs6cyYABA1i4cGGzx996662cOnWK1atXd/iHkY5R7a7np//Yxj8/OQrA9RMH8NB144hx2BrvWFcLu/7pqy0peL9huz0azsmDsdfCyCkQrf9mIiK9UWu/v+3hnnjGjBmUlJRw//33U1hYyIQJE1i7dm2wU2tBQQFWqyZ27c5iHXZ+/40JZA9MYuG/dvPiliPsPFbOr24Yz4SsPg07RkXD+Bt9S/Eu+PRvsHM1nNjvm2p+9ytgc8DwK+Dca2HUVIhOMulTiYhIVxV2zYgZVDNing2fH2fec5s5XuXGYoFbvjSYH08ZRWJ0VPMHGAYUbYedL8GO1XB8b8Nr1igYfhkMuxQGXwQZ48AWdh4WEZFuImLNNGZQGDFXaaWLh1/dxYtbjgCQnuBkwbRzuXpcZuO+JE0Zhq/GZOdqXzgp2d34dUcCDMrxBZPBF0P/iWB3Ru6DiIhIp1IYkQ73/r5Sfr56OwdKqwC4bFQaD04/j6zk2NadoHg3fLYWDr4PBR+Aq6zx6/Zo3wywgy+CftmQNhr6DgGrrdnTiYhI16YwIhFRW+fhsfWfs3T957g9XqKjrNyVN5Jvf3koUbYw+gp5PVC0wxdMDr7nW1eXnr6fPQbSRkL6WEgfA2ljfOukgXCmWhkRETGdwohE1L7iSn6+ahsfHvAN7R2dmcBD153HpMHJbTuhYUDpXl8wKfgAindCyR7wuJrf35EAqSMgZTiknONbkof5nquTrIh0dYbhm7/J4/YvIY+99Q3bvB7f8+DS5Hm9C+proK7Gd1+xulr/ugbq/Y/r/ec0PCHn8Jz+/MoH4JwrOvRjKoxIxBmGwT82H+GhV3dystp335qrxmZw95UjGdOvA/47eT1w4gCU7PL1PQksx/f6/gdqSVy6P6QMhz5DID7dN4NsQoZvHZcGthY64IqIObxe/5doNbgrfV+yQZaQmlD/OvC86Zeq4Q157P+SDX5h1/q+oOtr/V/WIds9Lt+Xtsfl2x4IBsFtbt/5LDawWsFi9T+2+dYWq287Fv9xrpB14Nzuhm3eLnivrxuehHH/2aGnVBiRTnOiys2v/rWLv286TOCv6Zrx/bjrihGMyEjo+Desd/vul3N8X8iy37euKm7dOWJTID7TF1Ti0iA2GWKS/eu+viV0myNezULSM3g9/i9kV8Ov5/rahl/U9SG/rOtCfnHX1/p/qTfz6zz0eSAAGIbvseFtCAmGf3u9C9xVUFflW7urfY97NYtvKgSbw/djyRble2y1gdUesoQ8t9h8nf6jYn1TLUTF+B7bo/3bYnyLzdHkeH+ACj2fxQoZ5/l+tHUghRHpdHuLKli8bi+vfnoM8H13T8/uz515IxmaGtc5hagt9wcVf1gpOwyVxVBZ6F8X+/5BDJfVDs5EcCaErP1LdMhzRzw44vxLC4+jYv3/8yvcdFmhX9iBL+vAL+PgL25vk+f+taeu8S/r4K/rkOr4wJcyRstrr/9c3rqQavy6xtX4ZwsG3nrw1Id8lpoz1yp2FVFxvi9Zi6XhegDBXzvB5zTz5Wpt/EUb/MKO8a3tMb4vbrt/CW6P9n1p252N16GPrbaQ2peQgBX6N4HRzHmcYHeErP2PA4EjcO4e+G+CwoiYZtexchb/32e8tqMIAJvVwnUTB/DDy0cwKKWVI28ixev1TWFfUei78V9lsa82peYkVJ/wvVZ90rcObGup30p7WKwt/KMYeO7wzcsS+IUUeGy1hzy3+9ahv3hsUaf/gmr2y47Tn7eq3BYaVZk3fW4Yjb+EA1+eoV/Ghqf5f4yD/0j7f8UF29CbqeIOfRwMDCFrT8hjwxtSxhbWhrfxObrDF3ZHsEb5/96cIb+kQ35V22Mafl0Hf2GHfvE3+aUe/JVtCWnCsIY0Y/jXtqiGkB4VGxLa43zvqYkzewyFETHd9iNl/O6Nz1i329d0YrdauPGCgXz7y8M4J72b3LvGMHxV1DUnwVXhX8pDHocstWX+KueqhnbvwHN3Jbgq21YrI+ay2v2/mqMaqsaDX8hN+g1Ybc2Hq9Bt1ij/cPWzBCSrzR86Hb7gaWsSUBtVvTdXjR+ybhp8AzUBGjYvEaYwIl3GloKT/O7/9vLOZyXBbRefk8ItXxpC3ph07OEMCe7OAm3lZ+tIF/iF7q1raKMPVtfXh2wP6WnfbFu+//UWazKarltR/uaaE4Kv+QWrt6P8tR+OxjUgFkvDKIBGowjqfDUaHrfvc9qi/Ofynyf0ceCLPfSL1dbkeaCGyWJtpuzekMf+6xJaXR84j82pWYJF2kFhRLqcj744weNv7+fN3UV4/X91/ZOiuSlnEDMuHERagmZfFRHpSRRGpMs6fLKa5z4sYOVHhzhe5QYgymZh6nn9mJk7mEmD+555mnkREekWFEaky3PVe1iz7RjPbDjI5oJTwe1j+iVy46SBfD27H+kJ0eYVUERE2kVhRLqV7UfKeGbDQV765Ai1dV4ArBa4aHgq/zGhP1POzSQpRhOViYh0Jwoj0i2VVdexeusRXtp6pFFticNm5bLRaUyfMIDLR6cTHaVRACIiXZ3CiHR7Bcer+eenR1m95Qh7iyuD2+Oddq46N4Orz+vHxeekEuNQMBER6YoURqTHMAyD3YUVvPzJUV7eepQjp2qCrznsVnKHpXD56HQuH51OVrLJk6qJiEiQwoj0SF6vweaCk/zzk6P8367iRsEE4Jz0eC4fnc5lo9K5YEhfonrLHCYiIl2Qwoj0eIZhsLe4kjd3F/Pm7mI2HTyJx9vw55wQbefL56SSOzyF3GEpnJMeryHDIiKdSGFEep2y6jre2VvCW7uLWf9ZCSf8c5gEpMY7g8Ekd3gKQ1JiFU5ERCJIYUR6NY/X4JPDp3h/Xykb9h/n4y9O4qr3NtonMzGa3OEp5AxN5vzBfRmeFo/NqnAiItJRFEZEQrjqPWwtOMWG/cfZ8PlxthScwu1pHE7inXbGD0xi4qA+TMjqy4SsPpqiXkSkHRRGRM6gts7DpoMn2fD5cT4+eIJPD5dR7T79jroD+sT4w0kfzhuQxNj+iSRGa/I1EZHWUBgRCYPHa/BZUQVbD51ia8Epthw6yd7iSpr7v2NQciznDUjk3P6+cHJu/0RNWy8i0gyFEZF2qqitY9vhMrYcOsUnh06x42j5aUOJA9ITnJzbP5FRmYmMyoxnRHoC56THa6ZYEenVFEZEIuBklZudx8rZcbSM7Ud86/2lVc3WoFgtMCQljhEZ8YzKSGBERgKjMhMYkhKHw675T0Sk51MYEekk1e56dh2rYOfRMvYUVfBZUSWfFVVwqrqu2f2tFshKjmVoahxDU+MYlhrH0NR4hqbF0S8xGqtG9IhID6EwImIiwzAoqXDxWVEle4oq2FtU4V9XUumqb/E4p93K0NQ4BqfEMijZt2T51wP6xuC0q9lHRLoPhRGRLigQUvaXVnHAv+wvqeJAaSUFJ6qp87T8v6PF4psbJRBOsvrGkpUcw0D/Oj0hWvOkiEiXojAi0s3Ue7wcOVXD/pIqCk5UB5dD/nVzQ49DRdksDOjTEE4G9o1lYN8Y+iXF0C8pmozEaPVVEZFO1drvb3tbTr5kyRJ+85vfUFhYSHZ2No8++iiTJ09udt8XX3yRhx9+mH379lFXV8eIESP40Y9+xC233NKWtxbpsew2K4NT4hicEnfaa4ZhcLzKHQwngYBy+GQNh05Wc/RULXUegy+OV/PF8epmz2+x+KbE75cU7V98ISXTH1QyEqNJT3AS52zTPwsiIm0W9r86K1euJD8/n6VLl5KTk8PixYuZMmUKe/bsIT09/bT9k5OT+fnPf87o0aNxOBy88sorzJ49m/T0dKZMmdIhH0Kkp7NYLKTGO0mNd3L+oL6nvV7v8VJYXsvhkzW+gOIPKodPVnOsrJbCslrcHi8lFS5KKlx8erisxfeKd9pJT3SSnuAMBpSMxGjSEpykJfi2pyVEkxht1719RKRDhN1Mk5OTw4UXXsgf/vAHALxeL1lZWfzgBz/gnnvuadU5zj//fK655hp++ctftmp/NdOItE+gZqWwrJajp2ooLK/l6KlaCstqOFpWS0mFi6Ly2rM2BYVy2K2kxYcGFKc/MDlIjnOSEu8gJc5BSryTPjFRGiUk0gtFpJnG7XazadMm5s+fH9xmtVrJy8tjw4YNZz3eMAzefPNN9uzZw69//etw3lpE2iG0ZuW8AUkt7lfpqqeovJai8oaAUlzuoqjCRUmFb1txhYuK2nrc9b4+Li1NBBfKaoHkOAfJcQ5S4pwk+4OK77kvvCTHOUiJ923rG+tQZ1yRXiSsMFJaWorH4yEjI6PR9oyMDHbv3t3icWVlZQwYMACXy4XNZuOxxx7jyiuvbHF/l8uFy+UKPi8vLw+nmCLSRvFOO/Fp8QxPiz/jfrV1nmAwKalwUVLpoqS8lpJKNyeqXJyocnO80s3xKjdlNXV4DSitdFNa6QYqz1oOiwWSYqJIjnXQJzaKvrEO+sY56Bsb5V/7lj6xUb4lxkFSTBTRUVY1HYl0Q53SUy0hIYGtW7dSWVnJunXryM/PZ9iwYVx66aXN7r9w4UIeeOCBziiaiLRBdJSNLP8cKGdT5/FyssoXTHwBxRdWTlT5wkkwvPi3naquwzDgVHVdixPHtcRht9InJoqkGF9ISfKHFN/jhnVScB/f64nRduw2jTQSMUtYfUbcbjexsbG88MILXHvttcHts2bN4tSpU7z00kutOs/tt9/OoUOHeO2115p9vbmakaysLPUZEekF6jxeTlb7QsnJKjcnq92crK7zBxXf45NVbk5U+2pdyqrrOFVTh8fbvlkKYh024p12EqLtJERH+dd2EpxRwW1JMXaSYqNIjG4cahJjonQfIpFmRKTPiMPhYNKkSaxbty4YRrxeL+vWrWPevHmtPo/X620UNppyOp04nc5wiiYiPUSUzUp6QnRYd0I2DINKVz1lNb7alMD6VE1DYCmrqWv0emAJzIhb7fZQ7fZQXNHyv01n4rBbSYqJIsEfaOL9QSY+GGp8gSbwPDT4BB7HOezq6Cu9UtjNNPn5+cyaNYsLLriAyZMns3jxYqqqqpg9ezYAM2fOZMCAASxcuBDwNblccMEFDB8+HJfLxZo1a3jmmWf44x//2LGfRER6LYvF4q/NiGLg6SOfz6jO46Wytp6K2nrKa+uoqK2notYXUgKPfa/VU+4PMOW1DWGm3N8nxl3fMHS67Z8D4h2+IBPvbFgHwkuc0xdqfNujiHPaiHP4tsc5bb61w06sf7s6AUt3EXYYmTFjBiUlJdx///0UFhYyYcIE1q5dG+zUWlBQgNXa0PZaVVXF97//fQ4fPkxMTAyjR4/mL3/5CzNmzOi4TyEi0kZRNquvU2yco03Hh9bKlNXUUVlb3zjI+B9XhgSbCpf/uasuGITqvQaGgW//M9y/KBzRUVZfqAkJNvH+ZqemYSfWYSfOYSPW6V87fAEnsI6JsqlzsESMpoMXETGZYRi46r2NamKqXA2hpcrtDzQu3/ZKf6CpctVT5fZQ5aqn2uV/3e1pd/+Z5lgsEBvlCyvxTjuxjkBNTEONTJx/e6zT5tvXYSfGYSPWYfOv/a/7++fEOuy6RUEPF9Hp4EVEpONYLBaio2xER9lIS2hff7lAsKn2h5RAgAkEm8qQMON7Xuffx0O1O2Tt9lDtDze+8+ILPm5Pu5qimnLYrI2amJo2N8U6fE1OMaFrp42YqIaam/hAM5U/ECngdD8KIyIiPUhosEluY9NTKK/XoLbeQ6WrnmqXhyp/YPGtfdsqXfVUu+updHmocdcHOwNX+x/X1Pme17gbgo673guA2+PFXe3lZJjDuM8kymZpFG5Ca2Ri/M1RgRqbWIedmKjTa2+io2whx9j8+6gfTqQojIiISIusVov/C9oOCR133jqP1xdk/KGmyl87E6jJCQSZKrcv4FT5w0yVq56aOn/TlDskHLnqcfkDTp3HaNM8Na3htFuDISY2JNDE+vvbxEb5w4vD1uhxIPBER51+rK/Wx9ar57pRGBERkU4XZbOSFGslKTaqw84ZCDiBWptAf5pAgAnU2ISGm2DtTeC1Ov/juvpG2wK9K131Xlz1HVuTE+CwWRv627TQkbhpR+PGNT1NApL/XN0h5CiMiIhIjxCJgAON++FUhzZD+WtnqutCHrsbgk9tSPNUMOQEm60azhPocBxosjpFxwYdh782J65JWGnchGXnuokDGDew5XtXRZLCiIiIyBl0dD+cUIZh4PZ4fU1QgVobf+1OYFugI3FwHdI0VV3XcEww5Lh8ASkYcuq9uOu9Z222mjioj8KIiIhIb2OxWHDabTjtNvqc/VZPrRYIOdUhwSbQxyYQVkJDTnWdh5EZHdgpKEwKIyIiIj1MaMhp64R+nanr92oRERGRHk1hREREREylMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRUCiMiIiJiKoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIipusVdew3DAKC8vNzkkoiIiEhrBb63A9/jLekWYaSiogKArKwsk0siIiIi4aqoqCApKanF1y3G2eJKF+D1ejl69CgJCQlYLJYOO295eTlZWVkcOnSIxMTEDjuvNE/Xu3PpencuXe/Opevd+dpyzQ3DoKKigv79+2O1ttwzpFvUjFitVgYOHBix8ycmJuqPuRPpencuXe/OpevduXS9O1+41/xMNSIB6sAqIiIiplIYEREREVP16jDidDpZsGABTqfT7KL0CrrenUvXu3PpencuXe/OF8lr3i06sIqIiEjP1atrRkRERMR8CiMiIiJiKoURERERMZXCiIiIiJiqV4eRJUuWMGTIEKKjo8nJyWHjxo1mF6lHeOedd5g2bRr9+/fHYrGwevXqRq8bhsH9999Pv379iImJIS8vj71795pT2B5g4cKFXHjhhSQkJJCens61117Lnj17Gu1TW1vL3LlzSUlJIT4+nhtuuIGioiKTSty9/fGPf2T8+PHBiZ9yc3P517/+FXxd1zpyfvWrX2GxWLjrrruC23S9O9YvfvELLBZLo2X06NHB1yN1vXttGFm5ciX5+fksWLCAzZs3k52dzZQpUyguLja7aN1eVVUV2dnZLFmypNnX/9//+3/8/ve/Z+nSpXz44YfExcUxZcoUamtrO7mkPcPbb7/N3Llz+eCDD3jjjTeoq6vjqquuoqqqKrjP3XffzT//+U/+/ve/8/bbb3P06FGuv/56E0vdfQ0cOJBf/epXbNq0iY8//pjLL7+c6dOns2PHDkDXOlI++ugjHn/8ccaPH99ou653xzv33HM5duxYcHn33XeDr0Xsehu91OTJk425c+cGn3s8HqN///7GwoULTSxVzwMYq1atCj73er1GZmam8Zvf/Ca47dSpU4bT6TT++te/mlDCnqe4uNgAjLffftswDN/1jYqKMv7+978H99m1a5cBGBs2bDCrmD1K3759jT/96U+61hFSUVFhjBgxwnjjjTeMSy65xLjzzjsNw9DfdiQsWLDAyM7Obva1SF7vXlkz4na72bRpE3l5ecFtVquVvLw8NmzYYGLJer4DBw5QWFjY6NonJSWRk5Oja99BysrKAEhOTgZg06ZN1NXVNbrmo0ePZtCgQbrm7eTxeHj++eepqqoiNzdX1zpC5s6dyzXXXNPouoL+tiNl79699O/fn2HDhnHzzTdTUFAARPZ6d4sb5XW00tJSPB4PGRkZjbZnZGSwe/duk0rVOxQWFgI0e+0Dr0nbeb1e7rrrLi6++GLOO+88wHfNHQ4Hffr0abSvrnnbbdu2jdzcXGpra4mPj2fVqlWMHTuWrVu36lp3sOeff57Nmzfz0Ucfnfaa/rY7Xk5ODitWrGDUqFEcO3aMBx54gK985Sts3749ote7V4YRkZ5q7ty5bN++vVEbr3S8UaNGsXXrVsrKynjhhReYNWsWb7/9ttnF6nEOHTrEnXfeyRtvvEF0dLTZxekVpk6dGnw8fvx4cnJyGDx4MH/729+IiYmJ2Pv2ymaa1NRUbDbbaT2Ai4qKyMzMNKlUvUPg+urad7x58+bxyiuv8NZbbzFw4MDg9szMTNxuN6dOnWq0v6552zkcDs455xwmTZrEwoULyc7O5pFHHtG17mCbNm2iuLiY888/H7vdjt1u5+233+b3v/89drudjIwMXe8I69OnDyNHjmTfvn0R/fvulWHE4XAwadIk1q1bF9zm9XpZt24dubm5Jpas5xs6dCiZmZmNrn15eTkffvihrn0bGYbBvHnzWLVqFW+++SZDhw5t9PqkSZOIiopqdM337NlDQUGBrnkH8Xq9uFwuXesOdsUVV7Bt2za2bt0aXC644AJuvvnm4GNd78iqrKzk888/p1+/fpH9+25X99du7PnnnzecTqexYsUKY+fOncZ3vvMdo0+fPkZhYaHZRev2KioqjC1bthhbtmwxAGPRokXGli1bjIMHDxqGYRi/+tWvjD59+hgvvfSS8emnnxrTp083hg4datTU1Jhc8u7pjjvuMJKSkoz169cbx44dCy7V1dXBfb73ve8ZgwYNMt58803j448/NnJzc43c3FwTS9193XPPPcbbb79tHDhwwPj000+Ne+65x7BYLMbrr79uGIaudaSFjqYxDF3vjvajH/3IWL9+vXHgwAHjvffeM/Ly8ozU1FSjuLjYMIzIXe9eG0YMwzAeffRRY9CgQYbD4TAmT55sfPDBB2YXqUd46623DOC0ZdasWYZh+Ib33nfffUZGRobhdDqNK664wtizZ4+5he7GmrvWgPHUU08F96mpqTG+//3vG3379jViY2ON6667zjh27Jh5he7GbrvtNmPw4MGGw+Ew0tLSjCuuuCIYRAxD1zrSmoYRXe+ONWPGDKNfv36Gw+EwBgwYYMyYMcPYt29f8PVIXW+LYRhG++pWRERERNquV/YZERERka5DYURERERMpTAiIiIiplIYEREREVMpjIiIiIipFEZERETEVAojIiIiYiqFERERETGVwoiIiIiYSmFERERETKUwIiIiIqZSGBERERFT/X+aPmnAN4NmKQAAAABJRU5ErkJggg=="
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABIqElEQVR4nO3deXwU9f0/8Nfeu7nvOxDuQ0i4YxSLhVQqyk/RtoioiNWqBatSq1A5vEGtFFRa1IK3iLe2WBSj0i/IZSAKcl+GIyeQ7GaTPWd+f8yeIYFssrtDsq/n4zGPnZ2dzX52jMwrn897PqMQRVEEERERkUyUcjeAiIiIIhvDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCu13A1oC0EQcPLkScTGxkKhUMjdHCIiImoDURRhMpmQlZUFpbL1/o9OEUZOnjyJ3NxcuZtBRERE7XDs2DHk5OS0+nqnCCOxsbEApC8TFxcnc2uIiIioLYxGI3Jzcz3n8dZ0ijDiHpqJi4tjGCEiIupkzldiwQJWIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGs2hVGli1bhry8POj1ehQWFmLr1q2t7mu32/HYY4+hV69e0Ov1KCgowNq1a9vdYCIiIupaAg4jq1evxqxZs7BgwQJs374dBQUFGD9+PKqrq1vcf+7cuXjppZfwwgsvYPfu3bjrrrswadIk7Nixo8ONJyIios5PIYqiGMgbCgsLMXLkSLz44osApPvG5Obm4p577sHs2bPP2j8rKwsPP/wwZsyY4dl2/fXXw2Aw4K233mrTZxqNRsTHx6O+vp6TnhEREXUSbT1/B9QzYrPZUFpaiuLiYu8PUCpRXFyMTZs2tfgeq9UKvV7vt81gMGDDhg2tfo7VaoXRaPRbiIiIqGsKKIzU1tbC6XQiPT3db3t6ejoqKytbfM/48eOxePFiHDhwAIIgYN26dfjoo49QUVHR6ucsXLgQ8fHxnoU3ySMiIuq6Qn41zdKlS9GnTx/0798fWq0WM2fOxPTp0895K+E5c+agvr7esxw7dizUzSQiIiKZBHSjvJSUFKhUKlRVVfltr6qqQkZGRovvSU1NxSeffAKLxYJTp04hKysLs2fPRs+ePVv9HJ1OB51OF0jTiIiIIp7V4YTZ6oTZ6oDZ5oDZ6kCjzQmLXYDVIT1a7E5Y7E5YHQKsdicsDmnbnWN6ITvBIEu7AwojWq0Ww4cPR0lJCa699loAUgFrSUkJZs6cec736vV6ZGdnw26348MPP8Tvfve7djeaiIioMxFFEXanCJtTQJPNCZPFDpPFAaPr0fO8yQ6jxYEGqwN2pwCHIMLhFOAURNe6CIcgPbc7RTTZnGjwCR52Z0DXpPi5dmh25wgjADBr1ixMmzYNI0aMwKhRo7BkyRKYzWZMnz4dAHDLLbcgOzsbCxcuBABs2bIFJ06cwJAhQ3DixAk88sgjEAQBDz74YHC/CRERUSukk7n3JO50neTdJ3ib09trYHX4P/r2KjS5ehWabE402aXF4rvu2tdqF2BzSj0PVoe0Hti1qx2j1ygRrVUjWqdGlFYFnUYFvVoJvUYFvUYJnVp6lJ6roFMrkRYr34hEwGFk8uTJqKmpwfz581FZWYkhQ4Zg7dq1nqLW8vJyv3oQi8WCuXPn4vDhw4iJicGECRPw5ptvIiEhIWhfgoiIOjeHU4DFIfUaWOxOmG0ONFgcUq+BVeo5cD9vsEo9Cmarw3vydwh+QcD7KMAuhDcInI9CAcTo1IjTaxCrV7sW//UYnRo6tRJqpQIqlRIapQIqpQIalRIqpQJqpQJqlRIGjQrROhVidFLwiNapEa1VQa3qXBOsBzzPiBw4zwgRkbycggibQzrJS4/uxfvc5hBgtvoHCJPFFSqs7uEIh3+vgmvpyPBCeykVgFqphFqlgFathF6tgk4jPbp7D3TNehEMGhUMWpV3XaP0e+7uZdC5HrVqpfTc9bO0KmlRKhVh/75yaOv5O+CeESIiurA5BdFTQ+AuYGy0eYcWpHVpu/t5g2vfBlfPg7tnosFVDNlkd4at/e4TvqenQKdBjGs9ztVrEKuXegF8hx107hO/KwjoNSpo1VKvglolhQ61UiEFEKUiYgJBZ8AwQkQUZnan4ClWdBcx+q1bHLA5BAiiVM/gFAQ4RXedg+hZb7L5DGe4goR0FUVog4NSAejUKs9f/d5HFWJcQwbuYYcYvXc4wr09WquCXquCXu3uZVD69SooFAwJkYZhhIjoPJyCiAZPULDD2OS9CsI3RDRYHN4CR5/HJpu3+LHRJtU5hINaqfAUMBq0KkRpVYjSqD3r7h6IKK0KMTqNp/YgxtXrEKNTI1or9UJEab1hobPVI9CFj2GEiCKC3SmgrtGOukYb6prsOGO2Sc+bbKhv8r+s0tQscDRYHSFpU7RWhTiDxjP84FvIqFOroFYpPMWKSoXCVczofa7XqDw9Du4CRvfzaFcBJHsZqDNgGCGiC1qTzYnaBitqG6w41WCTHs02nDbbYLFLxZM2p1Q86V53F1PaHAKMFjvqGu1BCRR6jdITGqQQoUGcK0DEGdSI1alh0KpdPQ7eoQd3D4T7uTswsIeBSMIwQkQhJQgiTFap16G+ye4zyZMDDe519xUYPhNBucNHYxDrHxQKIN6gQYJBg4QoLRKiNEiM0iLe4B8qpMDhuy69plUzPBCFAsMIEbWJKIpotDlx2mzDmUabz6M05HG60Yb6Rilw+C4mix1CB6/a1KqVSI3RISVGi+QYHZKjtUiK1ko1DK7LJd2FlFq1ElqVyrMep1cjIUqLxCgpYKh4BQXRBYdhhCgCCYKI+iY7TrtDhVmqo6hrtOGMu66i0Y4zrse6Rmlfm6P9hZc6tVLqgTD410bE6vwnenIPgaTEaJEcrUNKrA7RWhVrH4i6MIYRoi5CFEUYmxyoMDahot6CijoLqowWnHbVV5wyWz3rZxrtcLazu0KrViI5WovEKKl3IjFai6Qojaf3IT5Kg3iDd4kzaBCn10CvUQX5GxNRV8EwQtQJOAURtQ1WVNZLAaPKZEVlvRQ6Kl1LRb0l4ImpYnVqJMVoPUEi0VVHkWDQIjHaGzDcz5OitTBo2EtBRMHFMEIkM4dTQJXJihNnmnCyrgkn6pqkgGF0BQ+jBTUma5vrLpKitciI0yMzXo+0OD1SYqQejKRoadgjMVrjedSp2VtBRPJjGCEKMVEUUW2y4nCNGUdPmXH8TCNO1llw4owreBgtbRoyUSkVSI3RIT1ej/RYHTLi9ciI1yMr3oCMeCl8pMfpORxCRJ0OwwhRkJwx23C41oyjtWYc8VmOnjKf9/JUjUqBzHgDshMMyEowSMEiXo+MOD3S43TIiNMjOUbHK0GIqEtiGCEKgNnqwNFTrqBRIz0edoWO+iZ7q+9TKRXITTQgLyUauYlRyE70Bo+cRANSY3S8aRcRRSyGEaJmrA4njp1uxJHaRhypbfB5NKPKaD3nezPj9eiREo28lGj0TIn2rOcmRnHCLCKiVjCMUMQyWuzYdaIeB6oaPD0cR2ulmo5zlXAkRWvRwxU0fJe85GgYtKzXICIKFMMIRQR38Nh1oh4/Hpcej55qbHX/aK0KPVKj0SMlBj2So6SejtQY9EiORnyUJowtJyLq+hhGqMux2J346WQ9dpTX4QdX8DhSa25x3+wEAwZmxXmGVHqkRKNHajRSY3ScS4OIKEwYRqjTO1nXhO3lZ7D95zpsLz+D3SeNsDnPnrY8O8GAwdnxGJwTj8HZ8RiUHY+kaK0MLSYiIl8MI9SpiKKIfVUmbDhQ6wkglUbLWfslR2sxtFsihnZLwKBsKXwweBARXZgYRuiCV2204P8O1GLDQWmpMflf0aJSKjAgMxZDcxMxrHsChnVLRLekKA6zEBF1EgwjdMFptDmw5chpbDhQiw0HarGvyuT3ul6jRGGPZBT2TMKwbonIz4lHlJa/ykREnRX/BacLgslix1d7qrDmxwr8b3+tX82HQgEMzo7H6N4pGN0nBcO7J/KeKkREXQjDCMnGZLGjZE81/vNjBf63v8YvgGQnGHBZHyl8XNorBYms9yCiC50gAE4boNHL3ZJOh2GEwqrB6kCJqwfk2/01sDm8AaR3WgyuGpyJq/Iz0ScthjUfRG1lqQfqj7uWY0DdMe9zmxnQxzdb4lrYlgAYEgFDAqCNkbok20MUAasJaDoNNLqWJp/HpjOAUg3EZgAxGdJjbAYQky61o6XPddoBcy3QUAU0VLseq6Sf5bQBgkPax/fRvS4KgC4WiEoCDElAVLLPeqLrMQnQxQX2nZvqgOrdQNVPQNUu1+NuwG6WflZMGhCdJj3GpLseXeuGRMBhBexNgKNJenQvvs8FJyA6fR4dUuDxbHN9t+hU15LiXY9Jkz5H2Tl6kRlGKOREUUTZsTq8/t1R/HdXJaw+AaRnajSuzs/CVYMz0TedASTi2Myuk4vPCcZcA1iM0j+yrZ5EEwBttPR+S713sRr9n1vqpX0cltb/wbc3SW1RaQG1Vnr0Xdzb1DpAGwvoYqTP1sZIbfSsx0j7WU1nt8Gvja4aKKUKUKikE7NSBSiUPttcJxBRlE44cD2Kgs82SCf4+mPS9w4mpdo/nBgSpROs4JBOog5LK49N0ncUHO37XLUBiE0HYjOlY2mukX43Gk8BOP+drTtEoZJ+twyJ/t/b9zg0nnKFjp+k494aq1FaTh0MbZvPR6GUwpcmqoXfpRZ+t27+GMgaKktTGUYoZKwOJ/7zQwVe33QUPx6v92zvkRKNq/OlHpB+6bEMIOEgCC2fqN0nR4XCdTJU+58QFSpAqZQeBYfrpNPSicgmPTrtzf6Sc/01JwrebTaz9y9cW4PcR6brMCQB8TlAQjfp0b3oYqVwd67A1lQHWOr8exoaa6WlvdR6b6+DpyfC9ei0Sb8DpgrAVAU0VErtcDQBZ45KS3MKZbOehnTp56m0gErj+t1Vu9Y1gMr1XKGUvn9TC700jWekR3uj9LvZ5NreVvG5QPpFrmWQtMSkAuZT3nDtCdrVgNm13lQnHR+NXgoKatejxuCzTSd9D9//H5v/v6lQSv89zTWu4FbjXW86Lf1/Z65p+/dxtjNEBgHDCAVdRX0T3t5cjlVby3HKbAMAaNVKTMzPwi1F3ZGfE88AAkh/mTjtgGB3PTq96xClf2jgCgnusOD73GFp+R8hc613vfGU9wR0oVIbzu7K1sVJQcVzwmx2ArX7zKiriT572EEX5+1J0Ua38A++a1G7/vFXKKVg5bQDTqt0snTYpEf3NnuT1CabGbA2uNYbXOtmwGaS3uNuiy6uhZ6deCkcAOcObILTNWTQ7L+/53fAtejjgfhuQHy29D07ShSl79l0xhtOmlyPVqO3h0itd63rvc/VOmnRx0uBQxsV2GfbmwBTpbQ0VAJ2y9nBI1RDDvYm/0Dm/s7Nn2ujgYzBUvhIGyj1lrTEkAik9A5NW9vKaZf+/2+oln63FUpAgZb/XXFvS+gmW3MZRigoRFHE1iOn8fqmo/jipyo4XXeay4zX46aLu+OGkblIjtHJ3MrzEJzSXy31x4G6cp8x+OPevxD9TghK70lB4bojr9PhOoG5T2y+JzWbd5tg93a1h5Mm6uyTpC7G+/3dJ0TB4T8uLTilvzjVemnYwu8k5FpX6Vx/lTbvWWm2rjF4TzAxae2rT3DapQCgjZY+k4JDoZBChDZKCjjhpDEAST2kJdzc4TQuM/yfHSoqjbcepxNgGKEOEUURX+6uwgtfH8CuE96/vi/umYRpRXn41cB0qFVKGVvow9rgX+TnGzbqywHjyfaPdQeLQil1zSoU3jFd33Fdv31VroK1NG/hWkyafxFbVIr015v7L3V1F7kqSaVp/a9SIup0GEaoXQRBxJe7K7G05CD2VEghxKBR4dqh2Zh2SXf0z4gLb4OsJsBYAZhO+j8aT3ivLrDUnf/nKFRAXLb/mHtCrnTCVyhaKCIUXeuitK7S+BQ/aly9Ba51tc41pt3KGLdSLdVnnIv7s0TBFVwukKBHRNQBDCMUEEEQ8d9dlXjh6wPYWyldFRCjU2PaJd1x++iewZsPRBSl8GA+JY17NtZKtRCNrufmWlfxW4UUOmym8/5IAK4x9lz/sBGf690Wm3FhXwrnHhYCQwgRdR0MI9QmTkHE5zsr8MLXB7C/SroCIlanxvRL83Db6B5IiGpnCHHagdr9QOVO71KzTwofgQ6Z6OKkSwLjMoHYLOkxLksq8EvIlXo89GHusSEiovNiGKFzEkURa3ZWYMlXB3Cw2hVC9GrcdmkP3HZpD8RHBVA8aGsETm4HKne5gsePQM1eqaCzNdpYIDpZqn2ISpbqIaKSpSU2wxU+sqRHdyEmERF1Kgwj1KqTdU3468c78e0+6Tr1OL0at43ugemX9kC8oQ0hRBCAqp3Aoa+lpXxzy8FDFyddn58x2HXZ3EApXEQlS3UWRETUpTGM0FkEQcSqbeVY+PleNFgd0KqVuHtML/z+sh6I058nhBhPAoe+AQ5/Iz02nzQpLhvIHOIKHq4AktC9/VNPExFRp8cwQn5+PmXGQx/+iM2HpVkIh3VLwDO/KUDvtFaGQEQRqPgB+OkjYP+XQM0e/9e1MUDeZUCvsdKS3IvBg4iI/DCMEACpQPXVjUfwty/3wWIXYNCo8Jfx/TDtkjyolC2Eh6rdwK4PpRBy+rDPCwoge5gUPHr+EsgZ2XXmtiAiopBgGCEcrDbhLx/8iB3ldQCAop7JePr6fHRLbjadc+0BYNdHUgCp2evdrtYDfccDA6+RAkhUUvgaT0REnR7DSARzCiKWrz+EpV8dgM0pIEanxl8nDMCUUbnee8eYKoEf3gV2fSBdAeOm0gK9i4GLrgP6/dp7vw0iIqIAMYxEqPpGO+55dwf+t1+6UuaX/VLx5KTByEowSHN/7P8C2PEmcGCddI8SQJohtOflwKDrgX4TOB03EREFBcNIBDpY3YA73vgeR2rN0GuUePyaQfjN8BwoavcDX74p9YT43nY6txAomCINw3AIhoiIgoxhJMJ8s7caf1q1AyarA1nxevzrhn4YeLoEWPEmcHybd8foNKDgBmDozUBqX/kaTEREXR7DSIQQRRHL1x/GM1/shSgCI7sn4NXBOxGz6hbAJs2sCoVKKkQdehPQ5wremp2IiMKCYSQCWOxOPPThj/i07CQA4K4hOjxofRbKr76RdkjuLfWAFEwBYtNlbCkREUUihpEurqK+CX94oxQ7T9RDrQReH3YYlxx4BgqrUbokt/hRYNQfeCt6IiKSDcNIF1b682nc+eZ21DZY0dPQiA9y3kPSri+lF7NHAJOWAyl95G0kERFFPIaRLmrtrgr8aVUZbE4Bv0/aib8KL0F17DSg1AC/nANcci+g4n9+IiKSH89GXdCmQ6fwp1Vl0DuNeCPlPVzc8JX0QvogqTckY7C8DSQiIvLBMNLF7Kkw4g9vfI+R4g94MfoVJDbUAgolMPp+YMxs3ieGiIguOAwjXcjxM434/YqNmOl8E3dq1wBOSFfKTHoJyBkhd/OIiIhaxDDSRZwx2/DXf32Ml2zPYLD6qLRxxO+BK54AtFHnfC8REZGcGEa6gCarA28vfxLLG/6JKKUVgj4RymuXAf2vkrtpRERE58Uw0sk5Gk5j1z9vxUzzekABNGZfiqjJ/wLisuRuGhERUZswjHRi4tGNML09HSPtVbCLKlSNeAA5V83mBGZERNSpMIx0Rk4H8L9nIK5/FokQcFRIR8WvXkTRZVfI3TIiIqKAMYx0NoITeO9mYN/nUAJ43/ELCFc+jcmXDpS7ZURERO3C/vzOpuRRYN/nsIga3GObieNjnmMQISKiTo1hpDMpWwVsXAoAeMB+F2JGTMZ9xby3DBERdW4cpuksjm0F/v0nAMDzjmtxJGM8PrlmEBQKhcwNIyIi6hiGkc6g/jjw7lTAacNa50g8L/wWn/4mHxoVO7aIiKjz49nsQmczA6umAOZq7Ed3zLLfjTvH9MZFWfFyt4yIiCgoGEYuZIIAfHwXUPkjGlQJmG6ZhYzUZNwzlnUiRETUdXCY5kK2/mlgz2cQlBpMa7wXJxWpeP/6fOg1KrlbRkREFDTsGblQ/fQxsH4RAOBp9R9QKvbDLRd3x4i8JJkbRkREFFztCiPLli1DXl4e9Ho9CgsLsXXr1nPuv2TJEvTr1w8GgwG5ubm4//77YbFY2tXgiHCyDPj4bgDApvQpeMl4KbITDPjLr/vL2y4iIqIQCDiMrF69GrNmzcKCBQuwfft2FBQUYPz48aiurm5x/3feeQezZ8/GggULsGfPHqxYsQKrV6/GX//61w43vksyVQHv3gg4mlCfPQY3lUt33n1y0iDE6DiqRkREXU/AYWTx4sW44447MH36dAwcOBDLly9HVFQUVq5c2eL+3333HS699FLceOONyMvLwxVXXIEpU6actzclIgkC8P40wHgCQnIf3GK8C05RieuGZePyfmlyt46IiCgkAgojNpsNpaWlKC4u9v4ApRLFxcXYtGlTi++55JJLUFpa6gkfhw8fxueff44JEya0+jlWqxVGo9FviQg73wfKNwHaGLzefRF+qBGREqPFvKs43TsREXVdAfX719bWwul0Ij093W97eno69u7d2+J7brzxRtTW1mL06NEQRREOhwN33XXXOYdpFi5ciEcffTSQpnV+9iag5DEAQPWQGXhqow0A8Mj/uwiJ0Vo5W0ZERBRSIb+a5ttvv8VTTz2Ff/zjH9i+fTs++ugjrFmzBo8//nir75kzZw7q6+s9y7Fjx0LdTPltWgYYj0OMz8GMQ4WwO0X8amA6rhqcKXfLiIiIQiqgnpGUlBSoVCpUVVX5ba+qqkJGRkaL75k3bx5uvvlm3H777QCAwYMHw2w24w9/+AMefvhhKJVn5yGdTgedThdI0zq3hmpgw98BAN/m3I1tpRbE6tV44lree4aIiLq+gHpGtFothg8fjpKSEs82QRBQUlKCoqKiFt/T2Nh4VuBQqaRJu0RRDLS9XdO3CwFbA5wZQ3DPzp4AgIcnDEB6nF7mhhEREYVewNeKzpo1C9OmTcOIESMwatQoLFmyBGazGdOnTwcA3HLLLcjOzsbChQsBABMnTsTixYsxdOhQFBYW4uDBg5g3bx4mTpzoCSURrXovUPoaAOCrbvei4aiI3mkxmDwyV952ERERhUnAYWTy5MmoqanB/PnzUVlZiSFDhmDt2rWeotby8nK/npC5c+dCoVBg7ty5OHHiBFJTUzFx4kQ8+eSTwfsWndm6eYAoQOx/Nf6+PwWACVMLu3F4hoiIIoZC7ARjJUajEfHx8aivr0dcXJzczQmeQ98Ab14LKNXYde0XuPqdKug1SmyZU4z4KI3crSMiIuqQtp6/eW8auQhO4Mu50vrI27Fyj9RJNTE/i0GEiIgiCsOIXMreAap2Afp41I28H//ZWQEAuOni7jI3jIiIKLwYRuRgMwNfPyGt/+IveH93I2wOAYOy45CfEy9v24iIiMKMYUQO370ANFQCiXkQRtyBd7aWAwCmFnZn4SoREUUchpFwM1YAG5dK68WPYFN5A47UmhGrU+P/FWTJ2zYiIiIZMIyE2zdPAPZGILcQGHgt3tr8MwBg0rBsROsCvtKaiIio02MYCafKncCOt6X1K55ElcmKL3dLU+vfWNhNxoYRERHJh2EkXETRdSmvCFx0HZA7Eu9tOwanIGJE90T0z+hC86cQEREFgGEkXCp+AA5/C6i0QPECOAURq1yFq7ycl4iIIhnDSLjsXSM99v01kJiHb/ZW42S9BYlRGvx6UMt3PCYiIooEDCPhsu9z6bHfBADA21ukwtXfjsiFXsMbBhIRUeRiGAmHM0el2VYVKqDveBw73Yhv99cAAG4cxcJVIiKKbAwj4bBvrfTYrQiISsKqreUQReCyPinIS4mWt21EREQyYxgJh32uepH+E2BzCHjv+2MAgKm8nJeIiIhhJOSazgBHN0rr/a7EFz9VorbBhvQ4HcYNSJe3bURERBcAhpFQO7AOEJ1A6gAgqaencHXyyG7QqHj4iYiIeDYMtb3eIZqD1SZsPnwaSgVww8hcedtFRER0gWAYCSWHFThYIq33uwpvb5EmORs3IB1ZCQYZG0ZERHThYBgJpaP/B9hMQEwGLGn5+LD0OAAWrhIREfliGAmlve6Jzn6NLUfrYLQ4kBmvxy/6pMrbLiIiogsIw0ioiCKw77/Ser+rsPnwKQDApb1ToFQqZGwYERHRhYVhJFRO7gBMJwFNNNDjF9h0SAojF/dMlrlhREREFxaGkVBx94r0HocGQY2dJ+oBABf3TJKxUURERBcehpFQ8bkx3vdHT8MpiMhNMiAnMUredhEREV1gGEZCodmN8TYfPg0AuLgHh2iIiIiaYxgJBfcQjevGeO7iVdaLEBERnY1hJBTcQzT9J6DB6vDUixSyXoSIiOgsDCPB1uzGeKwXISIiOjeGkWBrdmM81osQERGdG8NIsPncGA8ANrFehIiI6JwYRoLJYQUOfiWt97sKJosdu9zzi/RiGCEiImoJw0gwHf0/wNYAxGQAWUPx/c9n4BREdEuKQjbv0ktERNQihpFg8rkxHpRKn0t6eRUNERFRaxhGgqXZjfEAeItXWS9CRETUKoaRYGl2YzzfepFChhEiIqJWMYwEi3uis97jAI2e9SJERERtxDASLJ4hGumSXtaLEBERtQ3DSDA0uzEewHoRIiKitmIYCYaDJdJjt4uBqCT/+UUYRoiIiM6JYSQYjm2VHrtfCgD4/qhUL9I9OQpZrBchIiI6J4aRYDjuCiO5hQB86kV4PxoiIqLzYhjpqIYa4PRhaT1nOACfMNKLxatERETnwzDSUce3SY+p/QFDIkwWO3a65xdhzwgREdF5MYx01LEt0mPOSABSvYgggvUiREREbcQw0lHunhHWixAREbULw0hHOO3Aie3Seu4oAKwXISIiChTDSEdU7gQcTYA+AUjuw3oRIiKidmAY6Qj3/CI5IwGlEtuOnma9CBERUYAYRjrirPlFpCngizjrKhERUZsxjHSEu2ckV7qSxntzPIYRIiKitmIYaS9jBVB/DFAogezhMPrcj6aQd+olIiJqM4aR9nIP0aRdBOhi8b2rXiQvOQqZ8awXISIiaiuGkfbyDNG4L+mV6kU4RENERBQYhpH2OiuMsF6EiIioPRhG2sNhBSrKpPXcUawXISIi6gCGkfao+AFw2oCoFCCxB+tFiIiIOoBhpD3cN8fLLQQUCuw6YQQADOuWKGOjiIiIOieGkfZoNr/I3kopjAzIjJOrRURERJ0Ww0igRNEnjEgzr+6tMAEA+mXEytUqIiKiTothJFD1x4CGSkCpBrKGosnmxNFTZgBA/0yGESIiokAxjATK3SuSkQ9oDDhQbYIgAsnRWqTG6ORtGxERUSfEMBKoZvOL+A7RKBQKuVpFRETUaTGMBMpzJY0rjFRKYaR/BotXiYiI2oNhJBA2M1C5U1rPcYcR6Uoa1osQERG1D8NIIE7uAEQnEJsFxOdAFEWfnhGGESIiovZoVxhZtmwZ8vLyoNfrUVhYiK1bt7a67+WXXw6FQnHWctVVV7W70bLxnV9EoUBNgxWnzTYoFUCfNIYRIiKi9gg4jKxevRqzZs3CggULsH37dhQUFGD8+PGorq5ucf+PPvoIFRUVnmXXrl1QqVT47W9/2+HGh10r84vkJUfDoFXJ1SoiIqJOLeAwsnjxYtxxxx2YPn06Bg4ciOXLlyMqKgorV65scf+kpCRkZGR4lnXr1iEqKqrzhRFRBI67woirXmSfe4iG9SJERETtFlAYsdlsKC0tRXFxsfcHKJUoLi7Gpk2b2vQzVqxYgRtuuAHR0dGt7mO1WmE0Gv0W2Z0+DDSeAlQ6IDMfALDHXbzKK2mIiIjaLaAwUltbC6fTifT0dL/t6enpqKysPO/7t27dil27duH2228/534LFy5EfHy8Z8nNzQ2kmaHhHqLJGgKopcnNOA08ERFRx4X1apoVK1Zg8ODBGDVq1Dn3mzNnDurr6z3LsWPHwtTCc2g2v4jDKeBgdQMAYAB7RoiIiNpNHcjOKSkpUKlUqKqq8tteVVWFjIyMc77XbDbj3XffxWOPPXbez9HpdNDpLrCp1Y9vkx5d9SJHas2wOQVEa1XISTTI2DAiIqLOLaCeEa1Wi+HDh6OkpMSzTRAElJSUoKio6Jzvff/992G1WnHTTTe1r6VyshiB6t3SuqtnZI+reLVvRiyUSk4DT0RE1F4B9YwAwKxZszBt2jSMGDECo0aNwpIlS2A2mzF9+nQAwC233ILs7GwsXLjQ730rVqzAtddei+Tk5OC0PJxOlAKiACR0A2KlHqB9LF4lIiIKioDDyOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAq/Ttc9u3bhw0bNuDLL78MTqvDzT1E45pfBPAWrw7gZb1EREQdEnAYAYCZM2di5syZLb727bffnrWtX79+EEWxPR91YXAXr+Z4C2/d08D3S2cYISIi6gjem+Z8BMGnZ0QKI0aLHSfqmgBwmIaIiKijGEbOp3Y/YKkHNFFA+iAA3plXs+L1iI/SyNk6IiKiTo9h5HzcU8BnDwdU0qjW3gqpeJWTnREREXUcw8j5nCiVHnNGeDbt9dyThkM0REREHcUwcj7Ve6VH1xAN4BNG2DNCRETUYQwj5yKKQM0eaT21v2uT6L1bL4tXiYiIOoxh5FxMlVLxqkIFpPQBABw/04QGqwMalQI9U1u/8zARERG1DcPIubh7RZJ6eu/U6+oV6ZUaA42Kh4+IiKijeDY9F3e9SGo/zyb3lTQDWLxKREQUFAwj51LjCiNpAzyb9laxeJWIiCiYGEbOxR1GXMWrAOcYISIiCjaGkdaIoneYxtUzYrE7caTWDIDDNERERMHCMNIaUwVgdV1Jk9wbAHCwugGCCCRGaZAWq5O5gURERF0Dw0hrql1X0iT38lxJs8dniEahUMjVMiIioi6FYaQ1LdSLcLIzIiKi4GMYaY27Z8T3ShpXGBmQyeJVIiKiYGEYaU1NC3OMVLqHadgzQkREFCwMIy0RRaBmn7SeKvWM1JisqG2wQaEA+qbHyNg4IiKiroVhpCXGk4DVCCjVnitp3PUiecnRiNKq5WwdERFRl8Iw0hLPPWl6AWotAJ8hmnTWixAREQUTw0hLPJOd+cy86r6ShsWrREREQcUw0hJ3z0iq75U0Us8IL+slIiIKLoaRljTrGXE4BeyvagDAG+QREREFG8NIcy1cSXP0VCNsDgEGjQrdkqJkbBwREVHXwzDSXP1xwGaSrqRJ6gnAO0TTNyMWSiWngSciIgomhpHm3JOdJff2XklT4Zp5lUM0REREQccw0lwL96TxXEnDMEJERBR0DCPNeYpXz76ShtPAExERBR/DSHOey3qlnhGTxY7jZ5oAsGeEiIgoFBhGfPleSePqGdlfJQ3RZMTpkRitlatlREREXRbDiK/6Y4CtAVBqPFfS7HEVr/ZjrwgREVFIMIz4cteLpPQBVBoAwKEaabIzhhEiIqLQYBjx5akX6efZVNdoBwCkxHCIhoiIKBQYRny5e0Z87kljbJLCSJxeI0eLiIiIujyGEV/unhGfu/WaLA4AQCzDCBERUUgwjLgJAlCzX1r37RmxuHpGDGo5WkVERNTlMYy41R8D7GZApfVcSQNwmIaIiCjUGEbcPPek6QOovL0gRtcwTZyBYYSIiCgUGEbcqs+uF3E4BTRYXWFEz2EaIiKiUGAYcas5+0oadxABWMBKREQUKgwjbtVnzzHivpJGr1FCq+ahIiIiCgWeYQHpSppa15U0PnfrrWfxKhERUcgxjABA3c+AvVG6kiaxh2ez97JehhEiIqJQYRgBvPUiKX39r6RpYvEqERFRqDGMAD7Fq/39NrNnhIiIKPQYRgDvPWnS/MMIp4InIiIKPYYRwOduvQP8NntnX+UwDRERUagwjPjekyatWRjhMA0REVHIMYzUHQUcTYBKByTm+b3kLWBlGCEiIgoVhpFqnytplCq/l3jHXiIiotBjGKk5+540bu6aERawEhERhQ7DSHXLl/UC3qtpWMBKREQUOgwj7jlGmhWvAixgJSIiCofIDiOC03tPmhZ6Roy8Nw0REVHIRXYYOXMUcFgAtf6sK2kEQYTJ6hqmYQErERFRyER2GKlp/UqaBpsDoiits2eEiIgodCI7jFS7Z15tvXhVq1JCr1Gd9ToREREFR2SHkZqW70kD+NSLcIiGiIgopCI7jHgu623hShoWrxIREYVFZP/ZP/ZhoHInkDX0rJeM7jv28rJeIiKikIrsMNLvSmlpAe/YS0REFB6RPUxzDiZOeEZERBQWDCOtMHIqeCIiorBgGGkFC1iJiIjCg2GkFbwvDRERUXi0K4wsW7YMeXl50Ov1KCwsxNatW8+5f11dHWbMmIHMzEzodDr07dsXn3/+ebsaHC7GJg7TEBERhUPAZ9rVq1dj1qxZWL58OQoLC7FkyRKMHz8e+/btQ1pa2ln722w2/OpXv0JaWho++OADZGdn4+eff0ZCQkIw2h8y7BkhIiIKj4DDyOLFi3HHHXdg+vTpAIDly5djzZo1WLlyJWbPnn3W/itXrsTp06fx3XffQaORTux5eXkda3UYuKeDj2XPCBERUUgFNExjs9lQWlqK4uJi7w9QKlFcXIxNmza1+J7PPvsMRUVFmDFjBtLT0zFo0CA89dRTcDqdrX6O1WqF0Wj0W8LN0zPCAlYiIqKQCiiM1NbWwul0Ij093W97eno6KisrW3zP4cOH8cEHH8DpdOLzzz/HvHnz8Nxzz+GJJ55o9XMWLlyI+Ph4z5KbmxtIM4PCe28ahhEiIqJQCvnVNIIgIC0tDS+//DKGDx+OyZMn4+GHH8by5ctbfc+cOXNQX1/vWY4dOxbqZvoRRdFnnhGGESIiolAKqCAiJSUFKpUKVVVVfturqqqQkZHR4nsyMzOh0WigUqk82wYMGIDKykrYbDZotdqz3qPT6aDT6QJpWlA12pxwCiIA3rWXiIgo1ALqGdFqtRg+fDhKSko82wRBQElJCYqKilp8z6WXXoqDBw9CEATPtv379yMzM7PFIHIhcBevqpUKGDSq8+xNREREHRHwMM2sWbPwyiuv4PXXX8eePXtw9913w2w2e66uueWWWzBnzhzP/nfffTdOnz6Ne++9F/v378eaNWvw1FNPYcaMGcH7FkHmLl6N1auhUChkbg0REVHXFvAYxOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAqvRknNzcXX3zxBe6//37k5+cjOzsb9957Lx566KHgfYsgY/EqERFR+ChEURTlbsT5GI1GxMfHo76+HnFxcSH/vK/3VuG2177H4Ox4/Pue0SH/PCIioq6oredv3pumBZ6p4Fm8SkREFHIMIy3ghGdEREThwzDSAk4FT0REFD4MIy3wFLCyZ4SIiCjkGEZawDv2EhERhQ/DSAs8BawcpiEiIgo5hpEWsGeEiIgofBhGWsCb5BEREYUPw0gLTE3e6eCJiIgotBhGWsBhGiIiovBhGGlGFEWfGVgZRoiIiEKNYaQZq0OAzSkA4NU0RERE4cAw0ox7wjOlAojWMowQERGFGsNIM0bPVPAaKJUKmVtDRETU9TGMNOMuXuWVNEREROHBMNIM70tDREQUXgwjzXgmPDOwZ4SIiCgcGEaaYc8IERFReDGMNGOycI4RIiKicGIYaYYFrEREROHFMNIMh2mIiIjCi2GkGSOHaYiIiMKKYaQZb88Ih2mIiIjCgWGkGRPv2EtERBRWDCPNeIZpWDNCREQUFgwjzbiHaXg1DRERUXgwjDTjvrQ3nsM0REREYcEw4sPqcMJiFwBwmIaIiChcGEZ8uGdfBYAYDtMQERGFBcOID3cYidWpoVIqZG4NERFRZGAY8cHiVSIiovBjGPFh5BwjREREYccw4sPYxDlGiIiIwo1hxIe3Z4TDNEREROHCMOLDMxU8e0aIiIjChmHEh2eYhjUjREREYcMw4sM9TMOraYiIiMKHYcSH+9JeDtMQERGFD8OID88de1nASkREFDYMIz7YM0JERBR+DCM+TBYWsBIREYUbw4gPIy/tJSIiCjuGER+8Nw0REVH4MYy4OJwCzDYnAA7TEBERhRPDiIu7XgRgzwgREVE4MYy4uMNIlFYFjYqHhYiIKFx41nVh8SoREZE8GEZcWLxKREQkD4YRF0/PCItXiYiIwophxMVzx172jBAREYUVw4gLe0aIiIjkwTDi4rlJHgtYiYiIwophxMVzkzzesZeIiCisGEZc3MM0sewZISIiCiuGERdvASvDCBERUTgxjLh4C1g5TENERBRODCMuJhawEhERyYJhxMVbwMowQkREFE4MIy7eAlYO0xAREYUTwwgAQRDRYOUwDRERkRwYRgCYrA6IorTOnhEiIqLwYhgBYHIN0ejUSug1KplbQ0REFFkYRuAzxwiLV4mIiMKOYQQ+c4xwiIaIiCjsGEbgvayXU8ETERGFX7vCyLJly5CXlwe9Xo/CwkJs3bq11X1fe+01KBQKv0Wv17e7waHguWMvh2mIiIjCLuAwsnr1asyaNQsLFizA9u3bUVBQgPHjx6O6urrV98TFxaGiosKz/Pzzzx1qdLB5JjzjMA0REVHYBXz2Xbx4Me644w5Mnz4dALB8+XKsWbMGK1euxOzZs1t8j0KhQEZGRsdaGkIm9owQEZ3F6XTCbrfL3Qy6gGk0GqhUHb8KNaAwYrPZUFpaijlz5ni2KZVKFBcXY9OmTa2+r6GhAd27d4cgCBg2bBieeuopXHTRRa3ub7VaYbVaPc+NRmMgzQyYt4CVYYSISBRFVFZWoq6uTu6mUCeQkJCAjIwMKBSKdv+MgMJIbW0tnE4n0tPT/banp6dj7969Lb6nX79+WLlyJfLz81FfX4+//e1vuOSSS/DTTz8hJyenxfcsXLgQjz76aCBN6xDvfWk4TENE5A4iaWlpiIqK6tBJhrouURTR2NjoKdPIzMxs988K+dm3qKgIRUVFnueXXHIJBgwYgJdeegmPP/54i++ZM2cOZs2a5XluNBqRm5sbsjZ670vDnhEiimxOp9MTRJKTk+VuDl3gDAYDAKC6uhppaWntHrIJKIykpKRApVKhqqrKb3tVVVWba0I0Gg2GDh2KgwcPtrqPTqeDTqcLpGkd4pn0jAWsRBTh3DUiUVFRMreEOgv374rdbm93GAnoahqtVovhw4ejpKTEs00QBJSUlPj1fpyL0+nEzp07O9SdE2wmq3uYhj0jREQAODRDbRaM35WAuwJmzZqFadOmYcSIERg1ahSWLFkCs9nsubrmlltuQXZ2NhYuXAgAeOyxx3DxxRejd+/eqKurw7PPPouff/4Zt99+e4cbHyzenhGGESIionALOIxMnjwZNTU1mD9/PiorKzFkyBCsXbvWU9RaXl4OpdLb4XLmzBnccccdqKysRGJiIoYPH47vvvsOAwcODN636CB3zUg8C1iJiIjCTiGKoih3I87HaDQiPj4e9fX1iIuLC+rPFkURvf76OQQR2PLXcUiPu7BmhyUiCieLxYIjR46gR48eF9xs2XRhOtfvTFvP3xF/bxqzzQnBFcc4TENERMHCCePaLuLDiHuOEY1KAb0m4g8HEVGntXbtWowePRoJCQlITk7G1VdfjUOHDnleP378OKZMmYKkpCRER0djxIgR2LJli+f1f//73xg5ciT0ej1SUlIwadIkz2sKhQKffPKJ3+clJCTgtddeAwAcPXoUCoUCq1evxpgxY6DX6/H222/j1KlTmDJlCrKzsxEVFYXBgwdj1apVfj9HEAQ888wz6N27N3Q6Hbp164Ynn3wSADB27FjMnDnTb/+amhpotVq/i0k6u4gvkvBMBa/XsHqciKgFoiiiye4M++caNKqA/l02m82YNWsW8vPz0dDQgPnz52PSpEkoKytDY2MjxowZg+zsbHz22WfIyMjA9u3bIQgCAGDNmjWYNGkSHn74Ybzxxhuw2Wz4/PPPA27z7Nmz8dxzz2Ho0KHQ6/WwWCwYPnw4HnroIcTFxWHNmjW4+eab0atXL4waNQqANLfWK6+8gr///e8YPXo0KioqPBOJ3n777Zg5cyaee+45z5QXb731FrKzszF27NiA23ehivgw4pkKnpf1EhG1qMnuxMD5X4T9c3c/Nh5R2rafpq6//nq/5ytXrkRqaip2796N7777DjU1Ndi2bRuSkpIAAL179/bs++STT+KGG27wm/27oKAg4Dbfd999uO666/y2PfDAA571e+65B1988QXee+89jBo1CiaTCUuXLsWLL76IadOmAQB69eqF0aNHAwCuu+46zJw5E59++il+97vfAQBee+013HrrrV3qD+iIH5fgHXuJiLqGAwcOYMqUKejZsyfi4uKQl5cHQLrKs6ysDEOHDvUEkebKysowbty4DrdhxIgRfs+dTicef/xxDB48GElJSYiJicEXX3yB8vJyAMCePXtgtVpb/Wy9Xo+bb74ZK1euBABs374du3btwq233trhtl5IIv4MzKngiYjOzaBRYfdj42X53EBMnDgR3bt3xyuvvIKsrCwIgoBBgwbBZrN5pi1v9bPO87pCoUDzi09bKlCNjo72e/7ss89i6dKlWLJkCQYPHozo6Gjcd999sNlsbfpcQBqqGTJkCI4fP45XX30VY8eORffu3c/7vs6EPSPuCc84xwgRUYsUCgWitOqwL4EMQ5w6dQr79u3D3LlzMW7cOAwYMABnzpzxvJ6fn4+ysjKcPn26xffn5+efsyA0NTUVFRUVnucHDhxAY2Pjedu1ceNGXHPNNbjppptQUFCAnj17Yv/+/Z7X+/TpA4PBcM7PHjx4MEaMGIFXXnkF77zzDm677bbzfm5nE/FhxOSuGWHPCBFRp5WYmIjk5GS8/PLLOHjwIL7++mu/G65OmTIFGRkZuPbaa7Fx40YcPnwYH374ITZt2gQAWLBgAVatWoUFCxZgz5492LlzJ55++mnP+8eOHYsXX3wRO3bswPfff4+77roLGs35zxt9+vTBunXr8N1332HPnj248847/e7vptfr8dBDD+HBBx/EG2+8gUOHDmHz5s1YsWKF38+5/fbbsWjRIoii6HeVT1cR8WHE6L6ahgWsRESdllKpxLvvvovS0lIMGjQI999/P5599lnP61qtFl9++SXS0tIwYcIEDB48GIsWLfLc2O3yyy/H+++/j88++wxDhgzB2LFjsXXrVs/7n3vuOeTm5uKyyy7DjTfeiAceeKBNNxOcO3cuhg0bhvHjx+Pyyy/3BCJf8+bNw5///GfMnz8fAwYMwOTJk1FdXe23z5QpU6BWqzFlypQuORldxM/AOvvDH/HutmN44Iq+mDm2T1B/NhFRZ8MZWC9MR48eRa9evbBt2zYMGzZM7ub4CcYMrBFfKMFLe4mI6EJlt9tx6tQpzJ07FxdffPEFF0SChcM0rgLWWF7aS0REF5iNGzciMzMT27Ztw/Lly+VuTshE/BmYBaxERHShuvzyy8+6pLgrYs8IC1iJiIhkxTDSxJ4RIiIiOUV0GBFF0aeANeJHrIiIiGQR0WHEYhdgd0pjcZwOnoiISB4RHUbcvSJKBRCtDeweCERERBQcER1GTD5zjHSlWzETERF1JhEdRurdN8njEA0RUcTLy8vDkiVL5G5GRIroMMLiVSIiIvlFdhjhZb1ERNQFOJ1OCIIgdzPaLbLDiIVTwRMRdQUvv/wysrKyzjohX3PNNbjttttw6NAhXHPNNUhPT0dMTAxGjhyJr776qt2ft3jxYgwePBjR0dHIzc3FH//4RzQ0NPjts3HjRlx++eWIiopCYmIixo8fjzNnzgAABEHAM888g969e0On06Fbt2548sknAQDffvstFAoF6urqPD+rrKwMCoUCR48eBQC89tprSEhIwGeffYaBAwdCp9OhvLwc27Ztw69+9SukpKQgPj4eY8aMwfbt2/3aVVdXhzvvvBPp6enQ6/UYNGgQ/vOf/8BsNiMuLg4ffPCB3/6ffPIJoqOjYTKZ2n28zieiwwingiciagNRBGzm8C8BTIP+29/+FqdOncI333zj2Xb69GmsXbsWU6dORUNDAyZMmICSkhLs2LEDv/71rzFx4kSUl5e365AolUo8//zz+Omnn/D666/j66+/xoMPPuh5vaysDOPGjcPAgQOxadMmbNiwARMnToTT6QQAzJkzB4sWLcK8efOwe/duvPPOO0hPTw+oDY2NjXj66afxr3/9Cz/99BPS0tJgMpkwbdo0bNiwAZs3b0afPn0wYcIET5AQBAFXXnklNm7ciLfeegu7d+/GokWLoFKpEB0djRtuuAGvvvqq3+e8+uqr+M1vfoPY2Nh2Hau2iOguAfdN8jgVPBHROdgbgaeywv+5fz0JaKPbtGtiYiKuvPJKvPPOOxg3bhwA4IMPPkBKSgp++ctfQqlUoqCgwLP/448/jo8//hifffYZZs6cGXDT7rvvPs96Xl4ennjiCdx11134xz/+AQB45plnMGLECM9zALjooosAACaTCUuXLsWLL76IadOmAQB69eqF0aNHB9QGu92Of/zjH37fa+zYsX77vPzyy0hISMD69etx9dVX46uvvsLWrVuxZ88e9O3bFwDQs2dPz/633347LrnkElRUVCAzMxPV1dX4/PPPO9SL1BYR3TNiZM8IEVGXMXXqVHz44YewWq0AgLfffhs33HADlEolGhoa8MADD2DAgAFISEhATEwM9uzZ0+6eka+++grjxo1DdnY2YmNjcfPNN+PUqVNobGwE4O0ZacmePXtgtVpbfb2ttFot8vPz/bZVVVXhjjvuQJ8+fRAfH4+4uDg0NDR4vmdZWRlycnI8QaS5UaNG4aKLLsLrr78OAHjrrbfQvXt3/OIXv+hQW88nwntGeDUNEdF5aaKkXgo5PjcAEydOhCiKWLNmDUaOHIn/+7//w9///ncAwAMPPIB169bhb3/7G3r37g2DwYDf/OY3sNlsATfr6NGjuPrqq3H33XfjySefRFJSEjZs2IDf//73sNlsiIqKgsFgaPX953oNkIaAAPjdrddut7f4c5rPkTVt2jScOnUKS5cuRffu3aHT6VBUVOT5nuf7bEDqHVm2bBlmz56NV199FdOnTw/5XFwR3jPiLmBlzwgRUasUCmm4JNxLgCdAvV6P6667Dm+//TZWrVqFfv36YdiwYQCkYtJbb70VkyZNwuDBg5GRkeEpBg1UaWkpBEHAc889h4svvhh9+/bFyZP+YS0/Px8lJSUtvr9Pnz4wGAytvp6amgoAqKio8GwrKytrU9s2btyIP/3pT5gwYQIuuugi6HQ61NbW+rXr+PHj2L9/f6s/46abbsLPP/+M559/Hrt37/YMJYVSZIcRz6W97BkhIuoKpk6dijVr1mDlypWYOnWqZ3ufPn3w0UcfoaysDD/88ANuvPHGdl8K27t3b9jtdrzwwgs4fPgw3nzzTSxfvtxvnzlz5mDbtm344x//iB9//BF79+7FP//5T9TW1kKv1+Ohhx7Cgw8+iDfeeAOHDh3C5s2bsWLFCs/Pz83NxSOPPIIDBw5gzZo1eO6559rUtj59+uDNN9/Enj17sGXLFkydOtWvN2TMmDH4xS9+geuvvx7r1q3DkSNH8N///hdr16717JOYmIjrrrsOf/nLX3DFFVcgJyenXccpEBEdRiaPzMWdY3qiV1qM3E0hIqIgGDt2LJKSkrBv3z7ceOONnu2LFy9GYmIiLrnkEkycOBHjx4/39JoEqqCgAIsXL8bTTz+NQYMG4e2338bChQv99unbty++/PJL/PDDDxg1ahSKiorw6aefQq2W/vidN28e/vznP2P+/PkYMGAAJk+ejOrqagCARqPBqlWrsHfvXuTn5+Ppp5/GE0880aa2rVixAmfOnMGwYcNw8803409/+hPS0tL89vnwww8xcuRITJkyBQMHDsSDDz7oucrHzT3kdNttt7XrGAVKIYoBXDslE6PRiPj4eNTX1yMuLk7u5hARdVkWiwVHjhxBjx49oNfr5W4OyeTNN9/E/fffj5MnT0Kr1Z5z33P9zrT1/M3xCSIiIgIgzV1SUVGBRYsW4c477zxvEAmWiB6mISIiau7tt99GTExMi4t7rpCu6plnnkH//v2RkZGBOXPmhO1zOUxDREQeHKaRJiWrqqpq8TWNRoPu3buHuUUXNg7TEBERBVlsbGxIpz6ns3GYhoiIiGTFMEJERGfpzLejp/AKxu8Kh2mIiMhDq9VCqVTi5MmTSE1NhVarDflU4NQ5iaIIm82GmpoaKJXKDl15wzBCREQeSqUSPXr0QEVFxVlTnBO1JCoqCt26dfPcU6c9GEaIiMiPVqtFt27d4HA4zpqZk8iXSqWCWq3ucO8ZwwgREZ1FoVBAo9FAo+GNRCn0WMBKREREsmIYISIiIlkxjBAREZGsOkXNiHvGeqPRKHNLiIiIqK3c5+3z3XmmU4QRk8kEAMjNzZW5JURERBQok8mE+Pj4Vl/vFDfKEwQBJ0+eRGxsbFAn3zEajcjNzcWxY8d4A74w4PEOLx7v8OLxDi8e7/Bq7/EWRREmkwlZWVnnnIekU/SMKJVK5OTkhOznx8XF8Zc5jHi8w4vHO7x4vMOLxzu82nO8z9Uj4sYCViIiIpIVwwgRERHJKqLDiE6nw4IFC6DT6eRuSkTg8Q4vHu/w4vEOLx7v8Ar18e4UBaxERETUdUV0zwgRERHJj2GEiIiIZMUwQkRERLJiGCEiIiJZRXQYWbZsGfLy8qDX61FYWIitW7fK3aQu4X//+x8mTpyIrKwsKBQKfPLJJ36vi6KI+fPnIzMzEwaDAcXFxThw4IA8je0CFi5ciJEjRyI2NhZpaWm49tprsW/fPr99LBYLZsyYgeTkZMTExOD6669HVVWVTC3u3P75z38iPz/fM/lTUVER/vvf/3pe57EOnUWLFkGhUOC+++7zbOPxDq5HHnkECoXCb+nfv7/n9VAd74gNI6tXr8asWbOwYMECbN++HQUFBRg/fjyqq6vlblqnZzabUVBQgGXLlrX4+jPPPIPnn38ey5cvx5YtWxAdHY3x48fDYrGEuaVdw/r16zFjxgxs3rwZ69atg91uxxVXXAGz2ezZ5/7778e///1vvP/++1i/fj1OnjyJ6667TsZWd145OTlYtGgRSktL8f3332Ps2LG45ppr8NNPPwHgsQ6Vbdu24aWXXkJ+fr7fdh7v4LvoootQUVHhWTZs2OB5LWTHW4xQo0aNEmfMmOF57nQ6xaysLHHhwoUytqrrASB+/PHHnueCIIgZGRnis88+69lWV1cn6nQ6cdWqVTK0sOuprq4WAYjr168XRVE6vhqNRnz//fc9++zZs0cEIG7atEmuZnYpiYmJ4r/+9S8e6xAxmUxinz59xHXr1oljxowR7733XlEU+bsdCgsWLBALCgpafC2Uxzsie0ZsNhtKS0tRXFzs2aZUKlFcXIxNmzbJ2LKu78iRI6isrPQ79vHx8SgsLOSxD5L6+noAQFJSEgCgtLQUdrvd75j3798f3bp14zHvIKfTiXfffRdmsxlFRUU81iEyY8YMXHXVVX7HFeDvdqgcOHAAWVlZ6NmzJ6ZOnYry8nIAoT3eneJGecFWW1sLp9OJ9PR0v+3p6enYu3evTK2KDJWVlQDQ4rF3v0btJwgC7rvvPlx66aUYNGgQAOmYa7VaJCQk+O3LY95+O3fuRFFRESwWC2JiYvDxxx9j4MCBKCsr47EOsnfffRfbt2/Htm3bznqNv9vBV1hYiNdeew39+vVDRUUFHn30UVx22WXYtWtXSI93RIYRoq5qxowZ2LVrl98YLwVfv379UFZWhvr6enzwwQeYNm0a1q9fL3ezupxjx47h3nvvxbp166DX6+VuTkS48sorPev5+fkoLCxE9+7d8d5778FgMITscyNymCYlJQUqleqsCuCqqipkZGTI1KrI4D6+PPbBN3PmTPznP//BN998g5ycHM/2jIwM2Gw21NXV+e3PY95+Wq0WvXv3xvDhw7Fw4UIUFBRg6dKlPNZBVlpaiurqagwbNgxqtRpqtRrr16/H888/D7VajfT0dB7vEEtISEDfvn1x8ODBkP5+R2QY0Wq1GD58OEpKSjzbBEFASUkJioqKZGxZ19ejRw9kZGT4HXuj0YgtW7bw2LeTKIqYOXMmPv74Y3z99dfo0aOH3+vDhw+HRqPxO+b79u1DeXk5j3mQCIIAq9XKYx1k48aNw86dO1FWVuZZRowYgalTp3rWebxDq6GhAYcOHUJmZmZof787VP7aib377ruiTqcTX3vtNXH37t3iH/7wBzEhIUGsrKyUu2mdnslkEnfs2CHu2LFDBCAuXrxY3LFjh/jzzz+LoiiKixYtEhMSEsRPP/1U/PHHH8VrrrlG7NGjh9jU1CRzyzunu+++W4yPjxe//fZbsaKiwrM0NjZ69rnrrrvEbt26iV9//bX4/fffi0VFRWJRUZGMre68Zs+eLa5fv148cuSI+OOPP4qzZ88WFQqF+OWXX4qiyGMdar5X04gij3ew/fnPfxa//fZb8ciRI+LGjRvF4uJiMSUlRayurhZFMXTHO2LDiCiK4gsvvCB269ZN1Gq14qhRo8TNmzfL3aQu4ZtvvhEBnLVMmzZNFEXp8t558+aJ6enpok6nE8eNGyfu27dP3kZ3Yi0dawDiq6++6tmnqalJ/OMf/ygmJiaKUVFR4qRJk8SKigr5Gt2J3XbbbWL37t1FrVYrpqamiuPGjfMEEVHksQ615mGExzu4Jk+eLGZmZoparVbMzs4WJ0+eLB48eNDzeqiOt0IURbFjfStERERE7ReRNSNERER04WAYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrBhGiIiISFb/HzA/XZhSOg8yAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
-      ]
+      ],
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjYuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/P9b71AAAACXBIWXMAAA9hAAAPYQGoP6dpAABIqElEQVR4nO3deXwU9f0/8Nfeu7nvOxDuQ0i4YxSLhVQqyk/RtoioiNWqBatSq1A5vEGtFFRa1IK3iLe2WBSj0i/IZSAKcl+GIyeQ7GaTPWd+f8yeIYFssrtDsq/n4zGPnZ2dzX52jMwrn897PqMQRVEEERERkUyUcjeAiIiIIhvDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCu13A1oC0EQcPLkScTGxkKhUMjdHCIiImoDURRhMpmQlZUFpbL1/o9OEUZOnjyJ3NxcuZtBRERE7XDs2DHk5OS0+nqnCCOxsbEApC8TFxcnc2uIiIioLYxGI3Jzcz3n8dZ0ijDiHpqJi4tjGCEiIupkzldiwQJWIiIikhXDCBEREcmKYYSIiIhkxTBCREREsmIYISIiIlkxjBAREZGs2hVGli1bhry8POj1ehQWFmLr1q2t7mu32/HYY4+hV69e0Ov1KCgowNq1a9vdYCIiIupaAg4jq1evxqxZs7BgwQJs374dBQUFGD9+PKqrq1vcf+7cuXjppZfwwgsvYPfu3bjrrrswadIk7Nixo8ONJyIios5PIYqiGMgbCgsLMXLkSLz44osApPvG5Obm4p577sHs2bPP2j8rKwsPP/wwZsyY4dl2/fXXw2Aw4K233mrTZxqNRsTHx6O+vp6TnhEREXUSbT1/B9QzYrPZUFpaiuLiYu8PUCpRXFyMTZs2tfgeq9UKvV7vt81gMGDDhg2tfo7VaoXRaPRbiIiIqGsKKIzU1tbC6XQiPT3db3t6ejoqKytbfM/48eOxePFiHDhwAIIgYN26dfjoo49QUVHR6ucsXLgQ8fHxnoU3ySMiIuq6Qn41zdKlS9GnTx/0798fWq0WM2fOxPTp0895K+E5c+agvr7esxw7dizUzSQiIiKZBHSjvJSUFKhUKlRVVfltr6qqQkZGRovvSU1NxSeffAKLxYJTp04hKysLs2fPRs+ePVv9HJ1OB51OF0jTiIiIIp7V4YTZ6oTZ6oDZ5oDZ6kCjzQmLXYDVIT1a7E5Y7E5YHQKsdicsDmnbnWN6ITvBIEu7AwojWq0Ww4cPR0lJCa699loAUgFrSUkJZs6cec736vV6ZGdnw26348MPP8Tvfve7djeaiIioMxFFEXanCJtTQJPNCZPFDpPFAaPr0fO8yQ6jxYEGqwN2pwCHIMLhFOAURNe6CIcgPbc7RTTZnGjwCR52Z0DXpPi5dmh25wgjADBr1ixMmzYNI0aMwKhRo7BkyRKYzWZMnz4dAHDLLbcgOzsbCxcuBABs2bIFJ06cwJAhQ3DixAk88sgjEAQBDz74YHC/CRERUSukk7n3JO50neTdJ3ib09trYHX4P/r2KjS5ehWabE402aXF4rvu2tdqF2BzSj0PVoe0Hti1qx2j1ygRrVUjWqdGlFYFnUYFvVoJvUYFvUYJnVp6lJ6roFMrkRYr34hEwGFk8uTJqKmpwfz581FZWYkhQ4Zg7dq1nqLW8vJyv3oQi8WCuXPn4vDhw4iJicGECRPw5ptvIiEhIWhfgoiIOjeHU4DFIfUaWOxOmG0ONFgcUq+BVeo5cD9vsEo9Cmarw3vydwh+QcD7KMAuhDcInI9CAcTo1IjTaxCrV7sW//UYnRo6tRJqpQIqlRIapQIqpQIalRIqpQJqpQJqlRIGjQrROhVidFLwiNapEa1VQa3qXBOsBzzPiBw4zwgRkbycggibQzrJS4/uxfvc5hBgtvoHCJPFFSqs7uEIh3+vgmvpyPBCeykVgFqphFqlgFathF6tgk4jPbp7D3TNehEMGhUMWpV3XaP0e+7uZdC5HrVqpfTc9bO0KmlRKhVh/75yaOv5O+CeESIiurA5BdFTQ+AuYGy0eYcWpHVpu/t5g2vfBlfPg7tnosFVDNlkd4at/e4TvqenQKdBjGs9ztVrEKuXegF8hx107hO/KwjoNSpo1VKvglolhQ61UiEFEKUiYgJBZ8AwQkQUZnan4ClWdBcx+q1bHLA5BAiiVM/gFAQ4RXedg+hZb7L5DGe4goR0FUVog4NSAejUKs9f/d5HFWJcQwbuYYcYvXc4wr09WquCXquCXu3uZVD69SooFAwJkYZhhIjoPJyCiAZPULDD2OS9CsI3RDRYHN4CR5/HJpu3+LHRJtU5hINaqfAUMBq0KkRpVYjSqD3r7h6IKK0KMTqNp/YgxtXrEKNTI1or9UJEab1hobPVI9CFj2GEiCKC3SmgrtGOukYb6prsOGO2Sc+bbKhv8r+s0tQscDRYHSFpU7RWhTiDxjP84FvIqFOroFYpPMWKSoXCVczofa7XqDw9Du4CRvfzaFcBJHsZqDNgGCGiC1qTzYnaBitqG6w41WCTHs02nDbbYLFLxZM2p1Q86V53F1PaHAKMFjvqGu1BCRR6jdITGqQQoUGcK0DEGdSI1alh0KpdPQ7eoQd3D4T7uTswsIeBSMIwQkQhJQgiTFap16G+ye4zyZMDDe519xUYPhNBucNHYxDrHxQKIN6gQYJBg4QoLRKiNEiM0iLe4B8qpMDhuy69plUzPBCFAsMIEbWJKIpotDlx2mzDmUabz6M05HG60Yb6Rilw+C4mix1CB6/a1KqVSI3RISVGi+QYHZKjtUiK1ko1DK7LJd2FlFq1ElqVyrMep1cjIUqLxCgpYKh4BQXRBYdhhCgCCYKI+iY7TrtDhVmqo6hrtOGMu66i0Y4zrse6Rmlfm6P9hZc6tVLqgTD410bE6vwnenIPgaTEaJEcrUNKrA7RWhVrH4i6MIYRoi5CFEUYmxyoMDahot6CijoLqowWnHbVV5wyWz3rZxrtcLazu0KrViI5WovEKKl3IjFai6Qojaf3IT5Kg3iDd4kzaBCn10CvUQX5GxNRV8EwQtQJOAURtQ1WVNZLAaPKZEVlvRQ6Kl1LRb0l4ImpYnVqJMVoPUEi0VVHkWDQIjHaGzDcz5OitTBo2EtBRMHFMEIkM4dTQJXJihNnmnCyrgkn6pqkgGF0BQ+jBTUma5vrLpKitciI0yMzXo+0OD1SYqQejKRoadgjMVrjedSp2VtBRPJjGCEKMVEUUW2y4nCNGUdPmXH8TCNO1llw4owreBgtbRoyUSkVSI3RIT1ej/RYHTLi9ciI1yMr3oCMeCl8pMfpORxCRJ0OwwhRkJwx23C41oyjtWYc8VmOnjKf9/JUjUqBzHgDshMMyEowSMEiXo+MOD3S43TIiNMjOUbHK0GIqEtiGCEKgNnqwNFTrqBRIz0edoWO+iZ7q+9TKRXITTQgLyUauYlRyE70Bo+cRANSY3S8aRcRRSyGEaJmrA4njp1uxJHaRhypbfB5NKPKaD3nezPj9eiREo28lGj0TIn2rOcmRnHCLCKiVjCMUMQyWuzYdaIeB6oaPD0cR2ulmo5zlXAkRWvRwxU0fJe85GgYtKzXICIKFMMIRQR38Nh1oh4/Hpcej55qbHX/aK0KPVKj0SMlBj2So6SejtQY9EiORnyUJowtJyLq+hhGqMux2J346WQ9dpTX4QdX8DhSa25x3+wEAwZmxXmGVHqkRKNHajRSY3ScS4OIKEwYRqjTO1nXhO3lZ7D95zpsLz+D3SeNsDnPnrY8O8GAwdnxGJwTj8HZ8RiUHY+kaK0MLSYiIl8MI9SpiKKIfVUmbDhQ6wkglUbLWfslR2sxtFsihnZLwKBsKXwweBARXZgYRuiCV2204P8O1GLDQWmpMflf0aJSKjAgMxZDcxMxrHsChnVLRLekKA6zEBF1EgwjdMFptDmw5chpbDhQiw0HarGvyuT3ul6jRGGPZBT2TMKwbonIz4lHlJa/ykREnRX/BacLgslix1d7qrDmxwr8b3+tX82HQgEMzo7H6N4pGN0nBcO7J/KeKkREXQjDCMnGZLGjZE81/vNjBf63v8YvgGQnGHBZHyl8XNorBYms9yCiC50gAE4boNHL3ZJOh2GEwqrB6kCJqwfk2/01sDm8AaR3WgyuGpyJq/Iz0ScthjUfRG1lqQfqj7uWY0DdMe9zmxnQxzdb4lrYlgAYEgFDAqCNkbok20MUAasJaDoNNLqWJp/HpjOAUg3EZgAxGdJjbAYQky61o6XPddoBcy3QUAU0VLseq6Sf5bQBgkPax/fRvS4KgC4WiEoCDElAVLLPeqLrMQnQxQX2nZvqgOrdQNVPQNUu1+NuwG6WflZMGhCdJj3GpLseXeuGRMBhBexNgKNJenQvvs8FJyA6fR4dUuDxbHN9t+hU15LiXY9Jkz5H2Tl6kRlGKOREUUTZsTq8/t1R/HdXJaw+AaRnajSuzs/CVYMz0TedASTi2Myuk4vPCcZcA1iM0j+yrZ5EEwBttPR+S713sRr9n1vqpX0cltb/wbc3SW1RaQG1Vnr0Xdzb1DpAGwvoYqTP1sZIbfSsx0j7WU1nt8Gvja4aKKUKUKikE7NSBSiUPttcJxBRlE44cD2Kgs82SCf4+mPS9w4mpdo/nBgSpROs4JBOog5LK49N0ncUHO37XLUBiE0HYjOlY2mukX43Gk8BOP+drTtEoZJ+twyJ/t/b9zg0nnKFjp+k494aq1FaTh0MbZvPR6GUwpcmqoXfpRZ+t27+GMgaKktTGUYoZKwOJ/7zQwVe33QUPx6v92zvkRKNq/OlHpB+6bEMIOEgCC2fqN0nR4XCdTJU+58QFSpAqZQeBYfrpNPSicgmPTrtzf6Sc/01JwrebTaz9y9cW4PcR6brMCQB8TlAQjfp0b3oYqVwd67A1lQHWOr8exoaa6WlvdR6b6+DpyfC9ei0Sb8DpgrAVAU0VErtcDQBZ45KS3MKZbOehnTp56m0gErj+t1Vu9Y1gMr1XKGUvn9TC700jWekR3uj9LvZ5NreVvG5QPpFrmWQtMSkAuZT3nDtCdrVgNm13lQnHR+NXgoKatejxuCzTSd9D9//H5v/v6lQSv89zTWu4FbjXW86Lf1/Z65p+/dxtjNEBgHDCAVdRX0T3t5cjlVby3HKbAMAaNVKTMzPwi1F3ZGfE88AAkh/mTjtgGB3PTq96xClf2jgCgnusOD73GFp+R8hc613vfGU9wR0oVIbzu7K1sVJQcVzwmx2ArX7zKiriT572EEX5+1J0Ua38A++a1G7/vFXKKVg5bQDTqt0snTYpEf3NnuT1CabGbA2uNYbXOtmwGaS3uNuiy6uhZ6deCkcAOcObILTNWTQ7L+/53fAtejjgfhuQHy29D07ShSl79l0xhtOmlyPVqO3h0itd63rvc/VOmnRx0uBQxsV2GfbmwBTpbQ0VAJ2y9nBI1RDDvYm/0Dm/s7Nn2ujgYzBUvhIGyj1lrTEkAik9A5NW9vKaZf+/2+oln63FUpAgZb/XXFvS+gmW3MZRigoRFHE1iOn8fqmo/jipyo4XXeay4zX46aLu+OGkblIjtHJ3MrzEJzSXy31x4G6cp8x+OPevxD9TghK70lB4bojr9PhOoG5T2y+JzWbd5tg93a1h5Mm6uyTpC7G+/3dJ0TB4T8uLTilvzjVemnYwu8k5FpX6Vx/lTbvWWm2rjF4TzAxae2rT3DapQCgjZY+k4JDoZBChDZKCjjhpDEAST2kJdzc4TQuM/yfHSoqjbcepxNgGKEOEUURX+6uwgtfH8CuE96/vi/umYRpRXn41cB0qFVKGVvow9rgX+TnGzbqywHjyfaPdQeLQil1zSoU3jFd33Fdv31VroK1NG/hWkyafxFbVIr015v7L3V1F7kqSaVp/a9SIup0GEaoXQRBxJe7K7G05CD2VEghxKBR4dqh2Zh2SXf0z4gLb4OsJsBYAZhO+j8aT3ivLrDUnf/nKFRAXLb/mHtCrnTCVyhaKCIUXeuitK7S+BQ/aly9Ba51tc41pt3KGLdSLdVnnIv7s0TBFVwukKBHRNQBDCMUEEEQ8d9dlXjh6wPYWyldFRCjU2PaJd1x++iewZsPRBSl8GA+JY17NtZKtRCNrufmWlfxW4UUOmym8/5IAK4x9lz/sBGf690Wm3FhXwrnHhYCQwgRdR0MI9QmTkHE5zsr8MLXB7C/SroCIlanxvRL83Db6B5IiGpnCHHagdr9QOVO71KzTwofgQ6Z6OKkSwLjMoHYLOkxLksq8EvIlXo89GHusSEiovNiGKFzEkURa3ZWYMlXB3Cw2hVC9GrcdmkP3HZpD8RHBVA8aGsETm4HKne5gsePQM1eqaCzNdpYIDpZqn2ISpbqIaKSpSU2wxU+sqRHdyEmERF1Kgwj1KqTdU3468c78e0+6Tr1OL0at43ugemX9kC8oQ0hRBCAqp3Aoa+lpXxzy8FDFyddn58x2HXZ3EApXEQlS3UWRETUpTGM0FkEQcSqbeVY+PleNFgd0KqVuHtML/z+sh6I058nhBhPAoe+AQ5/Iz02nzQpLhvIHOIKHq4AktC9/VNPExFRp8cwQn5+PmXGQx/+iM2HpVkIh3VLwDO/KUDvtFaGQEQRqPgB+OkjYP+XQM0e/9e1MUDeZUCvsdKS3IvBg4iI/DCMEACpQPXVjUfwty/3wWIXYNCo8Jfx/TDtkjyolC2Eh6rdwK4PpRBy+rDPCwoge5gUPHr+EsgZ2XXmtiAiopBgGCEcrDbhLx/8iB3ldQCAop7JePr6fHRLbjadc+0BYNdHUgCp2evdrtYDfccDA6+RAkhUUvgaT0REnR7DSARzCiKWrz+EpV8dgM0pIEanxl8nDMCUUbnee8eYKoEf3gV2fSBdAeOm0gK9i4GLrgP6/dp7vw0iIqIAMYxEqPpGO+55dwf+t1+6UuaX/VLx5KTByEowSHN/7P8C2PEmcGCddI8SQJohtOflwKDrgX4TOB03EREFBcNIBDpY3YA73vgeR2rN0GuUePyaQfjN8BwoavcDX74p9YT43nY6txAomCINw3AIhoiIgoxhJMJ8s7caf1q1AyarA1nxevzrhn4YeLoEWPEmcHybd8foNKDgBmDozUBqX/kaTEREXR7DSIQQRRHL1x/GM1/shSgCI7sn4NXBOxGz6hbAJs2sCoVKKkQdehPQ5wremp2IiMKCYSQCWOxOPPThj/i07CQA4K4hOjxofRbKr76RdkjuLfWAFEwBYtNlbCkREUUihpEurqK+CX94oxQ7T9RDrQReH3YYlxx4BgqrUbokt/hRYNQfeCt6IiKSDcNIF1b682nc+eZ21DZY0dPQiA9y3kPSri+lF7NHAJOWAyl95G0kERFFPIaRLmrtrgr8aVUZbE4Bv0/aib8KL0F17DSg1AC/nANcci+g4n9+IiKSH89GXdCmQ6fwp1Vl0DuNeCPlPVzc8JX0QvogqTckY7C8DSQiIvLBMNLF7Kkw4g9vfI+R4g94MfoVJDbUAgolMPp+YMxs3ieGiIguOAwjXcjxM434/YqNmOl8E3dq1wBOSFfKTHoJyBkhd/OIiIhaxDDSRZwx2/DXf32Ml2zPYLD6qLRxxO+BK54AtFHnfC8REZGcGEa6gCarA28vfxLLG/6JKKUVgj4RymuXAf2vkrtpRERE58Uw0sk5Gk5j1z9vxUzzekABNGZfiqjJ/wLisuRuGhERUZswjHRi4tGNML09HSPtVbCLKlSNeAA5V83mBGZERNSpMIx0Rk4H8L9nIK5/FokQcFRIR8WvXkTRZVfI3TIiIqKAMYx0NoITeO9mYN/nUAJ43/ELCFc+jcmXDpS7ZURERO3C/vzOpuRRYN/nsIga3GObieNjnmMQISKiTo1hpDMpWwVsXAoAeMB+F2JGTMZ9xby3DBERdW4cpuksjm0F/v0nAMDzjmtxJGM8PrlmEBQKhcwNIyIi6hiGkc6g/jjw7lTAacNa50g8L/wWn/4mHxoVO7aIiKjz49nsQmczA6umAOZq7Ed3zLLfjTvH9MZFWfFyt4yIiCgoGEYuZIIAfHwXUPkjGlQJmG6ZhYzUZNwzlnUiRETUdXCY5kK2/mlgz2cQlBpMa7wXJxWpeP/6fOg1KrlbRkREFDTsGblQ/fQxsH4RAOBp9R9QKvbDLRd3x4i8JJkbRkREFFztCiPLli1DXl4e9Ho9CgsLsXXr1nPuv2TJEvTr1w8GgwG5ubm4//77YbFY2tXgiHCyDPj4bgDApvQpeMl4KbITDPjLr/vL2y4iIqIQCDiMrF69GrNmzcKCBQuwfft2FBQUYPz48aiurm5x/3feeQezZ8/GggULsGfPHqxYsQKrV6/GX//61w43vksyVQHv3gg4mlCfPQY3lUt33n1y0iDE6DiqRkREXU/AYWTx4sW44447MH36dAwcOBDLly9HVFQUVq5c2eL+3333HS699FLceOONyMvLwxVXXIEpU6actzclIgkC8P40wHgCQnIf3GK8C05RieuGZePyfmlyt46IiCgkAgojNpsNpaWlKC4u9v4ApRLFxcXYtGlTi++55JJLUFpa6gkfhw8fxueff44JEya0+jlWqxVGo9FviQg73wfKNwHaGLzefRF+qBGREqPFvKs43TsREXVdAfX719bWwul0Ij093W97eno69u7d2+J7brzxRtTW1mL06NEQRREOhwN33XXXOYdpFi5ciEcffTSQpnV+9iag5DEAQPWQGXhqow0A8Mj/uwiJ0Vo5W0ZERBRSIb+a5ttvv8VTTz2Ff/zjH9i+fTs++ugjrFmzBo8//nir75kzZw7q6+s9y7Fjx0LdTPltWgYYj0OMz8GMQ4WwO0X8amA6rhqcKXfLiIiIQiqgnpGUlBSoVCpUVVX5ba+qqkJGRkaL75k3bx5uvvlm3H777QCAwYMHw2w24w9/+AMefvhhKJVn5yGdTgedThdI0zq3hmpgw98BAN/m3I1tpRbE6tV44lree4aIiLq+gHpGtFothg8fjpKSEs82QRBQUlKCoqKiFt/T2Nh4VuBQqaRJu0RRDLS9XdO3CwFbA5wZQ3DPzp4AgIcnDEB6nF7mhhEREYVewNeKzpo1C9OmTcOIESMwatQoLFmyBGazGdOnTwcA3HLLLcjOzsbChQsBABMnTsTixYsxdOhQFBYW4uDBg5g3bx4mTpzoCSURrXovUPoaAOCrbvei4aiI3mkxmDwyV952ERERhUnAYWTy5MmoqanB/PnzUVlZiSFDhmDt2rWeotby8nK/npC5c+dCoVBg7ty5OHHiBFJTUzFx4kQ8+eSTwfsWndm6eYAoQOx/Nf6+PwWACVMLu3F4hoiIIoZC7ARjJUajEfHx8aivr0dcXJzczQmeQ98Ab14LKNXYde0XuPqdKug1SmyZU4z4KI3crSMiIuqQtp6/eW8auQhO4Mu50vrI27Fyj9RJNTE/i0GEiIgiCsOIXMreAap2Afp41I28H//ZWQEAuOni7jI3jIiIKLwYRuRgMwNfPyGt/+IveH93I2wOAYOy45CfEy9v24iIiMKMYUQO370ANFQCiXkQRtyBd7aWAwCmFnZn4SoREUUchpFwM1YAG5dK68WPYFN5A47UmhGrU+P/FWTJ2zYiIiIZMIyE2zdPAPZGILcQGHgt3tr8MwBg0rBsROsCvtKaiIio02MYCafKncCOt6X1K55ElcmKL3dLU+vfWNhNxoYRERHJh2EkXETRdSmvCFx0HZA7Eu9tOwanIGJE90T0z+hC86cQEREFgGEkXCp+AA5/C6i0QPECOAURq1yFq7ycl4iIIhnDSLjsXSM99v01kJiHb/ZW42S9BYlRGvx6UMt3PCYiIooEDCPhsu9z6bHfBADA21ukwtXfjsiFXsMbBhIRUeRiGAmHM0el2VYVKqDveBw73Yhv99cAAG4cxcJVIiKKbAwj4bBvrfTYrQiISsKqreUQReCyPinIS4mWt21EREQyYxgJh32uepH+E2BzCHjv+2MAgKm8nJeIiIhhJOSazgBHN0rr/a7EFz9VorbBhvQ4HcYNSJe3bURERBcAhpFQO7AOEJ1A6gAgqaencHXyyG7QqHj4iYiIeDYMtb3eIZqD1SZsPnwaSgVww8hcedtFRER0gWAYCSWHFThYIq33uwpvb5EmORs3IB1ZCQYZG0ZERHThYBgJpaP/B9hMQEwGLGn5+LD0OAAWrhIREfliGAmlve6Jzn6NLUfrYLQ4kBmvxy/6pMrbLiIiogsIw0ioiCKw77/Ser+rsPnwKQDApb1ToFQqZGwYERHRhYVhJFRO7gBMJwFNNNDjF9h0SAojF/dMlrlhREREFxaGkVBx94r0HocGQY2dJ+oBABf3TJKxUURERBcehpFQ8bkx3vdHT8MpiMhNMiAnMUredhEREV1gGEZCodmN8TYfPg0AuLgHh2iIiIiaYxgJBfcQjevGeO7iVdaLEBERnY1hJBTcQzT9J6DB6vDUixSyXoSIiOgsDCPB1uzGeKwXISIiOjeGkWBrdmM81osQERGdG8NIsPncGA8ANrFehIiI6JwYRoLJYQUOfiWt97sKJosdu9zzi/RiGCEiImoJw0gwHf0/wNYAxGQAWUPx/c9n4BREdEuKQjbv0ktERNQihpFg8rkxHpRKn0t6eRUNERFRaxhGgqXZjfEAeItXWS9CRETUKoaRYGl2YzzfepFChhEiIqJWMYwEi3uis97jAI2e9SJERERtxDASLJ4hGumSXtaLEBERtQ3DSDA0uzEewHoRIiKitmIYCYaDJdJjt4uBqCT/+UUYRoiIiM6JYSQYjm2VHrtfCgD4/qhUL9I9OQpZrBchIiI6J4aRYDjuCiO5hQB86kV4PxoiIqLzYhjpqIYa4PRhaT1nOACfMNKLxatERETnwzDSUce3SY+p/QFDIkwWO3a65xdhzwgREdF5MYx01LEt0mPOSABSvYgggvUiREREbcQw0lHunhHWixAREbULw0hHOO3Aie3Seu4oAKwXISIiChTDSEdU7gQcTYA+AUjuw3oRIiKidmAY6Qj3/CI5IwGlEtuOnma9CBERUYAYRjrirPlFpCngizjrKhERUZsxjHSEu2ckV7qSxntzPIYRIiKitmIYaS9jBVB/DFAogezhMPrcj6aQd+olIiJqM4aR9nIP0aRdBOhi8b2rXiQvOQqZ8awXISIiaiuGkfbyDNG4L+mV6kU4RENERBQYhpH2OiuMsF6EiIioPRhG2sNhBSrKpPXcUawXISIi6gCGkfao+AFw2oCoFCCxB+tFiIiIOoBhpD3cN8fLLQQUCuw6YQQADOuWKGOjiIiIOieGkfZoNr/I3kopjAzIjJOrRURERJ0Ww0igRNEnjEgzr+6tMAEA+mXEytUqIiKiTothJFD1x4CGSkCpBrKGosnmxNFTZgBA/0yGESIiokAxjATK3SuSkQ9oDDhQbYIgAsnRWqTG6ORtGxERUSfEMBKoZvOL+A7RKBQKuVpFRETUaTGMBMpzJY0rjFRKYaR/BotXiYiI2oNhJBA2M1C5U1rPcYcR6Uoa1osQERG1D8NIIE7uAEQnEJsFxOdAFEWfnhGGESIiovZoVxhZtmwZ8vLyoNfrUVhYiK1bt7a67+WXXw6FQnHWctVVV7W70bLxnV9EoUBNgxWnzTYoFUCfNIYRIiKi9gg4jKxevRqzZs3CggULsH37dhQUFGD8+PGorq5ucf+PPvoIFRUVnmXXrl1QqVT47W9/2+HGh10r84vkJUfDoFXJ1SoiIqJOLeAwsnjxYtxxxx2YPn06Bg4ciOXLlyMqKgorV65scf+kpCRkZGR4lnXr1iEqKqrzhRFRBI67woirXmSfe4iG9SJERETtFlAYsdlsKC0tRXFxsfcHKJUoLi7Gpk2b2vQzVqxYgRtuuAHR0dGt7mO1WmE0Gv0W2Z0+DDSeAlQ6IDMfALDHXbzKK2mIiIjaLaAwUltbC6fTifT0dL/t6enpqKysPO/7t27dil27duH2228/534LFy5EfHy8Z8nNzQ2kmaHhHqLJGgKopcnNOA08ERFRx4X1apoVK1Zg8ODBGDVq1Dn3mzNnDurr6z3LsWPHwtTCc2g2v4jDKeBgdQMAYAB7RoiIiNpNHcjOKSkpUKlUqKqq8tteVVWFjIyMc77XbDbj3XffxWOPPXbez9HpdNDpLrCp1Y9vkx5d9SJHas2wOQVEa1XISTTI2DAiIqLOLaCeEa1Wi+HDh6OkpMSzTRAElJSUoKio6Jzvff/992G1WnHTTTe1r6VyshiB6t3SuqtnZI+reLVvRiyUSk4DT0RE1F4B9YwAwKxZszBt2jSMGDECo0aNwpIlS2A2mzF9+nQAwC233ILs7GwsXLjQ730rVqzAtddei+Tk5OC0PJxOlAKiACR0A2KlHqB9LF4lIiIKioDDyOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAq/Ttc9u3bhw0bNuDLL78MTqvDzT1E45pfBPAWrw7gZb1EREQdEnAYAYCZM2di5syZLb727bffnrWtX79+EEWxPR91YXAXr+Z4C2/d08D3S2cYISIi6gjem+Z8BMGnZ0QKI0aLHSfqmgBwmIaIiKijGEbOp3Y/YKkHNFFA+iAA3plXs+L1iI/SyNk6IiKiTo9h5HzcU8BnDwdU0qjW3gqpeJWTnREREXUcw8j5nCiVHnNGeDbt9dyThkM0REREHcUwcj7Ve6VH1xAN4BNG2DNCRETUYQwj5yKKQM0eaT21v2uT6L1bL4tXiYiIOoxh5FxMlVLxqkIFpPQBABw/04QGqwMalQI9U1u/8zARERG1DcPIubh7RZJ6eu/U6+oV6ZUaA42Kh4+IiKijeDY9F3e9SGo/zyb3lTQDWLxKREQUFAwj51LjCiNpAzyb9laxeJWIiCiYGEbOxR1GXMWrAOcYISIiCjaGkdaIoneYxtUzYrE7caTWDIDDNERERMHCMNIaUwVgdV1Jk9wbAHCwugGCCCRGaZAWq5O5gURERF0Dw0hrql1X0iT38lxJs8dniEahUMjVMiIioi6FYaQ1LdSLcLIzIiKi4GMYaY27Z8T3ShpXGBmQyeJVIiKiYGEYaU1NC3OMVLqHadgzQkREFCwMIy0RRaBmn7SeKvWM1JisqG2wQaEA+qbHyNg4IiKiroVhpCXGk4DVCCjVnitp3PUiecnRiNKq5WwdERFRl8Iw0hLPPWl6AWotAJ8hmnTWixAREQUTw0hLPJOd+cy86r6ShsWrREREQcUw0hJ3z0iq75U0Us8IL+slIiIKLoaRljTrGXE4BeyvagDAG+QREREFG8NIcy1cSXP0VCNsDgEGjQrdkqJkbBwREVHXwzDSXP1xwGaSrqRJ6gnAO0TTNyMWSiWngSciIgomhpHm3JOdJff2XklT4Zp5lUM0REREQccw0lwL96TxXEnDMEJERBR0DCPNeYpXz76ShtPAExERBR/DSHOey3qlnhGTxY7jZ5oAsGeEiIgoFBhGfPleSePqGdlfJQ3RZMTpkRitlatlREREXRbDiK/6Y4CtAVBqPFfS7HEVr/ZjrwgREVFIMIz4cteLpPQBVBoAwKEaabIzhhEiIqLQYBjx5akX6efZVNdoBwCkxHCIhoiIKBQYRny5e0Z87kljbJLCSJxeI0eLiIiIujyGEV/unhGfu/WaLA4AQCzDCBERUUgwjLgJAlCzX1r37RmxuHpGDGo5WkVERNTlMYy41R8D7GZApfVcSQNwmIaIiCjUGEbcPPek6QOovL0gRtcwTZyBYYSIiCgUGEbcqs+uF3E4BTRYXWFEz2EaIiKiUGAYcas5+0oadxABWMBKREQUKgwjbtVnzzHivpJGr1FCq+ahIiIiCgWeYQHpSppa15U0PnfrrWfxKhERUcgxjABA3c+AvVG6kiaxh2ez97JehhEiIqJQYRgBvPUiKX39r6RpYvEqERFRqDGMAD7Fq/39NrNnhIiIKPQYRgDvPWnS/MMIp4InIiIKPYYRwOduvQP8NntnX+UwDRERUagwjPjekyatWRjhMA0REVHIMYzUHQUcTYBKByTm+b3kLWBlGCEiIgoVhpFqnytplCq/l3jHXiIiotBjGKk5+540bu6aERawEhERhQ7DSHXLl/UC3qtpWMBKREQUOgwj7jlGmhWvAixgJSIiCofIDiOC03tPmhZ6Roy8Nw0REVHIRXYYOXMUcFgAtf6sK2kEQYTJ6hqmYQErERFRyER2GKlp/UqaBpsDoiits2eEiIgodCI7jFS7Z15tvXhVq1JCr1Gd9ToREREFR2SHkZqW70kD+NSLcIiGiIgopCI7jHgu623hShoWrxIREYVFZP/ZP/ZhoHInkDX0rJeM7jv28rJeIiKikIrsMNLvSmlpAe/YS0REFB6RPUxzDiZOeEZERBQWDCOtMHIqeCIiorBgGGkFC1iJiIjCg2GkFbwvDRERUXi0K4wsW7YMeXl50Ov1KCwsxNatW8+5f11dHWbMmIHMzEzodDr07dsXn3/+ebsaHC7GJg7TEBERhUPAZ9rVq1dj1qxZWL58OQoLC7FkyRKMHz8e+/btQ1pa2ln722w2/OpXv0JaWho++OADZGdn4+eff0ZCQkIw2h8y7BkhIiIKj4DDyOLFi3HHHXdg+vTpAIDly5djzZo1WLlyJWbPnn3W/itXrsTp06fx3XffQaORTux5eXkda3UYuKeDj2XPCBERUUgFNExjs9lQWlqK4uJi7w9QKlFcXIxNmza1+J7PPvsMRUVFmDFjBtLT0zFo0CA89dRTcDqdrX6O1WqF0Wj0W8LN0zPCAlYiIqKQCiiM1NbWwul0Ij093W97eno6KisrW3zP4cOH8cEHH8DpdOLzzz/HvHnz8Nxzz+GJJ55o9XMWLlyI+Ph4z5KbmxtIM4PCe28ahhEiIqJQCvnVNIIgIC0tDS+//DKGDx+OyZMn4+GHH8by5ctbfc+cOXNQX1/vWY4dOxbqZvoRRdFnnhGGESIiolAKqCAiJSUFKpUKVVVVfturqqqQkZHR4nsyMzOh0WigUqk82wYMGIDKykrYbDZotdqz3qPT6aDT6QJpWlA12pxwCiIA3rWXiIgo1ALqGdFqtRg+fDhKSko82wRBQElJCYqKilp8z6WXXoqDBw9CEATPtv379yMzM7PFIHIhcBevqpUKGDSq8+xNREREHRHwMM2sWbPwyiuv4PXXX8eePXtw9913w2w2e66uueWWWzBnzhzP/nfffTdOnz6Ne++9F/v378eaNWvw1FNPYcaMGcH7FkHmLl6N1auhUChkbg0REVHXFvAYxOTJk1FTU4P58+ejsrISQ4YMwdq1az1FreXl5VAqvRknNzcXX3zxBe6//37k5+cjOzsb9957Lx566KHgfYsgY/EqERFR+ChEURTlbsT5GI1GxMfHo76+HnFxcSH/vK/3VuG2177H4Ox4/Pue0SH/PCIioq6oredv3pumBZ6p4Fm8SkREFHIMIy3ghGdEREThwzDSAk4FT0REFD4MIy3wFLCyZ4SIiCjkGEZawDv2EhERhQ/DSAs8BawcpiEiIgo5hpEWsGeEiIgofBhGWsCb5BEREYUPw0gLTE3e6eCJiIgotBhGWsBhGiIiovBhGGlGFEWfGVgZRoiIiEKNYaQZq0OAzSkA4NU0RERE4cAw0ox7wjOlAojWMowQERGFGsNIM0bPVPAaKJUKmVtDRETU9TGMNOMuXuWVNEREROHBMNIM70tDREQUXgwjzXgmPDOwZ4SIiCgcGEaaYc8IERFReDGMNGOycI4RIiKicGIYaYYFrEREROHFMNIMh2mIiIjCi2GkGSOHaYiIiMKKYaQZb88Ih2mIiIjCgWGkGRPv2EtERBRWDCPNeIZpWDNCREQUFgwjzbiHaXg1DRERUXgwjDTjvrQ3nsM0REREYcEw4sPqcMJiFwBwmIaIiChcGEZ8uGdfBYAYDtMQERGFBcOID3cYidWpoVIqZG4NERFRZGAY8cHiVSIiovBjGPFh5BwjREREYccw4sPYxDlGiIiIwo1hxIe3Z4TDNEREROHCMOLDMxU8e0aIiIjChmHEh2eYhjUjREREYcMw4sM9TMOraYiIiMKHYcSH+9JeDtMQERGFD8OID88de1nASkREFDYMIz7YM0JERBR+DCM+TBYWsBIREYUbw4gPIy/tJSIiCjuGER+8Nw0REVH4MYy4OJwCzDYnAA7TEBERhRPDiIu7XgRgzwgREVE4MYy4uMNIlFYFjYqHhYiIKFx41nVh8SoREZE8GEZcWLxKREQkD4YRF0/PCItXiYiIwophxMVzx172jBAREYUVw4gLe0aIiIjkwTDi4rlJHgtYiYiIwophxMVzkzzesZeIiCisGEZc3MM0sewZISIiCiuGERdvASvDCBERUTgxjLh4C1g5TENERBRODCMuJhawEhERyYJhxMVbwMowQkREFE4MIy7eAlYO0xAREYUTwwgAQRDRYOUwDRERkRwYRgCYrA6IorTOnhEiIqLwYhgBYHIN0ejUSug1KplbQ0REFFkYRuAzxwiLV4mIiMKOYQQ+c4xwiIaIiCjsGEbgvayXU8ETERGFX7vCyLJly5CXlwe9Xo/CwkJs3bq11X1fe+01KBQKv0Wv17e7waHguWMvh2mIiIjCLuAwsnr1asyaNQsLFizA9u3bUVBQgPHjx6O6urrV98TFxaGiosKz/Pzzzx1qdLB5JjzjMA0REVHYBXz2Xbx4Me644w5Mnz4dALB8+XKsWbMGK1euxOzZs1t8j0KhQEZGRsdaGkIm9owQEZ3F6XTCbrfL3Qy6gGk0GqhUHb8KNaAwYrPZUFpaijlz5ni2KZVKFBcXY9OmTa2+r6GhAd27d4cgCBg2bBieeuopXHTRRa3ub7VaYbVaPc+NRmMgzQyYt4CVYYSISBRFVFZWoq6uTu6mUCeQkJCAjIwMKBSKdv+MgMJIbW0tnE4n0tPT/banp6dj7969Lb6nX79+WLlyJfLz81FfX4+//e1vuOSSS/DTTz8hJyenxfcsXLgQjz76aCBN6xDvfWk4TENE5A4iaWlpiIqK6tBJhrouURTR2NjoKdPIzMxs988K+dm3qKgIRUVFnueXXHIJBgwYgJdeegmPP/54i++ZM2cOZs2a5XluNBqRm5sbsjZ670vDnhEiimxOp9MTRJKTk+VuDl3gDAYDAKC6uhppaWntHrIJKIykpKRApVKhqqrKb3tVVVWba0I0Gg2GDh2KgwcPtrqPTqeDTqcLpGkd4pn0jAWsRBTh3DUiUVFRMreEOgv374rdbm93GAnoahqtVovhw4ejpKTEs00QBJSUlPj1fpyL0+nEzp07O9SdE2wmq3uYhj0jREQAODRDbRaM35WAuwJmzZqFadOmYcSIERg1ahSWLFkCs9nsubrmlltuQXZ2NhYuXAgAeOyxx3DxxRejd+/eqKurw7PPPouff/4Zt99+e4cbHyzenhGGESIionALOIxMnjwZNTU1mD9/PiorKzFkyBCsXbvWU9RaXl4OpdLb4XLmzBnccccdqKysRGJiIoYPH47vvvsOAwcODN636CB3zUg8C1iJiIjCTiGKoih3I87HaDQiPj4e9fX1iIuLC+rPFkURvf76OQQR2PLXcUiPu7BmhyUiCieLxYIjR46gR48eF9xs2XRhOtfvTFvP3xF/bxqzzQnBFcc4TENERMHCCePaLuLDiHuOEY1KAb0m4g8HEVGntXbtWowePRoJCQlITk7G1VdfjUOHDnleP378OKZMmYKkpCRER0djxIgR2LJli+f1f//73xg5ciT0ej1SUlIwadIkz2sKhQKffPKJ3+clJCTgtddeAwAcPXoUCoUCq1evxpgxY6DX6/H222/j1KlTmDJlCrKzsxEVFYXBgwdj1apVfj9HEAQ888wz6N27N3Q6Hbp164Ynn3wSADB27FjMnDnTb/+amhpotVq/i0k6u4gvkvBMBa/XsHqciKgFoiiiye4M++caNKqA/l02m82YNWsW8vPz0dDQgPnz52PSpEkoKytDY2MjxowZg+zsbHz22WfIyMjA9u3bIQgCAGDNmjWYNGkSHn74Ybzxxhuw2Wz4/PPPA27z7Nmz8dxzz2Ho0KHQ6/WwWCwYPnw4HnroIcTFxWHNmjW4+eab0atXL4waNQqANLfWK6+8gr///e8YPXo0KioqPBOJ3n777Zg5cyaee+45z5QXb731FrKzszF27NiA23ehivgw4pkKnpf1EhG1qMnuxMD5X4T9c3c/Nh5R2rafpq6//nq/5ytXrkRqaip2796N7777DjU1Ndi2bRuSkpIAAL179/bs++STT+KGG27wm/27oKAg4Dbfd999uO666/y2PfDAA571e+65B1988QXee+89jBo1CiaTCUuXLsWLL76IadOmAQB69eqF0aNHAwCuu+46zJw5E59++il+97vfAQBee+013HrrrV3qD+iIH5fgHXuJiLqGAwcOYMqUKejZsyfi4uKQl5cHQLrKs6ysDEOHDvUEkebKysowbty4DrdhxIgRfs+dTicef/xxDB48GElJSYiJicEXX3yB8vJyAMCePXtgtVpb/Wy9Xo+bb74ZK1euBABs374du3btwq233trhtl5IIv4MzKngiYjOzaBRYfdj42X53EBMnDgR3bt3xyuvvIKsrCwIgoBBgwbBZrN5pi1v9bPO87pCoUDzi09bKlCNjo72e/7ss89i6dKlWLJkCQYPHozo6Gjcd999sNlsbfpcQBqqGTJkCI4fP45XX30VY8eORffu3c/7vs6EPSPuCc84xwgRUYsUCgWitOqwL4EMQ5w6dQr79u3D3LlzMW7cOAwYMABnzpzxvJ6fn4+ysjKcPn26xffn5+efsyA0NTUVFRUVnucHDhxAY2Pjedu1ceNGXHPNNbjppptQUFCAnj17Yv/+/Z7X+/TpA4PBcM7PHjx4MEaMGIFXXnkF77zzDm677bbzfm5nE/FhxOSuGWHPCBFRp5WYmIjk5GS8/PLLOHjwIL7++mu/G65OmTIFGRkZuPbaa7Fx40YcPnwYH374ITZt2gQAWLBgAVatWoUFCxZgz5492LlzJ55++mnP+8eOHYsXX3wRO3bswPfff4+77roLGs35zxt9+vTBunXr8N1332HPnj248847/e7vptfr8dBDD+HBBx/EG2+8gUOHDmHz5s1YsWKF38+5/fbbsWjRIoii6HeVT1cR8WHE6L6ahgWsRESdllKpxLvvvovS0lIMGjQI999/P5599lnP61qtFl9++SXS0tIwYcIEDB48GIsWLfLc2O3yyy/H+++/j88++wxDhgzB2LFjsXXrVs/7n3vuOeTm5uKyyy7DjTfeiAceeKBNNxOcO3cuhg0bhvHjx+Pyyy/3BCJf8+bNw5///GfMnz8fAwYMwOTJk1FdXe23z5QpU6BWqzFlypQuORldxM/AOvvDH/HutmN44Iq+mDm2T1B/NhFRZ8MZWC9MR48eRa9evbBt2zYMGzZM7ub4CcYMrBFfKMFLe4mI6EJlt9tx6tQpzJ07FxdffPEFF0SChcM0rgLWWF7aS0REF5iNGzciMzMT27Ztw/Lly+VuTshE/BmYBaxERHShuvzyy8+6pLgrYs8IC1iJiIhkxTDSxJ4RIiIiOUV0GBFF0aeANeJHrIiIiGQR0WHEYhdgd0pjcZwOnoiISB4RHUbcvSJKBRCtDeweCERERBQcER1GTD5zjHSlWzETERF1JhEdRurdN8njEA0RUcTLy8vDkiVL5G5GRIroMMLiVSIiIvlFdhjhZb1ERNQFOJ1OCIIgdzPaLbLDiIVTwRMRdQUvv/wysrKyzjohX3PNNbjttttw6NAhXHPNNUhPT0dMTAxGjhyJr776qt2ft3jxYgwePBjR0dHIzc3FH//4RzQ0NPjts3HjRlx++eWIiopCYmIixo8fjzNnzgAABEHAM888g969e0On06Fbt2548sknAQDffvstFAoF6urqPD+rrKwMCoUCR48eBQC89tprSEhIwGeffYaBAwdCp9OhvLwc27Ztw69+9SukpKQgPj4eY8aMwfbt2/3aVVdXhzvvvBPp6enQ6/UYNGgQ/vOf/8BsNiMuLg4ffPCB3/6ffPIJoqOjYTKZ2n28zieiwwingiciagNRBGzm8C8BTIP+29/+FqdOncI333zj2Xb69GmsXbsWU6dORUNDAyZMmICSkhLs2LEDv/71rzFx4kSUl5e365AolUo8//zz+Omnn/D666/j66+/xoMPPuh5vaysDOPGjcPAgQOxadMmbNiwARMnToTT6QQAzJkzB4sWLcK8efOwe/duvPPOO0hPTw+oDY2NjXj66afxr3/9Cz/99BPS0tJgMpkwbdo0bNiwAZs3b0afPn0wYcIET5AQBAFXXnklNm7ciLfeegu7d+/GokWLoFKpEB0djRtuuAGvvvqq3+e8+uqr+M1vfoPY2Nh2Hau2iOguAfdN8jgVPBHROdgbgaeywv+5fz0JaKPbtGtiYiKuvPJKvPPOOxg3bhwA4IMPPkBKSgp++ctfQqlUoqCgwLP/448/jo8//hifffYZZs6cGXDT7rvvPs96Xl4ennjiCdx11134xz/+AQB45plnMGLECM9zALjooosAACaTCUuXLsWLL76IadOmAQB69eqF0aNHB9QGu92Of/zjH37fa+zYsX77vPzyy0hISMD69etx9dVX46uvvsLWrVuxZ88e9O3bFwDQs2dPz/633347LrnkElRUVCAzMxPV1dX4/PPPO9SL1BYR3TNiZM8IEVGXMXXqVHz44YewWq0AgLfffhs33HADlEolGhoa8MADD2DAgAFISEhATEwM9uzZ0+6eka+++grjxo1DdnY2YmNjcfPNN+PUqVNobGwE4O0ZacmePXtgtVpbfb2ttFot8vPz/bZVVVXhjjvuQJ8+fRAfH4+4uDg0NDR4vmdZWRlycnI8QaS5UaNG4aKLLsLrr78OAHjrrbfQvXt3/OIXv+hQW88nwntGeDUNEdF5aaKkXgo5PjcAEydOhCiKWLNmDUaOHIn/+7//w9///ncAwAMPPIB169bhb3/7G3r37g2DwYDf/OY3sNlsATfr6NGjuPrqq3H33XfjySefRFJSEjZs2IDf//73sNlsiIqKgsFgaPX953oNkIaAAPjdrddut7f4c5rPkTVt2jScOnUKS5cuRffu3aHT6VBUVOT5nuf7bEDqHVm2bBlmz56NV199FdOnTw/5XFwR3jPiLmBlzwgRUasUCmm4JNxLgCdAvV6P6667Dm+//TZWrVqFfv36YdiwYQCkYtJbb70VkyZNwuDBg5GRkeEpBg1UaWkpBEHAc889h4svvhh9+/bFyZP+YS0/Px8lJSUtvr9Pnz4wGAytvp6amgoAqKio8GwrKytrU9s2btyIP/3pT5gwYQIuuugi6HQ61NbW+rXr+PHj2L9/f6s/46abbsLPP/+M559/Hrt37/YMJYVSZIcRz6W97BkhIuoKpk6dijVr1mDlypWYOnWqZ3ufPn3w0UcfoaysDD/88ANuvPHGdl8K27t3b9jtdrzwwgs4fPgw3nzzTSxfvtxvnzlz5mDbtm344x//iB9//BF79+7FP//5T9TW1kKv1+Ohhx7Cgw8+iDfeeAOHDh3C5s2bsWLFCs/Pz83NxSOPPIIDBw5gzZo1eO6559rUtj59+uDNN9/Enj17sGXLFkydOtWvN2TMmDH4xS9+geuvvx7r1q3DkSNH8N///hdr16717JOYmIjrrrsOf/nLX3DFFVcgJyenXccpEBEdRiaPzMWdY3qiV1qM3E0hIqIgGDt2LJKSkrBv3z7ceOONnu2LFy9GYmIiLrnkEkycOBHjx4/39JoEqqCgAIsXL8bTTz+NQYMG4e2338bChQv99unbty++/PJL/PDDDxg1ahSKiorw6aefQq2W/vidN28e/vznP2P+/PkYMGAAJk+ejOrqagCARqPBqlWrsHfvXuTn5+Ppp5/GE0880aa2rVixAmfOnMGwYcNw8803409/+hPS0tL89vnwww8xcuRITJkyBQMHDsSDDz7oucrHzT3kdNttt7XrGAVKIYoBXDslE6PRiPj4eNTX1yMuLk7u5hARdVkWiwVHjhxBjx49oNfr5W4OyeTNN9/E/fffj5MnT0Kr1Z5z33P9zrT1/M3xCSIiIgIgzV1SUVGBRYsW4c477zxvEAmWiB6mISIiau7tt99GTExMi4t7rpCu6plnnkH//v2RkZGBOXPmhO1zOUxDREQeHKaRJiWrqqpq8TWNRoPu3buHuUUXNg7TEBERBVlsbGxIpz6ns3GYhoiIiGTFMEJERGfpzLejp/AKxu8Kh2mIiMhDq9VCqVTi5MmTSE1NhVarDflU4NQ5iaIIm82GmpoaKJXKDl15wzBCREQeSqUSPXr0QEVFxVlTnBO1JCoqCt26dfPcU6c9GEaIiMiPVqtFt27d4HA4zpqZk8iXSqWCWq3ucO8ZwwgREZ1FoVBAo9FAo+GNRCn0WMBKREREsmIYISIiIlkxjBAREZGsOkXNiHvGeqPRKHNLiIiIqK3c5+3z3XmmU4QRk8kEAMjNzZW5JURERBQok8mE+Pj4Vl/vFDfKEwQBJ0+eRGxsbFAn3zEajcjNzcWxY8d4A74w4PEOLx7v8OLxDi8e7/Bq7/EWRREmkwlZWVnnnIekU/SMKJVK5OTkhOznx8XF8Zc5jHi8w4vHO7x4vMOLxzu82nO8z9Uj4sYCViIiIpIVwwgRERHJKqLDiE6nw4IFC6DT6eRuSkTg8Q4vHu/w4vEOLx7v8Ar18e4UBaxERETUdUV0zwgRERHJj2GEiIiIZMUwQkRERLJiGCEiIiJZRXQYWbZsGfLy8qDX61FYWIitW7fK3aQu4X//+x8mTpyIrKwsKBQKfPLJJ36vi6KI+fPnIzMzEwaDAcXFxThw4IA8je0CFi5ciJEjRyI2NhZpaWm49tprsW/fPr99LBYLZsyYgeTkZMTExOD6669HVVWVTC3u3P75z38iPz/fM/lTUVER/vvf/3pe57EOnUWLFkGhUOC+++7zbOPxDq5HHnkECoXCb+nfv7/n9VAd74gNI6tXr8asWbOwYMECbN++HQUFBRg/fjyqq6vlblqnZzabUVBQgGXLlrX4+jPPPIPnn38ey5cvx5YtWxAdHY3x48fDYrGEuaVdw/r16zFjxgxs3rwZ69atg91uxxVXXAGz2ezZ5/7778e///1vvP/++1i/fj1OnjyJ6667TsZWd145OTlYtGgRSktL8f3332Ps2LG45ppr8NNPPwHgsQ6Vbdu24aWXXkJ+fr7fdh7v4LvoootQUVHhWTZs2OB5LWTHW4xQo0aNEmfMmOF57nQ6xaysLHHhwoUytqrrASB+/PHHnueCIIgZGRnis88+69lWV1cn6nQ6cdWqVTK0sOuprq4WAYjr168XRVE6vhqNRnz//fc9++zZs0cEIG7atEmuZnYpiYmJ4r/+9S8e6xAxmUxinz59xHXr1oljxowR7733XlEU+bsdCgsWLBALCgpafC2Uxzsie0ZsNhtKS0tRXFzs2aZUKlFcXIxNmzbJ2LKu78iRI6isrPQ79vHx8SgsLOSxD5L6+noAQFJSEgCgtLQUdrvd75j3798f3bp14zHvIKfTiXfffRdmsxlFRUU81iEyY8YMXHXVVX7HFeDvdqgcOHAAWVlZ6NmzJ6ZOnYry8nIAoT3eneJGecFWW1sLp9OJ9PR0v+3p6enYu3evTK2KDJWVlQDQ4rF3v0btJwgC7rvvPlx66aUYNGgQAOmYa7VaJCQk+O3LY95+O3fuRFFRESwWC2JiYvDxxx9j4MCBKCsr47EOsnfffRfbt2/Htm3bznqNv9vBV1hYiNdeew39+vVDRUUFHn30UVx22WXYtWtXSI93RIYRoq5qxowZ2LVrl98YLwVfv379UFZWhvr6enzwwQeYNm0a1q9fL3ezupxjx47h3nvvxbp166DX6+VuTkS48sorPev5+fkoLCxE9+7d8d5778FgMITscyNymCYlJQUqleqsCuCqqipkZGTI1KrI4D6+PPbBN3PmTPznP//BN998g5ycHM/2jIwM2Gw21NXV+e3PY95+Wq0WvXv3xvDhw7Fw4UIUFBRg6dKlPNZBVlpaiurqagwbNgxqtRpqtRrr16/H888/D7VajfT0dB7vEEtISEDfvn1x8ODBkP5+R2QY0Wq1GD58OEpKSjzbBEFASUkJioqKZGxZ19ejRw9kZGT4HXuj0YgtW7bw2LeTKIqYOXMmPv74Y3z99dfo0aOH3+vDhw+HRqPxO+b79u1DeXk5j3mQCIIAq9XKYx1k48aNw86dO1FWVuZZRowYgalTp3rWebxDq6GhAYcOHUJmZmZof787VP7aib377ruiTqcTX3vtNXH37t3iH/7wBzEhIUGsrKyUu2mdnslkEnfs2CHu2LFDBCAuXrxY3LFjh/jzzz+LoiiKixYtEhMSEsRPP/1U/PHHH8VrrrlG7NGjh9jU1CRzyzunu+++W4yPjxe//fZbsaKiwrM0NjZ69rnrrrvEbt26iV9//bX4/fffi0VFRWJRUZGMre68Zs+eLa5fv148cuSI+OOPP4qzZ88WFQqF+OWXX4qiyGMdar5X04gij3ew/fnPfxa//fZb8ciRI+LGjRvF4uJiMSUlRayurhZFMXTHO2LDiCiK4gsvvCB269ZN1Gq14qhRo8TNmzfL3aQu4ZtvvhEBnLVMmzZNFEXp8t558+aJ6enpok6nE8eNGyfu27dP3kZ3Yi0dawDiq6++6tmnqalJ/OMf/ygmJiaKUVFR4qRJk8SKigr5Gt2J3XbbbWL37t1FrVYrpqamiuPGjfMEEVHksQ615mGExzu4Jk+eLGZmZoparVbMzs4WJ0+eLB48eNDzeqiOt0IURbFjfStERERE7ReRNSNERER04WAYISIiIlkxjBAREZGsGEaIiIhIVgwjREREJCuGESIiIpIVwwgRERHJimGEiIiIZMUwQkRERLJiGCEiIiJZMYwQERGRrBhGiIiISFb/HzA/XZhSOg8yAAAAAElFTkSuQmCC"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
-   "source": [
-    "history = swivel_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Swivel trains faster but achieves a lower validation accuracy, and requires more epochs to train on."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Deploying the model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The first step is to serialize one of our trained Keras model as a SavedModel:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-07-31 13:36:40.513145: W tensorflow/python/util/util.cc:348] Sets are not currently considered sequences, but this may change in the future, so consider avoiding using them.\n",
-      "WARNING:absl:Found untraced functions such as _destroy_resource while saving (showing 1 of 1). These functions will not be directly callable after loading.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: ./savedmodels/swivel/assets\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Assets written to: ./savedmodels/swivel/assets\n"
-     ]
-    }
    ],
-   "source": [
-    "OUTPUT_DIR = \"./savedmodels\"\n",
-    "shutil.rmtree(OUTPUT_DIR, ignore_errors=True)\n",
-    "\n",
-    "EXPORT_PATH = os.path.join(OUTPUT_DIR, 'swivel')\n",
-    "os.environ['EXPORT_PATH'] = EXPORT_PATH\n",
-    "\n",
-    "shutil.rmtree(EXPORT_PATH, ignore_errors=True)\n",
-    "\n",
-    "tf.saved_model.save(swivel_model, EXPORT_PATH)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then we can deploy the model using the gcloud CLI as before:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating title_model\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n",
-      "Created ai platform model [projects/qwiklabs-gcp-04-af059b23c3fc/models/title_model].\n",
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Creating title_model:swivel\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n",
-      "Creating version (this might take a few minutes)......\n",
-      "...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................done.\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%bash\n",
-    "\n",
-    "# TODO 5\n",
-    "\n",
-    "MODEL_NAME=title_model\n",
-    "VERSION_NAME=swivel\n",
-    "\n",
-    "if [[ $(gcloud ai-platform models list --format='value(name)' | grep ^$MODEL_NAME$) ]]; then\n",
-    "    echo \"$MODEL_NAME already exists\"\n",
-    "else\n",
-    "    echo \"Creating $MODEL_NAME\"\n",
-    "    gcloud ai-platform models create --region=$REGION $MODEL_NAME\n",
-    "fi\n",
-    "\n",
-    "if [[ $(gcloud ai-platform versions list --model $MODEL_NAME --format='value(name)' | grep ^$VERSION_NAME$) ]]; then\n",
-    "    echo \"Deleting already existing $MODEL_NAME:$VERSION_NAME ... \"\n",
-    "    echo yes | gcloud ai-platform versions delete --model=$MODEL_NAME $VERSION_NAME\n",
-    "    echo \"Please run this cell again if you don't see a Creating message ... \"\n",
-    "    sleep 2\n",
-    "fi\n",
-    "\n",
-    "echo \"Creating $MODEL_NAME:$VERSION_NAME\"\n",
-    "gcloud ai-platform versions create \\\n",
-    "  --model=$MODEL_NAME $VERSION_NAME \\\n",
-    "  --framework=tensorflow \\\n",
-    "  --python-version=3.7 \\\n",
-    "  --runtime-version=2.1 \\\n",
-    "  --origin=$EXPORT_PATH \\\n",
-    "  --staging-bucket=gs://$BUCKET \\\n",
-    "  --machine-type n1-standard-4 \\\n",
-    "  --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Before we try our deployed model, let's inspect its signature to know what to send to the deployed API:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The given SavedModel SignatureDef contains the following input(s):\n",
-      "  inputs['keras_layer_1_input'] tensor_info:\n",
-      "      dtype: DT_STRING\n",
-      "      shape: (-1)\n",
-      "      name: serving_default_keras_layer_1_input:0\n",
-      "The given SavedModel SignatureDef contains the following output(s):\n",
-      "  outputs['dense_3'] tensor_info:\n",
-      "      dtype: DT_FLOAT\n",
-      "      shape: (-1, 3)\n",
-      "      name: StatefulPartitionedCall_2:0\n",
-      "Method name is: tensorflow/serving/predict\n",
-      "./savedmodels/swivel\n",
-      "./savedmodels/swivel/assets\n",
-      "./savedmodels/swivel/assets/tokens.txt\n",
-      "./savedmodels/swivel/variables\n",
-      "./savedmodels/swivel/variables/variables.index\n",
-      "./savedmodels/swivel/variables/variables.data-00000-of-00001\n",
-      "./savedmodels/swivel/saved_model.pb\n"
-     ]
-    }
-   ],
-   "source": [
-    "!saved_model_cli show \\\n",
-    " --tag_set serve \\\n",
-    " --signature_def serving_default \\\n",
-    " --dir {EXPORT_PATH}\n",
-    "!find {EXPORT_PATH}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's go ahead and hit our model:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Writing input.json\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%writefile input.json\n",
-    "{\"keras_layer_1_input\": \"hello\"}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 46,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using endpoint [https://us-central1-ml.googleapis.com/]\n",
-      "[[0.885626853, 0.0408654884, 0.0735076517]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "!gcloud ai-platform predict \\\n",
-    "  --model title_model \\\n",
-    "  --json-instances input.json \\\n",
-    "  --version swivel \\\n",
-    "  --region=$REGION"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "## Bonus"
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Try to beat the best model by modifying the model architecture, changing the TF-Hub embedding, and tweaking the training parameters."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
     "Copyright 2023 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
-   ]
+   ],
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
Removed the deployment step to ensure the lab can run in the restrictive Qwiklab enviornemnt.

Changes include:
- Removed one learning objective about model deployment.
- Removed the step of model deployment.

Two notebooks have been impacted:
- reusable_embeddings.ipynb under lab folder
- reusable_embeddings.ipynb under solution folder