### PR TITLE
upgrade pyarrow

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow>=2.11.0
-pyarrow==6.0.1
+pyarrow==7.0.0
 httplib2>=0.20.4
 grpcio-status>=1.38.1
 google-api-python-client>=1.8.0


### PR DESCRIPTION
upgraded pyarrow from existing 6.0.0 to 7.0.0 for the initial gsp lab 917  at https://github.com/GoogleCloudPlatform/training-data-analyst/blob/master/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise.ipynb
 
A similar pr  https://github.com/GoogleCloudPlatform/training-data-analyst/pull/2612  and my comment be seen here -> https://github.com/GoogleCloudPlatform/training-data-analyst/pull/2612#issuecomment-2120490633