### PR TITLE
updating links to TensorFlow API docs

### DIFF
--- a/courses/machine_learning/deepdive/02_tensorflow/c_estimator.ipynb
+++ b/courses/machine_learning/deepdive/02_tensorflow/c_estimator.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "## Create feature columns\n",
     "\n",
-    "Feature columns make it easy to perform common type of feature engineering on your raw data. For example you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these later in the course, but if you want to a sneak peak browse the official TensorFlow [feature columns guide](https://www.tensorflow.org/guide/feature_columns).\n",
+    "Feature columns make it easy to perform common type of feature engineering on your raw data. For example you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these later in the course, but if you want to a sneak peak browse the official TensorFlow API [feature column](https://www.tensorflow.org/api_docs/python/tf/feature_column) documentation.\n",
     "\n",
     "In our case we won't do any feature engineering. However we still need to create a list of feature columns because the Estimator we will use requires one. To specify the numeric values should be passed on without modification we use `tf.feature_column.numeric_column()`\n",
     "\n",

--- a/courses/machine_learning/deepdive/02_tensorflow/labs/c_estimator.ipynb
+++ b/courses/machine_learning/deepdive/02_tensorflow/labs/c_estimator.ipynb
@@ -86,7 +86,7 @@
    "source": [
     "## Create feature columns\n",
     "\n",
-    "Feature columns make it easy to perform common type of feature engineering on your raw data. For example you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these later in the course, but if you want to a sneak peak browse the official TensorFlow [feature columns guide](https://www.tensorflow.org/guide/feature_columns).\n",
+    "Feature columns make it easy to perform common type of feature engineering on your raw data. For example you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these later in the course, but if you want to a sneak peak browse the official TensorFlow API [feature column](https://www.tensorflow.org/api_docs/python/tf/feature_column) documentation.\n",
     "\n",
     "In our case we won't do any feature engineering. However we still need to create a list of feature columns because the Estimator we will use requires one. To specify the numeric values should be passed on without modification we use `tf.feature_column.numeric_column()`\n",
     "\n",

--- a/courses/machine_learning/deepdive/03_model_performance/a_feature_engineering_dnn.ipynb
+++ b/courses/machine_learning/deepdive/03_model_performance/a_feature_engineering_dnn.ipynb
@@ -123,7 +123,7 @@
     "- one hot encode categorical features\n",
     "- create feature crosses\n",
     "\n",
-    "For details on the possible `tf.feature_column` transformations and when to use each see the [official guide](https://www.tensorflow.org/guide/feature_columns).\n",
+    "For details on the possible `tf.feature_column` transformations and when to use each see the [official API documentation](https://www.tensorflow.org/api_docs/python/tf/feature_column).\n",
     "\n",
     "Let's use `tf.feature_column` to create a feature that shows the combination of day of week and hour of day. This will allow our model to easily learn the difference between say Wednesday at 5pm (rush hour, expect higher fares) and Sunday at 5pm (light traffic, expect lower fares).\n",
     "\n",
@@ -205,7 +205,7 @@
     "\n",
     "Ultimately our estimator expects a list of feature columns, so let's gather all our engineered features into a single list.\n",
     "\n",
-    "We cannot pass categorical or crossed feature columns directly into a DNN, Tensorflow will give us an error. We must first wrap them using either `indicator_column()` or `embedding_column()`. The former will pass through the one-hot encoded representation as is, the latter will embed the feature into a dense representation of specified dimensionality (the 4th root of the number of categories is a good starting point for number of dimensions). Read more about indicator and embedding columns [here](https://www.tensorflow.org/guide/feature_columns#indicator_and_embedding_columns).\n"
+    "We cannot pass categorical or crossed feature columns directly into a DNN, Tensorflow will give us an error. We must first wrap them using either `indicator_column()` or `embedding_column()`. The former will pass through the one-hot encoded representation as is, the latter will embed the feature into a dense representation of specified dimensionality (the 4th root of the number of categories is a good starting point for number of dimensions). Read more about indicator and embedding columns [here](https://www.tensorflow.org/api_docs/python/tf/feature_column/indicator_column) and [here](https://www.tensorflow.org/api_docs/python/tf/feature_column/embedding_column).\n"
    ]
   },
   {

--- a/courses/machine_learning/deepdive/03_model_performance/labs/a_feature_engineering_dnn.ipynb
+++ b/courses/machine_learning/deepdive/03_model_performance/labs/a_feature_engineering_dnn.ipynb
@@ -124,7 +124,7 @@
     "- one hot encode categorical features\n",
     "- create feature crosses\n",
     "\n",
-    "For details on the possible `tf.feature_column` transformations and when to use each see the [official guide](https://www.tensorflow.org/guide/feature_columns).\n",
+    "For details on the possible `tf.feature_column` transformations and when to use each see the [official API documentation](https://www.tensorflow.org/api_docs/python/tf/feature_column).\n",
     "\n",
     "Let's use `tf.feature_column` to create a feature that shows the combination of day of week and hour of day. This will allow our model to easily learn the difference between say Wednesday at 5pm (rush hour, expect higher fares) and Sunday at 5pm (light traffic, expect lower fares).\n",
     "\n",
@@ -221,7 +221,7 @@
     "\n",
     "Ultimately our estimator expects a list of feature columns, so let's gather all our engineered features into a single list.\n",
     "\n",
-    "We cannot pass categorical or crossed feature columns directly into a DNN, Tensorflow will give us an error. We must first wrap them using either `indicator_column()` or `embedding_column()`. The former will pass through the one-hot encoded representation as is, the latter will embed the feature into a dense representation of specified dimensionality (the 4th root of the number of categories is a good starting point for number of dimensions). Read more about indicator and embedding columns [here](https://www.tensorflow.org/guide/feature_columns#indicator_and_embedding_columns).\n"
+    "We cannot pass categorical or crossed feature columns directly into a DNN, Tensorflow will give us an error. We must first wrap them using either `indicator_column()` or `embedding_column()`. The former will pass through the one-hot encoded representation as is, the latter will embed the feature into a dense representation of specified dimensionality (the 4th root of the number of categories is a good starting point for number of dimensions). Read more about indicator and embedding columns [here](https://www.tensorflow.org/api_docs/python/tf/feature_column/indicator_column) and [here](https://www.tensorflow.org/api_docs/python/tf/feature_column/embedding_column).\n"
    ]
   },
   {

--- a/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
+++ b/courses/machine_learning/deepdive2/introduction_to_tensorflow/labs/3_keras_sequential_api.ipynb
@@ -268,7 +268,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use feature columns to connect our raw data to our keras DNN model. Feature columns make it easy to perform common types of feature engineering on your raw data. For example, you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these in more detail later in the course, but if you want to a sneak peak browse the official TensorFlow [feature columns guide](https://www.tensorflow.org/guide/feature_columns).\n",
+    "We will use feature columns to connect our raw data to our keras DNN model. Feature columns make it easy to perform common types of feature engineering on your raw data. For example, you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these in more detail later in the course, but if you want to a sneak peak browse the official TensorFlow API [feature column](https://www.tensorflow.org/api_docs/python/tf/feature_column) documentation.\n",
     "\n",
     "In our case we won't do any feature engineering. However, we still need to create a list of feature columns to specify the numeric values which will be passed on to our model. To do this, we use `tf.feature_column.numeric_column()`\n",
     "\n",

--- a/courses/machine_learning/deepdive2/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
+++ b/courses/machine_learning/deepdive2/introduction_to_tensorflow/solutions/3_keras_sequential_api.ipynb
@@ -276,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use feature columns to connect our raw data to our keras DNN model. Feature columns make it easy to perform common types of feature engineering on your raw data. For example, you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these in more detail later in the course, but if you want to a sneak peak browse the official TensorFlow [feature columns guide](https://www.tensorflow.org/guide/feature_columns).\n",
+    "We will use feature columns to connect our raw data to our keras DNN model. Feature columns make it easy to perform common types of feature engineering on your raw data. For example, you can one-hot encode categorical data, create feature crosses, embeddings and more. We'll cover these in more detail later in the course, but if you want to a sneak peak browse the official TensorFlow API [feature column](https://www.tensorflow.org/api_docs/python/tf/feature_column) documentation.\n",
     "\n",
     "In our case we won't do any feature engineering. However, we still need to create a list of feature columns to specify the numeric values which will be passed on to our model. To do this, we use `tf.feature_column.numeric_column()`\n",
     "\n",


### PR DESCRIPTION
fixing broken links from a non-existent guide (on feature columns) to respective API docs