### PR TITLE
Identified issues with tfdv_basic_spending.ipynb

### DIFF
--- a/courses/machine_learning/deepdive2/production_ml/labs/tfdv_basic_spending.ipynb
+++ b/courses/machine_learning/deepdive2/production_ml/labs/tfdv_basic_spending.ipynb
@@ -615,10 +615,8 @@
     "\n",
     "* Notice that numeric features and categorical features are visualized separately, and that charts are displayed showing the distributions for each feature.\n",
     "* Notice that features with missing or zero values display a percentage in red as a visual indicator that there may be issues with examples in those features.  The percentage is the percentage of examples that have missing or zero values for that feature.\n",
-    "* Notice that there are no examples with values for `pickup_census_tract`.  This is an opportunity for dimensionality reduction!\n",
     "* Try clicking \"expand\" above the charts to change the display\n",
     "* Try hovering over bars in the charts to display bucket ranges and counts\n",
-    "* Try switching between the log and linear scales, and notice how the log scale reveals much more detail about the `payment_type` categorical feature\n",
     "* Try selecting \"quantiles\" from the \"Chart to show\" menu, and hover over the markers to show the quantile percentages"
    ]
   },


### PR DESCRIPTION
training-data-analyst/courses/machine_learning/deepdive2/production_ml/solutions/tfdv_basic_spending.ipynb might be having mistakes

1. data location not disclosed asked candidate to write code to read data (train and test) in the first few cells of the notebook
2. unnecessary comment confusing candidate (could be from taxi example but relevant here ) .
    Here are those comments:- 

            -       Notice that there are no examples with values for pickup_census_tract. This is an opportunity for dimensionality reduction! 
            -       Try switching between the log and linear scales, and notice how the log scale reveals much more detail about the payment_type categorical feature