### PR TITLE
docs: Update seaborn usage with deprecation note (v0.14.0)

### DIFF
--- a/courses/machine_learning/deepdive2/launching_into_ml/solutions/workbench_explore_data.ipynb
+++ b/courses/machine_learning/deepdive2/launching_into_ml/solutions/workbench_explore_data.ipynb
@@ -183,7 +183,9 @@
     }
    ],
    "source": [
-    "# Copy the file using `gcloud storage cp` from Google Cloud Storage in the required directory\n",    "!gcloud storage cp gs://cloud-training/mlongcp/v3.0_MLonGC/toy_data/housing_pre-proc_toy.csv ../data/explore  "   ]
+    "# Copy the file using `gcloud storage cp` from Google Cloud Storage in the required directory\n",
+    "!gcloud storage cp gs://cloud-training/mlongcp/v3.0_MLonGC/toy_data/housing_pre-proc_toy.csv ../data/explore  "
+   ]
   },
   {
    "cell_type": "markdown",
@@ -749,7 +751,8 @@
    ],
    "source": [
     "# TODO 2a\n",
-    "# Plot a univariate distribution of observations using seaborn `distplot()` function\n",
+    "# Plot a univariate distribution of observations using seaborn `displot()`\n",
+    "# (`distplot()` is deprecated and removed in seaborn v0.14.0; use `histplot()` or `displot()`)\n",
     "sns.displot(df_USAhousing['median_house_value'])"
    ]
   },
@@ -980,9 +983,7 @@
   },
   {
    "cell_type": "markdown",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "Copyright 2023 Google Inc.  Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at\n",
     "http://www.apache.org/licenses/LICENSE-2.0\n",


### PR DESCRIPTION
→ Updates seaborn usage comments to reflect the deprecation of `distplot()` and its removal in **seaborn v0.14.0**. No functional changes are introduced.
→ **Ref:** [Seaborn distplot() documentation stating the deprecation](https://seaborn.pydata.org/generated/seaborn.distplot.html).