### PR TITLE
fix: bump down shapely version for compatibility with BQ

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/labs/python.BQ_explore_data.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/labs/python.BQ_explore_data.ipynb
@@ -52,7 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install --user google-cloud-bigquery==2.34.4"
+    "!pip install --user google-cloud-bigquery==2.34.4 \"shapely<2\""
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/launching_into_ml/solutions/python.BQ_explore_data.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/solutions/python.BQ_explore_data.ipynb
@@ -53,8 +53,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install the Google Cloud BigQuery library\n",
-    "!pip install --user google-cloud-bigquery==2.34.4"
+    "# Install the Google Cloud BigQuery library and shapely dependency\n",
+    "!pip install --user google-cloud-bigquery==2.34.4 \"shapely<2\""
    ]
   },
   {


### PR DESCRIPTION
While working through the lab, I encountered the error "ImportError: cannot import name 'WKBWriter' from 'shapely.geos'".

I solved it by forcing the shapely version to be lower than 2.0, which seems to fix the issue.
The issue is fixed in both the lab and the solution notebook.