### PR TITLE
Remove 2nd learning objective from Vertex AI Qwik Start notebook

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise.ipynb
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise.ipynb
@@ -15,8 +15,7 @@
    "source": [
     "## Learning objectives\n",
     "\n",
-    "* Train a TensorFlow model locally in a hosted [**Vertex Notebook**](https://cloud.google.com/vertex-ai/docs/general/notebooks?hl=sv).\n",
-    "* Create a [**managed Tabular dataset**](https://cloud.google.com/vertex-ai/docs/training/using-managed-datasets?hl=sv) artifact for experiment tracking.\n"
+    "* Train a TensorFlow model locally in a hosted [**Vertex Notebook**](https://cloud.google.com/vertex-ai/docs/general/notebooks?hl=sv).\n"
    ]
   },
   {


### PR DESCRIPTION
This PR remove 2nd learning objective from Vertex AI Qwik Start notebook titled lab_exercise.ipynb because it is not actually achieved (it was mistakenly kept in the notebook after it was created from the longer notebook titled lab_exercise_long.ipynb).

