### PR TITLE
Fix invalid constructor input for get_topic and create_topic in Pub/Sub publisher script

### DIFF
--- a/courses/streaming/publish/send_sensor_data.py
+++ b/courses/streaming/publish/send_sensor_data.py
@@ -89,10 +89,10 @@ if __name__ == '__main__':
    publisher = pubsub.PublisherClient()
    event_type = publisher.topic_path(args.project,TOPIC)
    try:
-      publisher.get_topic(event_type)
+      publisher.get_topic(request={"name": event_type})
       logging.info('Reusing pub/sub topic {}'.format(TOPIC))
    except:
-      publisher.create_topic(event_type)
+      publisher.create_topic(request={"name": event_type})
       logging.info('Creating pub/sub topic {}'.format(TOPIC))
 
    # notify about each line in the input file


### PR DESCRIPTION
This PR fixes a runtime TypeError in send_sensor_data.py caused by passing a raw topic name string directly into the get_topic() and create_topic() methods of the Google Cloud Pub/Sub client

Changes Made

Updated get_topic() to use the correct request parameter with a dictionary:
`publisher.get_topic(request={"name": event_type})`
Updated create_topic() similarly:
`publisher.create_topic(request={"name": event_type})`

Before Fix

```
publisher.get_topic(event_type)
publisher.create_topic(event_type)
```

Resulted in:

`TypeError: Invalid constructor input for GetTopicRequest: 'projects/...'`

After Fix

```
publisher.get_topic(request={"name": event_type})
publisher.create_topic(request={"name": event_type})
```

Testing

Successfully ran the script using an existing and non-existing topic.
Confirmed that new topics are created when absent, and reused otherwise without error.