### PR TITLE
Fix: Use protobuf==3.20.3 to avoid compatibility issues with Google Cloud AI Platform

### DIFF
--- a/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/model_monitoring_for_custom_model_batch_prediction_job.ipynb
+++ b/courses/machine_learning/deepdive2/machine_learning_in_the_enterprise/labs/model_monitoring_for_custom_model_batch_prediction_job.ipynb
@@ -323,6 +323,7 @@
     "  google-cloud-core==1.7.3 \\\n",
     "  google-resumable-media==1.3.3 \\\n",
     "  tfx-bsl==1.14.0"
+    "  protobuf==3.20.3"
    ]
   },
   {
@@ -331,6 +332,7 @@
     "id": "02nrfqgSOsw2"
    },
    "source": [
+    "Restart kernel (Workbench)"
     "Check that the version of google-cloud-aiplatform is 1.51.0 or later."
    ]
   },


### PR DESCRIPTION
Fix: Use protobuf==3.20.3 to avoid compatibility issues with Google Cloud AI Platform