### PR TITLE
Correct typo in Vertex AI Qwikstart self-paced lab

### DIFF
--- a/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise_long.ipynb
+++ b/self-paced-labs/vertex-ai/vertex-ai-qwikstart/lab_exercise_long.ipynb
@@ -967,7 +967,7 @@
     "\n",
     "Before you submit a custom training job, hyperparameter tuning job, or a training pipeline to Vertex AI, you need to create a Python training application or a custom container to define the training code and dependencies you want to run on Vertex AI.\n",
     "\n",
-    "**1. Use a Google Cloud prebuilt container**: if you use a Vertex AI prebuilt container, you write a Python `task.py` script or Python package to install into the container image that defines your code for training a custom model. See [Creating a Python training application for a pre-built container](https://cloud.google.com/vertex-ai/docs/training/create-python-pre-built-container) for more details on how to structure you Python code. Choose this option if a prebuilt container already contains the model training libraries you need such as `tensorflow` or `xgboost` and you are just doing ML training and prediction quickly. You can also specific additional Python dependencies to install through the `CustomTrainingJob(requirements=...` argument.\n",
+    "**1. Use a Google Cloud prebuilt container**: if you use a Vertex AI prebuilt container, you write a Python `task.py` script or Python package to install into the container image that defines your code for training a custom model. See [Creating a Python training application for a pre-built container](https://cloud.google.com/vertex-ai/docs/training/create-python-pre-built-container) for more details on how to structure you Python code. Choose this option if a prebuilt container already contains the model training libraries you need such as `tensorflow` or `xgboost` and you are just doing ML training and prediction quickly. You can also add specific additional Python dependencies to install through the `CustomTrainingJob(requirements=...` argument.\n",
     "\n",
     "**2. Use your own custom container image**: If you want to use your own custom container, you write your Python training scripts and a Dockerfile that contains instructions on your ML model code, dependencies, and execution instructions. You will build your custom container with Cloud Build, whose instructions are specified in `cloudbuild.yaml` and publish your container to your Artifact Registry. Choose this option if you want to package your ML model code with dependencies together in a container to build toward running as part of a portable and scalable [Vertex Pipelines](https://cloud.google.com/vertex-ai/docs/pipelines/introduction) workflow. "
    ]
@@ -1577,7 +1577,7 @@
     "    predefined_split_column_name=\"data_split\",\n",
     "    # the model training command line arguments defined in trainer.task.\n",
     "    args=CMD_ARGS,\n",
-    "    # Custom job WorkerPool arguments.\n", 
+    "    # Custom job WorkerPool arguments.\n",
     "    replica_count=1,\n",
     "    machine_type=\"e2-standard-4\",\n",
     "    # Provide your Tensorboard resource name to write Tensorboard logs during training.\n",


### PR DESCRIPTION
In the "Vertex AI custom ML model training workflow" section, it seems like a word was missing. I put the word "add" to make the sentence ok.

Resolves #2766