### PR TITLE
fix(text_classification): pin setuptools<70 and update setup cell for OCBL385 lab execution

### DIFF
--- a/courses/machine_learning/deepdive2/text_classification/labs/reusable_embeddings.ipynb
+++ b/courses/machine_learning/deepdive2/text_classification/labs/reusable_embeddings.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "7SN5USFEIIK3"
+   },
    "source": [
     "# Reusable Embeddings\n",
     "\n",
@@ -16,9 +18,17 @@
     "\n",
     "In this notebook, we will implement text models to recognize the probable source (Github, Tech-Crunch, or The New-York Times) of the titles we have in the title dataset.\n",
     "\n",
-    "First, we will load and pre-process the texts and labels so that they are suitable to be fed to sequential Keras models with first layer being TF-hub pre-trained modules. Thanks to this first layer, we won't need to tokenize and integerize the text before passing it to our models. The pre-trained layer will take care of that for us, and consume directly raw text. However, we will still have to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
+    "First, we will load and pre-process the texts and labels so that they are suitable to be fed to sequential Keras models with first layer being TF-Hub pre-trained modules. Thanks to this first layer, we won't need to tokenize and integerize the text before passing it to our models. The pre-trained layer will take care of that for us, and consume directly raw text. However, we will still have to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
     "\n",
-    "Then we will build, train and compare simple DNN models starting with different pre-trained TF-Hub layers."
+    "Then we will build, train and compare simple DNN models starting with one more pre-trained TF-Hub layers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Environment Setup\n",
+    "If you are running this notebook in an on-demand lab environment (such as Vertex AI Workbench / Qwiklabs), ensure the **Python 3 (Local)** kernel is selected. Run the first code cell below to install required packages (`setuptools<70.0.0`, `protobuf==3.20.3`, and `tensorflow==2.12.*`) before importing libraries to prevent `ModuleNotFoundError: No module named 'pkg_resources'`."
    ]
   },
   {
@@ -27,16 +37,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip install --upgrade pip\n",
+    "!pip install \"setuptools<70.0.0\"\n",
     "!pip install --upgrade \"tensorflow==2.12.*\" \"tensorflow-hub==0.12.0\" \"keras==2.12.*\"\n",
-    "!pip install protobuf==3.20.3\n",
-    "!pip install setuptools"
+    "!pip install protobuf==3.20.3"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "J1xI7nLzO8z4"
    },
    "outputs": [],
    "source": [
@@ -48,27 +59,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "e_zMItgXN00Y"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The google.cloud.bigquery extension is already loaded. To reload it, use:\n",
-      "  %reload_ext google.cloud.bigquery\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext google.cloud.bigquery"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "hBfO-t8TfK74"
+   },
    "source": [
     "Replace the variable values in the cell below:"
    ]
@@ -77,11 +81,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "3Z8P1n_zN00Y"
    },
    "outputs": [],
    "source": [
-    "PROJECT = \"cloud-training-demos\"  # Replace with your PROJECT\n",
+    "PROJECT = \"qwiklabs-gcp-00-082cafb2093a\"  # Replace with your PROJECT\n",
     "BUCKET = PROJECT \n",
     "REGION = \"us-central1\"\n",
     "\n",
@@ -91,8 +95,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9Btt0W0KN00Y"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gcloud config set project $PROJECT\n",
+    "gcloud config set compute/region $REGION"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "1mYgQcTf9w1r"
+   },
    "source": [
     "## Create a Dataset from BigQuery \n",
     "\n",
@@ -105,173 +124,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "e_bT7nB0N00a"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "127f4f32dadb442baba84f204c527933",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2438: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2452: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2466: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a557f5309ba94a0ba7bdf154e189502c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>url</th>\n",
-       "      <th>title</th>\n",
-       "      <th>score</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://blog.amigocloud.com/sub-meter-data-col...</td>\n",
-       "      <td>Entire Golf Course at Centimeter Accuracy – Fr...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>http://perspectives.mvdirona.com/2009/10/14/Re...</td>\n",
-       "      <td>Does it make sense to replace all disks with S...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://www.aclu.org/blog/national-security-te...</td>\n",
-       "      <td>ACLU-Obtained Documents Reveal Breadth of Secr...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>https://git.kernel.org/cgit/linux/kernel/git/t...</td>\n",
-       "      <td>Hurr durr I'ma sheep</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>http://bit-player.org/2015/mrs-nguyens-prestid...</td>\n",
-       "      <td>Mrs. Nguyen’s prestidigitation</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>http://parametricity.com/posts/2015-02-19-anim...</td>\n",
-       "      <td>Animating Abstractly</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>http://www.reuters.com/article/2015/02/16/us-f...</td>\n",
-       "      <td>Small farmers hold the key to seed diversity: ...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>http://digitalcommons.unl.edu/cgi/viewcontent....</td>\n",
-       "      <td>Are Political Orientations Genetically Transmi...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>http://www.psmag.com/health-and-behavior/how-t...</td>\n",
-       "      <td>How the American opiate epidemic was started b...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>http://www.bloomberg.com/news/videos/2015-02-2...</td>\n",
-       "      <td>Check Out Washio on Bloomberg West Today</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                 url  \\\n",
-       "0  https://blog.amigocloud.com/sub-meter-data-col...   \n",
-       "1  http://perspectives.mvdirona.com/2009/10/14/Re...   \n",
-       "2  https://www.aclu.org/blog/national-security-te...   \n",
-       "3  https://git.kernel.org/cgit/linux/kernel/git/t...   \n",
-       "4  http://bit-player.org/2015/mrs-nguyens-prestid...   \n",
-       "5  http://parametricity.com/posts/2015-02-19-anim...   \n",
-       "6  http://www.reuters.com/article/2015/02/16/us-f...   \n",
-       "7  http://digitalcommons.unl.edu/cgi/viewcontent....   \n",
-       "8  http://www.psmag.com/health-and-behavior/how-t...   \n",
-       "9  http://www.bloomberg.com/news/videos/2015-02-2...   \n",
-       "\n",
-       "                                               title  score  \n",
-       "0  Entire Golf Course at Centimeter Accuracy – Fr...     11  \n",
-       "1  Does it make sense to replace all disks with S...     11  \n",
-       "2  ACLU-Obtained Documents Reveal Breadth of Secr...     11  \n",
-       "3                               Hurr durr I'ma sheep     11  \n",
-       "4                     Mrs. Nguyen’s prestidigitation     11  \n",
-       "5                               Animating Abstractly     11  \n",
-       "6  Small farmers hold the key to seed diversity: ...     11  \n",
-       "7  Are Political Orientations Genetically Transmi...     11  \n",
-       "8  How the American opiate epidemic was started b...     11  \n",
-       "9           Check Out Washio on Bloomberg West Today     11  "
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%bigquery --project $PROJECT --use_rest_api\n",
+    "%%bigquery --project $PROJECT\n",
+    "\n",
     "SELECT\n",
     "    url, title, score\n",
     "FROM\n",
@@ -285,7 +143,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "P5yH9GvKAB-p"
+   },
    "source": [
     "Let's do some regular expression parsing in BigQuery to get the source of the newspaper article from the URL. For example, if the url is http://mobile.nytimes.com/...., I want to be left with <i>nytimes</i>"
    ]
@@ -294,159 +154,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "y-cI7vE0N00a"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b136e3f911e24562a0ba523e9babef00",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2438: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2452: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2466: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f013b318450c4b5ca0adc81418ca93cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>source</th>\n",
-       "      <th>num_articles</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>github</td>\n",
-       "      <td>183581</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>medium</td>\n",
-       "      <td>134373</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>youtube</td>\n",
-       "      <td>129422</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>nytimes</td>\n",
-       "      <td>84901</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>blogspot</td>\n",
-       "      <td>62136</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>itworld</td>\n",
-       "      <td>3163</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>nextplatform</td>\n",
-       "      <td>3155</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>atlasobscura</td>\n",
-       "      <td>3078</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>anandtech</td>\n",
-       "      <td>3015</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>99</th>\n",
-       "      <td>oreilly</td>\n",
-       "      <td>2988</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>100 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "          source  num_articles\n",
-       "0         github        183581\n",
-       "1         medium        134373\n",
-       "2        youtube        129422\n",
-       "3        nytimes         84901\n",
-       "4       blogspot         62136\n",
-       "..           ...           ...\n",
-       "95       itworld          3163\n",
-       "96  nextplatform          3155\n",
-       "97  atlasobscura          3078\n",
-       "98     anandtech          3015\n",
-       "99       oreilly          2988\n",
-       "\n",
-       "[100 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "%%bigquery --project $PROJECT --use_rest_api\n",
+    "%%bigquery --project $PROJECT\n",
     "\n",
     "SELECT\n",
     "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[SAFE_OFFSET(1)] AS source,\n",
@@ -459,48 +171,25 @@
     "GROUP BY\n",
     "    source\n",
     "ORDER BY num_articles DESC\n",
-    "LIMIT 100"
+    "  LIMIT 10"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "eJjI8nJcAAu1"
+   },
    "source": [
     "Now that we have good parsing of the URL to get the source, let's put together a dataset of source and titles. This will be our labeled dataset for machine learning."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "jVzN1EgzN00a"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "SELECT \n",
-      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
-      "    source\n",
-      "FROM\n",
-      "  (\n",
-      "SELECT\n",
-      "    title,\n",
-      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source\n",
-      "    \n",
-      "FROM\n",
-      "    `bigquery-public-data.hacker_news.full`\n",
-      "WHERE\n",
-      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
-      "    AND LENGTH(title) > 10\n",
-      ")\n",
-      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "regex = '.*://(.[^/]+)/'\n",
     "\n",
@@ -508,7 +197,7 @@
     "sub_query = \"\"\"\n",
     "SELECT\n",
     "    title,\n",
-    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '{0}'), '.'))[safe_offset (1)] AS source\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '{0}'), '.'))[SAFE_OFFSET(1)] AS source\n",
     "    \n",
     "FROM\n",
     "    `bigquery-public-data.hacker_news.full`\n",
@@ -532,7 +221,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "RLeT3m3N9w1r"
+   },
    "source": [
     "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset). AutoML however figures out on its own how to create these splits, so we won't need to do that here. \n",
     "\n"
@@ -540,92 +231,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "8PqC8QEzN00b"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2438: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2452: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2466: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>title</th>\n",
-       "      <th>source</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>the new face of committing in github for mac</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>a git notifier for mac os x written in go</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>show hn  hue-wheel for html5 browsers</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>send ripples from salesforce</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>grind polishes go programs</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                          title  source\n",
-       "0  the new face of committing in github for mac  github\n",
-       "1     a git notifier for mac os x written in go  github\n",
-       "2         show hn  hue-wheel for html5 browsers  github\n",
-       "3                  send ripples from salesforce  github\n",
-       "4                    grind polishes go programs  github"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bq = bigquery.Client(project=PROJECT)\n",
     "title_dataset = bq.query(query).to_dataframe()\n",
@@ -634,7 +244,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "f5fP2k_C9w1s"
+   },
    "source": [
     "AutoML for text classification requires that\n",
     "* the dataset be in csv form with \n",
@@ -646,1109 +258,486 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "jGkE1B00N00b"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The full dataset contains 328310 titles\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(\"The full dataset contains {n} titles\".format(n=len(title_dataset)))"
+    "print(\"The full dataset has %d titles\" % len(title_dataset))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "B3eA2k3C9w1s"
+   },
    "source": [
     "Let's make sure we have roughly the same number of labels for each of our three labels:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "9KlA8W0LN00b"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        183581\n",
-       "nytimes        84901\n",
-       "techcrunch     59828\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "title_dataset.source.value_counts()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "t7eK3F8G9w1s"
+   },
    "source": [
-    "Finally we will save our data, which is currently in-memory, to disk.\n",
-    "\n",
-    "We will create a csv file containing the full dataset and another containing only 1000 articles for development.\n",
-    "\n",
-    "**Note:** It may take a long time to train AutoML on the full dataset, so we recommend to use the sample dataset for the purpose of learning the tool. \n"
+    "Finally, let's save what we have to our Elasticsearch instance."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "0DkO4p8ON00b"
    },
    "outputs": [],
    "source": [
     "DATADIR = './data/'\n",
     "\n",
     "if not os.path.exists(DATADIR):\n",
-    "    os.makedirs(DATADIR)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "    os.makedirs(DATADIR)\n",
+    "    \n",
     "FULL_DATASET_NAME = 'titles_full.csv'\n",
     "FULL_DATASET_PATH = os.path.join(DATADIR, FULL_DATASET_NAME)\n",
     "\n",
     "# Let's shuffle the data before writing it to disk.\n",
-    "title_dataset = title_dataset.sample(n=len(title_dataset))\n",
+    "title_dataset = title_dataset.sample(n=len(title_dataset)).reset_index(drop=True)\n",
     "\n",
-    "title_dataset.to_csv(\n",
-    "    FULL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
+    "title_dataset.to_csv(FULL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's sample 1000 articles from the full dataset and make sure we have enough examples for each label in our sample dataset (see [here](https://cloud.google.com/natural-language/automl/docs/beginners-guide) for further details on how to prepare data for AutoML)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
    "metadata": {
-    "tags": []
+    "id": "w3vU4d1r9w1t"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        550\n",
-       "nytimes       269\n",
-       "techcrunch    181\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "sample_title_dataset = title_dataset.sample(n=1000)\n",
-    "sample_title_dataset.source.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's write the sample datatset to disk."
+    "Now let's check the first few lines of our CSV file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "f5kC8V0tN00c"
    },
    "outputs": [],
    "source": [
-    "SAMPLE_DATASET_NAME = 'titles_sample.csv'\n",
-    "SAMPLE_DATASET_PATH = os.path.join(DATADIR, SAMPLE_DATASET_NAME)\n",
-    "\n",
-    "sample_title_dataset.to_csv(\n",
-    "    SAMPLE_DATASET_PATH, header=False, index=False, encoding='utf-8')"
+    "!head -n 5 {FULL_DATASET_PATH}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "d0kN6g9vN00c"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-16 09:42:15.362055: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2025-07-16 09:42:21.637920: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/lib/x86_64-linux-gnu/:/opt/conda/lib\n",
-      "2025-07-16 09:42:21.638164: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/lib/x86_64-linux-gnu/:/opt/conda/lib\n",
-      "2025-07-16 09:42:21.638176: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.11.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import datetime\n",
-    "import os\n",
-    "import shutil\n",
+    "gcs_path = f\"gs://{BUCKET}/{FULL_DATASET_NAME}\"\n",
+    "!gsutil cp {FULL_DATASET_PATH} {gcs_path}\n",
+    "print(f\"Copied {FULL_DATASET_PATH} to {gcs_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8PqC8QEzN00c"
+   },
+   "source": [
+    "## Sampling and spliting the dataset\n",
     "\n",
-    "import pandas as pd\n",
+    "Before training, we need to split our dataset into train and evaluation splits.\n",
+    "Let's create a custom splitting logic using pandas, where:\n",
+    "- 80% of the data goes to `train` split\n",
+    "- 20% goes to `eval` split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "e_zMItgXN00c"
+   },
+   "outputs": [],
+   "source": [
+    "# Splitting function\n",
+    "def split_dataset(df, train_ratio=0.8):\n",
+    "    # Shuffle dataframe\n",
+    "    df_shuffled = df.sample(frac=1, random_state=42).reset_index(drop=True)\n",
+    "    \n",
+    "    split_idx = int(len(df_shuffled) * train_ratio)\n",
+    "    \n",
+    "    train_df = df_shuffled.iloc[:split_idx]\n",
+    "    eval_df = df_shuffled.iloc[split_idx:]\n",
+    "    \n",
+    "    return train_df, eval_df\n",
+    "\n",
+    "train_dataset, eval_dataset = split_dataset(title_dataset)\n",
+    "\n",
+    "print(f\"Train dataset size: {len(train_dataset)}\")\n",
+    "print(f\"Eval dataset size: {len(eval_dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3Z8P1n_zN00c"
+   },
+   "source": [
+    "Let's save the splits to disk so we can use them later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9Btt0W0KN00d"
+   },
+   "outputs": [],
+   "source": [
+    "TRAIN_DATASET_NAME = 'titles_train.csv'\n",
+    "TRAIN_DATASET_PATH = os.path.join(DATADIR, TRAIN_DATASET_NAME)\n",
+    "train_dataset.to_csv(TRAIN_DATASET_PATH, header=False, index=False, encoding='utf-8')\n",
+    "\n",
+    "EVAL_DATASET_NAME = 'titles_eval.csv'\n",
+    "EVAL_DATASET_PATH = os.path.join(DATADIR, EVAL_DATASET_NAME)\n",
+    "eval_dataset.to_csv(EVAL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e_bT7nB0N00d"
+   },
+   "source": [
+    "Let's verify our CSV files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "y-cI7vE0N00d"
+   },
+   "outputs": [],
+   "source": [
+    "!head -n 3 {TRAIN_DATASET_PATH}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jVzN1EgzN00d"
+   },
+   "outputs": [],
+   "source": [
+    "!head -n 3 {EVAL_DATASET_PATH}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jGkE1B00N00e"
+   },
+   "source": [
+    "## Data Loading with `tf.data.Dataset`\n",
+    "\n",
+    "Now that we have our CSV files (`titles_train.csv` and `titles_eval.csv`), we need to load them into TensorFlow. We will use `tf.data.experimental.make_csv_dataset`, which is efficient for streaming data from disk directly into a neural network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9KlA8W0LN00e"
+   },
+   "outputs": [],
+   "source": [
     "import tensorflow as tf\n",
-    "from tensorflow.keras.callbacks import TensorBoard, EarlyStopping\n",
-    "from tensorflow_hub import KerasLayer\n",
-    "from tensorflow.keras.layers import Dense\n",
-    "from tensorflow.keras.models import Sequential\n",
-    "from tensorflow.keras.preprocessing.text import Tokenizer\n",
-    "from tensorflow.keras.utils import to_categorical\n",
     "\n",
+    "BATCH_SIZE = 64\n",
     "\n",
-    "print(tf.__version__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's start by specifying where the information about the trained models will be saved as well as where our dataset is located:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_DIR = \"./text_models\"\n",
-    "DATA_DIR = \"./data\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Loading the dataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As in the previous labs, our dataset consists of titles of articles along with the label indicating from which source these articles have been taken from (GitHub, Tech-Crunch, or the New-York Times):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "titles_full.csv  titles_sample.csv\n"
-     ]
-    }
-   ],
-   "source": [
-    "ls ./data/"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>title</th>\n",
-       "      <th>source</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>purple flares got you down  camhoodie case for...</td>\n",
-       "      <td>techcrunch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>stacey 2.2.2 - html5boilerplate edition</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>an argument against cloud-based applications</td>\n",
-       "      <td>techcrunch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>show hn  list and selectively download files f...</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>the type of practice matters more than hours</td>\n",
-       "      <td>nytimes</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                               title      source\n",
-       "0  purple flares got you down  camhoodie case for...  techcrunch\n",
-       "1            stacey 2.2.2 - html5boilerplate edition      github\n",
-       "2       an argument against cloud-based applications  techcrunch\n",
-       "3  show hn  list and selectively download files f...      github\n",
-       "4       the type of practice matters more than hours     nytimes"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "DATASET_NAME = \"titles_full.csv\"\n",
-    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
-    "COLUMNS = ['title', 'source']\n",
+    "# Column names and defaults since we saved without headers\n",
+    "COLUMN_NAMES = ['title', 'source']\n",
+    "COLUMN_DEFAULTS = [[''], ['']]\n",
     "\n",
-    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
-    "titles_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's look again at the number of examples per label to make sure we have a well-balanced dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        183581\n",
-       "nytimes        84901\n",
-       "techcrunch     59828\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "titles_df.source.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Preparing the labels"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this lab, we will use pre-trained [TF-Hub embeddings modules for english](https://tfhub.dev/s?q=tf2%20embeddings%20text%20english) for the first layer of our models. One immediate\n",
-    "advantage of doing so is that the TF-Hub embedding module will take care for us of processing the raw text. \n",
-    "This also means that our model will be able to consume text directly instead of sequences of integers representing the words.\n",
-    "\n",
-    "However, as before, we still need to preprocess the labels into one-hot-encoded vectors:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "CLASSES = {\n",
-    "    'github': 0,\n",
-    "    'nytimes': 1,\n",
-    "    'techcrunch': 2\n",
-    "}\n",
-    "N_CLASSES = len(CLASSES)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def encode_labels(sources):\n",
-    "    classes = [CLASSES[source] for source in sources]\n",
-    "    one_hots = to_categorical(classes, num_classes=N_CLASSES)\n",
-    "    return one_hots"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0., 0., 1.],\n",
-       "       [1., 0., 0.],\n",
-       "       [0., 0., 1.],\n",
-       "       [1., 0., 0.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "encode_labels(titles_df.source[:4])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Preparing the train/test splits"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's split our data into train and test splits:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "N_TRAIN = int(len(titles_df) * 0.95)\n",
-    "\n",
-    "titles_train, sources_train = (\n",
-    "    titles_df.title[:N_TRAIN], titles_df.source[:N_TRAIN])\n",
-    "\n",
-    "titles_valid, sources_valid = (\n",
-    "    titles_df.title[N_TRAIN:], titles_df.source[N_TRAIN:])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To be on the safe side, we verify that the train and test splits\n",
-    "have roughly the same number of examples per class.\n",
-    "\n",
-    "Since it is the case, accuracy will be a good metric to use to measure\n",
-    "the performance of our models."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        174432\n",
-       "nytimes        80605\n",
-       "techcrunch     56857\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sources_train.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        9149\n",
-       "nytimes       4296\n",
-       "techcrunch    2971\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sources_valid.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's create the features and labels we will feed our models with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "X_train, Y_train = titles_train.values, encode_labels(sources_train)\n",
-    "X_valid, Y_valid = titles_valid.values, encode_labels(sources_valid)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array(['purple flares got you down  camhoodie case for iphone 5 can help',\n",
-       "       'stacey 2.2.2 - html5boilerplate edition',\n",
-       "       'an argument against cloud-based applications'], dtype=object)"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_train[:3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0., 0., 1.],\n",
-       "       [1., 0., 0.],\n",
-       "       [0., 0., 1.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Y_train[:3]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## NNLM Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We will first try a word embedding pre-trained using a [Neural Probabilistic Language Model](http://www.jmlr.org/papers/volume3/bengio03a/bengio03a.pdf). TF-Hub has a 50-dimensional one called \n",
-    "[nnlm-en-dim50-with-normalization](https://tfhub.dev/google/tf2-preview/nnlm-en-dim50/1), which also\n",
-    "normalizes the vectors produced. \n",
-    "\n",
-    "### Lab Task 1a: Import NNLM TF Hub module into `KerasLayer`\n",
-    "\n",
-    "Once loaded from its url, the TF-hub module can be used as a normal Keras layer in a sequential or functional model. Since we have enough data to fine-tune the parameters of the pre-trained embedding itself, we will set `trainable=True` in the `KerasLayer` that loads the pre-trained embedding:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-16 09:54:19.348113: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/lib/x86_64-linux-gnu/:/opt/conda/lib\n",
-      "2025-07-16 09:54:19.351379: W tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.cc:265] failed call to cuInit: UNKNOWN ERROR (303)\n",
-      "2025-07-16 09:54:19.353872: I tensorflow/compiler/xla/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (cloudlearningservices): /proc/driver/nvidia/version does not exist\n",
-      "2025-07-16 09:54:19.358256: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2025-07-16 09:54:19.729375: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n"
-     ]
-    }
-   ],
-   "source": [
-    "NNLM = \"https://tfhub.dev/google/nnlm-en-dim50/2\"\n",
-    "\n",
-    "nnlm_module = KerasLayer(# TODO)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that this TF-Hub embedding produces a single 50-dimensional vector when passed a sentence:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Lab Task 1b: Use module to encode a sentence string"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<tf.Tensor: shape=(1, 50), dtype=float32, numpy=\n",
-       "array([[ 0.19331802,  0.05893906,  0.15330684,  0.2505918 ,  0.19369544,\n",
-       "         0.03578748,  0.07387847, -0.10962156, -0.11377034,  0.07172022,\n",
-       "         0.12458669, -0.02289705, -0.18177685, -0.07084437, -0.00225849,\n",
-       "        -0.36875236,  0.05772953, -0.14222091,  0.08765972, -0.14068899,\n",
-       "        -0.07005888, -0.20634466,  0.07220475,  0.04258814,  0.0955702 ,\n",
-       "         0.19424029, -0.42492998, -0.00706906, -0.02095   , -0.05055764,\n",
-       "        -0.18988201, -0.02841404,  0.13222624, -0.01459922, -0.31255388,\n",
-       "        -0.09577855,  0.05469003, -0.13858607,  0.01141668, -0.12352604,\n",
-       "        -0.07250367, -0.11605677, -0.06976165,  0.14313601, -0.15183711,\n",
-       "        -0.06836402,  0.03054246, -0.13259597, -0.14599673,  0.05094011]],\n",
-       "      dtype=float32)>"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "nnlm_module(tf.constant([# TODO]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Swivel Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then we will try a word embedding obtained using [Swivel](https://arxiv.org/abs/1602.02215), an algorithm that essentially factorizes word co-occurrence matrices to create the words embeddings. \n",
-    "TF-Hub hosts the pretrained [gnews-swivel-20dim-with-oov](https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1) 20-dimensional Swivel module.\n",
-    "\n",
-    "### Lab Task 1c: Import Swivel TF Hub module into `KerasLayer`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "SWIVEL = \"https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1\"\n",
-    "swivel_module = KerasLayer(# TODO)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similarly as the previous pre-trained embedding, it outputs a single vector when passed a sentence:\n",
-    "\n",
-    "### Lab Task 1d: Use module to encode a sentence string"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<tf.Tensor: shape=(1, 20), dtype=float32, numpy=\n",
-       "array([[ 0.9967701 , -0.3100155 ,  0.5889897 , -0.16765082, -0.6171738 ,\n",
-       "        -1.1586996 , -0.8619045 ,  0.7281645 ,  0.32575002,  0.4754492 ,\n",
-       "        -0.9272241 ,  0.41090095, -0.75389475, -0.31525993, -1.8918804 ,\n",
-       "         0.6423996 ,  0.6801622 , -0.1335669 , -1.0017993 , -0.11908641]],\n",
-       "      dtype=float32)>"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "swivel_module(tf.constant([# TODO]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Building the models"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's write a function that \n",
-    "\n",
-    "* takes as input an instance of a `KerasLayer` (i.e. the `swivel_module` or the `nnlm_module` we constructed above) as well as the name of the model (say `swivel` or `nnlm`)\n",
-    "* returns a compiled Keras sequential model starting with this pre-trained TF-hub layer, adding one or more dense relu layers to it, and ending with a softmax layer giving the probability of each of the classes:\n",
-    "\n",
-    "### Lab Task 2: Incorporate a pre-trained TF Hub module as first layer of Keras Sequential Model"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def build_model(hub_module, name):\n",
-    "    model = Sequential([\n",
-    "        # TODO \n",
-    "        Dense(16, activation='relu'),\n",
-    "        Dense(N_CLASSES, activation='softmax')\n",
-    "    ], name=name)\n",
-    "\n",
-    "    model.compile(\n",
-    "        optimizer='adam',\n",
-    "        loss='categorical_crossentropy',\n",
-    "        metrics=['accuracy']\n",
-    "    )\n",
-    "    return model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's also wrap the training code into a `train_and_evaluate` function that \n",
-    "* takes as input the training and validation data, as well as the compiled model itself, and the `batch_size`\n",
-    "* trains the compiled model for 100 epochs at most, and does early-stopping when the validation loss is no longer decreasing\n",
-    "* returns an `history` object, which will help us to plot the learning curves"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def train_and_evaluate(train_data, val_data, model, batch_size=5000):\n",
-    "    X_train, Y_train = train_data\n",
-    "\n",
-    "    tf.random.set_seed(33)\n",
-    "\n",
-    "    model_dir = os.path.join(MODEL_DIR, model.name)\n",
-    "    if tf.io.gfile.exists(model_dir):\n",
-    "        tf.io.gfile.rmtree(model_dir)\n",
-    "\n",
-    "    history = model.fit(\n",
-    "        X_train, Y_train,\n",
-    "        epochs=10,\n",
+    "def load_dataset(file_path, batch_size=BATCH_SIZE, shuffle=True):\n",
+    "    return tf.data.experimental.make_csv_dataset(\n",
+    "        file_pattern=file_path,\n",
     "        batch_size=batch_size,\n",
-    "        validation_data=val_data,\n",
-    "        callbacks=TensorBoard(model_dir),\n",
+    "        column_names=COLUMN_NAMES,\n",
+    "        column_defaults=COLUMN_DEFAULTS,\n",
+    "        label_name='source',\n",
+    "        shuffle=shuffle,\n",
+    "        num_epochs=1\n",
     "    )\n",
-    "    return history"
+    "\n",
+    "train_ds = load_dataset(TRAIN_DATASET_PATH, shuffle=True)\n",
+    "eval_ds = load_dataset(EVAL_DATASET_PATH, shuffle=False)\n",
+    "\n",
+    "# Inspect one batch of data\n",
+    "for x, y in train_ds.take(1):\n",
+    "    print(\"Sample titles:\", x['title'][:3].numpy())\n",
+    "    print(\"Sample labels:\", y[:3].numpy())"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "0DkO4p8ON00e"
+   },
    "source": [
-    "## Training NNLM"
+    "## One-Hot Encoding Target Labels\n",
+    "\n",
+    "Our labels (`source`) are strings (`'github'`, `'nytimes'`, `'techcrunch'`). Neural networks expect numeric inputs and targets, so we map these strings to integer indices (`0`, `1`, `2`) and then convert those integers into one-hot vectors (`[1, 0, 0]`, `[0, 1, 0]`, `[0, 0, 1]`)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "f5kC8V0tN00f"
    },
    "outputs": [],
    "source": [
-    "data = (X_train, Y_train)\n",
-    "val_data = (X_valid, Y_valid)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-16 10:03:31.331673: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n",
-      "2025-07-16 10:03:31.564477: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n",
-      "2025-07-16 10:03:32.473034: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n",
-      "2025-07-16 10:03:32.485175: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "63/63 [==============================] - 43s 661ms/step - loss: 0.8547 - accuracy: 0.6257 - val_loss: 0.6109 - val_accuracy: 0.7477\n",
-      "Epoch 2/10\n",
-      "63/63 [==============================] - 38s 599ms/step - loss: 0.4683 - accuracy: 0.8199 - val_loss: 0.3699 - val_accuracy: 0.8649\n",
-      "Epoch 3/10\n",
-      "63/63 [==============================] - 37s 594ms/step - loss: 0.3084 - accuracy: 0.8865 - val_loss: 0.2958 - val_accuracy: 0.8857\n",
-      "Epoch 4/10\n",
-      "63/63 [==============================] - 78s 1s/step - loss: 0.2526 - accuracy: 0.9048 - val_loss: 0.2732 - val_accuracy: 0.8940\n",
-      "Epoch 5/10\n",
-      "63/63 [==============================] - 75s 1s/step - loss: 0.2255 - accuracy: 0.9152 - val_loss: 0.2651 - val_accuracy: 0.8967\n",
-      "Epoch 6/10\n",
-      "63/63 [==============================] - 81s 1s/step - loss: 0.2083 - accuracy: 0.9220 - val_loss: 0.2626 - val_accuracy: 0.8977\n",
-      "Epoch 7/10\n",
-      "63/63 [==============================] - 81s 1s/step - loss: 0.1958 - accuracy: 0.9273 - val_loss: 0.2633 - val_accuracy: 0.8977\n",
-      "Epoch 8/10\n",
-      "63/63 [==============================] - 74s 1s/step - loss: 0.1864 - accuracy: 0.9310 - val_loss: 0.2654 - val_accuracy: 0.8980\n",
-      "Epoch 9/10\n",
-      "63/63 [==============================] - 84s 1s/step - loss: 0.1786 - accuracy: 0.9339 - val_loss: 0.2686 - val_accuracy: 0.8973\n",
-      "Epoch 10/10\n",
-      "63/63 [==============================] - 81s 1s/step - loss: 0.1723 - accuracy: 0.9368 - val_loss: 0.2728 - val_accuracy: 0.8961\n"
-     ]
-    }
-   ],
-   "source": [
-    "nnlm_model = build_model(nnlm_module, 'nnlm')\n",
-    "nnlm_history = train_and_evaluate(data, val_data, nnlm_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Axes: >"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASvhJREFUeJzt3Xl8VPW9//HXzCSTSUL2QMISCLIjq2yFqNUapS5U6lKsWBALtly0atr7K2jFVqtoa73c60alotal0lq3VoraKFU2gyAIsu9hSUISsi+TzMzvj0kmCSSQSWbmJJn38/E4j5ycnPl+v0OUefM93/M5JpfL5UJERETEIGajByAiIiLBTWFEREREDKUwIiIiIoZSGBERERFDKYyIiIiIoRRGRERExFAKIyIiImIohRERERExVIjRA2gNp9PJiRMniIqKwmQyGT0cERERaQWXy0VpaSm9evXCbG55/qNThJETJ06QkpJi9DBERESkDbKzs+nTp0+LP+8UYSQqKgpwv5no6GiDRyMiIiKtUVJSQkpKiudzvCWdIozUX5qJjo5WGBEREelkzrfEQgtYRURExFAKIyIiImIohRERERExVKdYMyIiIsHN5XJRW1uLw+EweijSiMViISQkpN1lNxRGRESkQ7Pb7Zw8eZKKigqjhyLNiIiIoGfPnlit1ja3oTAiIiIdltPp5NChQ1gsFnr16oXValXxyw7C5XJht9s5deoUhw4dYtCgQecsbHYuCiMiItJh2e12nE4nKSkpREREGD0cOUN4eDihoaEcOXIEu92OzWZrUztawCoiIh1eW//FLf7ni9+NfrsiIiJiKIURERERMZTCiIiIiB9cdtll3HvvvUYPo1NQGBERERFDBW0Ycblc/CXrKAte38Kp0mqjhyMiIhK0gjaMmEwmXtt4hA+2n2T9gXyjhyMiIq3kcrmosNcasrlcrjaN+fTp08yaNYu4uDgiIiK4+uqr2bdvn+fnR44cYdq0acTFxREZGcmFF17IqlWrPK+dOXMm3bt3Jzw8nEGDBvHSSy/55M+yowjqOiNpAxP55kQJ6/cXcP2Y3kYPR0REWqGyxsHwxR8a0vfOh6cSYfX+o/P2229n3759vP/++0RHR/PLX/6Sa665hp07dxIaGsqCBQuw2+189tlnREZGsnPnTrp16wbAgw8+yM6dO/nXv/5FYmIi+/fvp7Ky0tdvzVBBH0Ze+Owga/fn43K5VNVPRER8rj6ErFu3jilTpgDw+uuvk5KSwrvvvsvNN9/M0aNHufHGGxk5ciQAF1xwgef1R48eZezYsYwfPx6A1NTUgL8HfwvqMDIhNY5Qi4njRZUcLaygX0Kk0UMSEZHzCA+1sPPhqYb17a1du3YREhLCpEmTPMcSEhIYMmQIu3btAuBnP/sZ8+fP56OPPiI9PZ0bb7yRUaNGATB//nxuvPFGtmzZwlVXXcX06dM9oaarCNo1IwAR1hAu6hsHwNr9WjciItIZmEwmIqwhhmz+mkGfO3cuBw8e5Ec/+hHbt29n/PjxPP300wBcffXVHDlyhPvuu48TJ05wxRVX8Itf/MIv4zBKUIcRcF+qAVi/v8DgkYiISFc0bNgwamtr+eKLLzzHCgoK2LNnD8OHD/ccS0lJ4ac//Slvv/02P//5z1m+fLnnZ927d2f27Nm89tprLF26lBdeeCGg78HfFEYGJgCw/kA+TmfbVkmLiIi0ZNCgQVx//fXMmzePtWvXsm3bNm677TZ69+7N9ddfD8C9997Lhx9+yKFDh9iyZQuffvopw4YNA2Dx4sW899577N+/n2+++YZ//vOfnp91FUEfRkb1iaVbWAinK2rYebLE6OGIiEgX9NJLLzFu3Diuu+46Jk+ejMvlYtWqVYSGhgLgcDhYsGABw4YN47vf/S6DBw/mueeeA8BqtbJo0SJGjRrFpZdeisVi4c033zTy7ficydXWm6YDqKSkhJiYGIqLi4mOjvZ5+z9+eROZu/O4/5qh3HnpAJ+3LyIibVNVVcWhQ4fo379/mx9PL/51rt9Raz+/g35mBBrWjazVuhEREZGAUxihIYxsOlRIda3D4NGIiIgEF4URYHBSNxK7hVFZ4+Cro0VGD0dERCSoKIzgvmfdc1eN6o2IiIgElMJInbQB9etGFEZEREQCSWGkTtogdxjZdqyY0qoag0cjIiISPBRG6vSODSc1IQKH00XWoUKjhyMiIhI0FEYaabjFV5dqREREAkVhpBE9p0ZERCTwFEYamXxBAiYT7MktJa+0yujhiIhIEEtNTWXp0qWtOtdkMvHuu+/6dTz+pDDSSFyklQt7ucvVbjig2REREZFAUBg5g+cW331aNyIiIhIICiNn8KwbOVBAJ3iGoIhI8HG5wF5uzNbKz4UXXniBXr164XQ6mxy//vrrueOOOzhw4ADXX389SUlJdOvWjQkTJvDvf//bZ39E27dv5zvf+Q7h4eEkJCRw5513UlZW5vn5mjVrmDhxIpGRkcTGxpKWlsaRI0cA2LZtG5dffjlRUVFER0czbtw4vvzyS5+NrTkhfm29E5qQGo/VYuZ4USVHCipITYw0ekgiItJYTQU81suYvu8/Adbzfy7cfPPN3H333Xz66adcccUVABQWFrJ69WpWrVpFWVkZ11xzDY8++ihhYWH8+c9/Ztq0aezZs4e+ffu2a4jl5eVMnTqVyZMns2nTJvLy8pg7dy533XUXL7/8MrW1tUyfPp158+bxl7/8BbvdTlZWFiaTCYCZM2cyduxYnn/+eSwWC1u3biU0NLRdYzqfNs2MPPvss6SmpmKz2Zg0aRJZWVnnPH/p0qUMGTKE8PBwUlJSuO+++6iq6pgLRMOtFi7qFwvoFl8REWmbuLg4rr76at544w3PsbfeeovExEQuv/xyRo8ezU9+8hNGjBjBoEGDeOSRRxgwYADvv/9+u/t+4403qKqq4s9//jMjRozgO9/5Ds888wyvvvoqubm5lJSUUFxczHXXXceAAQMYNmwYs2fP9oSgo0ePkp6eztChQxk0aBA333wzo0ePbve4zsXrmZGVK1eSkZHBsmXLmDRpEkuXLmXq1Kns2bOHHj16nHX+G2+8wcKFC1mxYgVTpkxh79693H777ZhMJp566imfvAlfSxuQyMaDhaw/kM9t3+pn9HBERKSx0Aj3DIVRfbfSzJkzmTdvHs899xxhYWG8/vrr3HLLLZjNZsrKyvj1r3/NBx98wMmTJ6mtraWyspKjR4+2e4i7du1i9OjRREY2zOCkpaXhdDrZs2cPl156KbfffjtTp07lyiuvJD09nR/84Af07NkTgIyMDObOncurr75Keno6N998MwMGDGj3uM7F65mRp556innz5jFnzhyGDx/OsmXLiIiIYMWKFc2ev379etLS0rj11ltJTU3lqquu4oc//OF5Z1OMVF8afv2BApxOrRsREelQTCb3pRIjtrpLGa0xbdo0XC4XH3zwAdnZ2Xz++efMnDkTgF/84he88847PPbYY3z++eds3bqVkSNHYrfb/fWn1sRLL73Ehg0bmDJlCitXrmTw4MFs3LgRgF//+td88803XHvttXzyyScMHz6cd955x6/j8SqM2O12Nm/eTHp6ekMDZjPp6els2LCh2ddMmTKFzZs3e8LHwYMHWbVqFddcc02L/VRXV1NSUtJkC6RRvWOICguhqKKGnScD27eIiHQNNpuNG264gddff52//OUvDBkyhIsuugiAdevWcfvtt/P973+fkSNHkpyczOHDh33S77Bhw9i2bRvl5eWeY+vWrcNsNjNkyBDPsbFjx7Jo0SLWr1/PiBEjmlxSGjx4MPfddx8fffQRN9xwAy+99JJPxtYSr8JIfn4+DoeDpKSkJseTkpLIyclp9jW33norDz/8MBdffDGhoaEMGDCAyy67jPvvv7/FfpYsWUJMTIxnS0lJ8WaY7RZiMTPpgnhA60ZERKTtZs6cyQcffMCKFSs8syIAgwYN4u2332br1q1s27aNW2+99aw7b9rTp81mY/bs2ezYsYNPP/2Uu+++mx/96EckJSVx6NAhFi1axIYNGzhy5AgfffQR+/btY9iwYVRWVnLXXXexZs0ajhw5wrp169i0aRPDhg3zydha4vdbe9esWcNjjz3Gc889x5YtW3j77bf54IMPeOSRR1p8zaJFiyguLvZs2dnZ/h7mWepv8V2nMCIiIm30ne98h/j4ePbs2cOtt97qOf7UU08RFxfHlClTmDZtGlOnTvXMmrRXREQEH374IYWFhUyYMIGbbrqJK664gmeeecbz8927d3PjjTcyePBg7rzzThYsWMBPfvITLBYLBQUFzJo1i8GDB/ODH/yAq6++mt/85jc+GVtLTC4vimnY7XYiIiJ46623mD59uuf47NmzKSoq4r333jvrNZdccgnf+ta3+P3vf+859tprr3nueTabz5+HSkpKiImJobi4mOjo6NYOt1325pZy1f98hi3UzLaHriIsxBKQfkVEpEFVVRWHDh2if//+2Gw2o4cjzTjX76i1n99ezYxYrVbGjRtHZmam55jT6SQzM5PJkyc3+5qKioqzAofF4v5g78hFxQb16Eb3qDCqapxsOVJk9HBERES6LK8v02RkZLB8+XJeeeUVdu3axfz58ykvL2fOnDkAzJo1i0WLFnnOnzZtGs8//zxvvvkmhw4d4uOPP+bBBx9k2rRpnlDSEZlMJtIGJACw/oAu1YiIiDFef/11unXr1ux24YUXGj08n/C6zsiMGTM4deoUixcvJicnhzFjxrB69WrPotajR482mQn51a9+hclk4le/+hXHjx+ne/fuTJs2jUcffdR378JP0gYm8u7WE6zdn8/Prxpy/heIiIj42Pe+9z0mTZrU7M/8XRk1ULxaM2IUI9aMAJwoqmTK459gMZv4avGVRNu6xi9dRKSz0JqRji/ga0aCTa/YcPonRuJwuvjiYKHRwxERCVqd4N/NQcsXvxuFkfNIG+heN6JbfEVEAq/+MkRFRYXBI5GW1P9u2nPJSE/tPY+0AYm8tvGowoiIiAEsFguxsbHk5eUB7hoZJi9Ksov/uFwuKioqyMvLIzY2tl03pSiMnMfkAQmYTLAvr4y8kip6ROuapYhIICUnJwN4Aol0LLGxsZ7fUVspjJxHbISVEb1i2H68mPUHCpg+trfRQxIRCSomk4mePXvSo0cPampqjB6ONBIaGuqTMh0KI62QNjCR7ceLWbs/X2FERMQgFoulQ9enkrbTAtZWqF/Eun5/vlZ0i4iI+JjCSCuM7xeP1WLmRHEVh/LLz/8CERERaTWFkVYIt1oY1y8OgHUHCgwejYiISNeiMNJKnnoj+3SLr4iIiC8pjLRS2sBEADYcLMDh1LoRERERX1EYaaWRvWOICguhuLKGnSdKjB6OiIhIl6Ew0kohFjPfGuC+VLNW1VhFRER8RmHEC2l1YWT9AYURERERX1EY8UL9upGsQ4VU1TgMHo2IiEjXoDDihYE9utEjKozqWidbjp42ejgiIiJdgsKIF0wmk2d2RE/xFRER8Q2FES81hBEVPxMREfEFhREv1Rc/+/pYESVVenqkiIhIeymMeKlnTDgXdI/E6YKNKg0vIiLSbgojbZA2wH2pZr3CiIiISLspjLRB/aUaFT8TERFpP4WRNph8QSImE+zPKyO3pMro4YiIiHRqCiNtEBMRysjeMYBu8RUREWkvhZE20i2+IiIivqEw0kYNi1jzcblcBo9GRESk81IYaaPxqXFYQ8ycLK7iYH650cMRERHptBRG2sgWamF8vzgA1mvdiIiISJspjLRD/boR3eIrIiLSdgoj7VAfRjYcKMDh1LoRERGRtlAYaYeRvWOIsoVQUlXLjuPFRg9HRESkU1IYaQeL2cTkC9zVWNcd0KUaERGRtlAYaaf6SzXrVW9ERESkTRRG2qk+jGw6XEhVjcPg0YiIiHQ+CiPtNKB7JEnRYVTXOtly5LTRwxEREel0FEbayWQyeaqx6hZfERER7ymM+IDnOTUHtG5ERETEWwojPlAfRrYfK6K4ssbg0YiIiHQubQojzz77LKmpqdhsNiZNmkRWVlaL51522WWYTKaztmuvvbbNg+5okmNsDOgeidMFGw9qdkRERMQbXoeRlStXkpGRwUMPPcSWLVsYPXo0U6dOJS8vr9nz3377bU6ePOnZduzYgcVi4eabb2734DsSz6UarRsRERHxitdh5KmnnmLevHnMmTOH4cOHs2zZMiIiIlixYkWz58fHx5OcnOzZPv74YyIiIhRGREREBPAyjNjtdjZv3kx6enpDA2Yz6enpbNiwoVVtvPjii9xyyy1ERkZ6N9IO7lsXJGA2wYFT5eQUVxk9HBERkU7DqzCSn5+Pw+EgKSmpyfGkpCRycnLO+/qsrCx27NjB3Llzz3ledXU1JSUlTbaOLiY8lJG9YwDNjoiIiHgjoHfTvPjii4wcOZKJEyee87wlS5YQExPj2VJSUgI0wvZpuMVXYURERKS1vAojiYmJWCwWcnNzmxzPzc0lOTn5nK8tLy/nzTff5Mc//vF5+1m0aBHFxcWeLTs725thGqbxuhGXy2XwaERERDoHr8KI1Wpl3LhxZGZmeo45nU4yMzOZPHnyOV/7t7/9jerqam677bbz9hMWFkZ0dHSTrTMY1y+OsBAzuSXVHDhVbvRwREREOgWvL9NkZGSwfPlyXnnlFXbt2sX8+fMpLy9nzpw5AMyaNYtFixad9boXX3yR6dOnk5CQ0P5Rd1C2UAvjU+MArRsRERFprRBvXzBjxgxOnTrF4sWLycnJYcyYMaxevdqzqPXo0aOYzU0zzp49e1i7di0fffSRb0bdgU0ZkMi6/QWs25/P7CmpRg9HRESkwzO5OsHihpKSEmJiYiguLu7wl2y2ZRdx/bPriLKFsHXxVVjMJqOHJCIiYojWfn7r2TQ+NqJ3DNG2EEqratl+vNjo4YiIiHR4CiM+ZjGbmDzAvS5G60ZERETOT2HED1QaXkREpPUURvygPox8eeQ0VTUOg0cjIiLSsSmM+MEFiZEkR9uw1zr58vBpo4cjIiLSoSmM+IHJZGLKwLp1IyoNLyIick4KI35ycd2lmvVaNyIiInJOCiN+Ur9u5OvjxRRX1Bg8GhERkY5LYcRPkqJtDOzRDZcLNhwsMHo4IiIiHZbCiB+lqd6IiIjIeSmM+JGn3ogWsYqIiLRIYcSPJl2QgNkEB0+Vc7K40ujhiIiIdEgKI34UEx7KyD6xAKzbr3UjIiIizVEY8bOL6+qN6BZfERGR5imM+FnaAPe6kbX783G5XAaPRkREpONRGPGzi/rFERZiJq+0mgOnyowejoiISIejMOJntlALE1LjAVi7T5dqREREzqQwEgANt/hqEauIiMiZFEYCIK1uEevGAwXUOpwGj0ZERKRjURgJgAt7xRBtC6G0upbtx4uNHo6IiEiHojASABaziSl1d9Ws16UaERGRJhRGAqT+Uo0WsYqIiDSlMBIg9YtYNx85TaXdYfBoREREOg6FkQDpnxhJzxgbdoeTL48UGj0cERGRDkNhJEBMJlPDLb56To2IiIiHwkgA1a8bWafn1IiIiHgojARQ/R01O04UU1RhN3g0IiIiHYPCSAAlRdsY1KMbLhdsPKhLNSIiIqAwEnD160bW6lKNiIgIoDAScPVhZL0WsYqIiAAKIwE36YJ4zCY4mF/OiaJKo4cjIiJiOIWRAIu2hTI6JRbQXTUiIiKgMGKItAH19UYURkRERBRGDDClvt7IgQJcLpfBoxERETGWwogBLuobhy3UzKnSavbllRk9HBEREUMpjBjAFmphQmo8oEs1IiIiwRtGnE7Y+xH8dRbYKwLevZ5TIyIi4ha8YQQXrPoF7HwPdrwV8N7rF7F+cbCAWocz4P2LiIh0FMEbRswWmDDXvZ/1AgR4IenwXtHERoRSWl3L18eLA9q3iIhIR9KmMPLss8+SmpqKzWZj0qRJZGVlnfP8oqIiFixYQM+ePQkLC2Pw4MGsWrWqTQP2qbG3QYgNcrZD9hcB7dpiNjH5grq7avZp3YiIiAQvr8PIypUrycjI4KGHHmLLli2MHj2aqVOnkpeX1+z5drudK6+8ksOHD/PWW2+xZ88eli9fTu/evds9+HaLiIeRN7v3s14IePdT6teNHFAYERGR4OV1GHnqqaeYN28ec+bMYfjw4SxbtoyIiAhWrFjR7PkrVqygsLCQd999l7S0NFJTU/n2t7/N6NGj2z14n5g4z/1153tQmhPQri+uCyNbjhRRaXcEtG8REZGOwqswYrfb2bx5M+np6Q0NmM2kp6ezYcOGZl/z/vvvM3nyZBYsWEBSUhIjRozgsccew+Fo+cO3urqakpKSJpvf9BwNKd8CZy1sftl//TQjNSGCXjE27A4nmw4XBrRvERGRjsKrMJKfn4/D4SApKanJ8aSkJHJymp9VOHjwIG+99RYOh4NVq1bx4IMP8oc//IHf/va3LfazZMkSYmJiPFtKSoo3w/Re/ezIlyug1u7fvhoxmUwNt/jqUo2IiAQpv99N43Q66dGjBy+88ALjxo1jxowZPPDAAyxbtqzF1yxatIji4mLPlp2d7d9BDvsedEuGslzY/Q//9nWGhnojCiMiIhKcvAojiYmJWCwWcnNzmxzPzc0lOTm52df07NmTwYMHY7FYPMeGDRtGTk4OdnvzsxBhYWFER0c32fwqxArj57j3vwjsQtb659R8c6KE0+WBm5URERHpKLwKI1arlXHjxpGZmek55nQ6yczMZPLkyc2+Ji0tjf379+N0NhT22rt3Lz179sRqtbZx2H4w7nYwh0D2Rji5LWDd9oiyMTipGy4XbDioaqwiIhJ8vL5Mk5GRwfLly3nllVfYtWsX8+fPp7y8nDlz3DMLs2bNYtGiRZ7z58+fT2FhIffccw979+7lgw8+4LHHHmPBggW+exe+EJUMw69372ctD2jXUwboUo2IiAQvr8PIjBkzePLJJ1m8eDFjxoxh69atrF692rOo9ejRo5w8edJzfkpKCh9++CGbNm1i1KhR/OxnP+Oee+5h4cKFvnsXvjLxTvfX7X+DisDd3XKx1o2IiEgQM7lcAa6D3gYlJSXExMRQXFzs3/UjLhf88RJ3RdYrH4G0n/mvr0ZKq2oY8/DHOJwu1i38Dr1jwwPSr4iIiD+19vM7eJ9N0xyTqWF2ZNOfwBmYQmRRtlBG94kBNDsiIiLBR2HkTCNuAlssFB2BfR8HrFvd4isiIsFKYeRM1gi46Efu/QA+r6YhjBTQCa6ciYiI+IzCSHPG/xgwwYFMyN8fkC7H9o3FFmomv6yavbllAelTRESkI1AYaU58fxg81b2/6U8B6TIsxMKE1HhAl2pERCS4KIy0pH4h69bXoTowMxW6xVdERIKRwkhLLrgcEgZCdQl8/WZAuqxfN/LFoUJqHc7znC0iItI1KIy0xGyGCXVP881a7q5B4mfDe0YTGxFKWXUt244V+70/ERGRjkBh5FzG/BBCI+HUbjj8ud+7M5tNTBngfnCeLtWIiEiwUBg5F1sMjL7FvR+g23xVb0RERIKNwsj5TKy7VLP7AyjK9nt3aXUPzdty9DQV9lq/9yciImI0hZHz6TEMUi8BlxM2v+T37volRNA7Npwah4tNh0/7vT8RERGjKYy0Rv1tvptfhpoqv3ZlMplIG6h1IyIiEjwURlpjyDUQ3RsqCmDnu37vTutGREQkmCiMtIYlBMbf4d4PwELWKXXrRnaeLKGw3O73/kRERIykMNJa424HixWOb4Zjm/3aVfeoMIYkReFywYYDBX7tS0RExGgKI60VmQgjbnTvb1ru9+48l2oO6FKNiIh0bQoj3qi/zXfH36HslF+70iJWEREJFgoj3ug9zr057LDlFb92NbF/PBaziSMFFWQXVvi1LxERESMpjHir/jbfL1eAw39FyaJsoYxJiQVgvS7ViIhIF6Yw4q3h0yEiEUqOw55Vfu0qzfOcGi1iFRGRrkthxFuhNhg3273v59t86xexrj+QjysATw0WERExgsJIW4y/A0xm95N883b5rZuxfeMID7WQX2ZnT26p3/oRERExksJIW8T0gaHXuvez/HebrzXEzMT+8YAu1YiISNelMNJW9QtZt70JVcV+60a3+IqISFenMNJWqZdA92FQUw5b/+K3bupLw39xsIAah9Nv/YiIiBhFYaStTKaGImibloPTP0FheM9o4iJCKbc72JZd5Jc+REREjKQw0h6jZkBYNBTsh4Of+qULs9nkmR3RuhEREemKFEbaI6wbjJnp3vfjbb6e59Ro3YiIiHRBCiPtNWGu++veD6HwkF+6qF/E+lX2aSrs/qv6KiIiYgSFkfZKHAgDrgBc8OWLfumib3wEfeLCqXG4yDpU6Jc+REREjKIw4gv1t/lueRXsvn+onclkIm2ALtWIiEjXpDDiC4OuhNh+UFUEO97ySxdTBuo5NSIi0jUpjPiC2dKwdiTrBfDDc2Tq76jZebKEgrJqn7cvIiJiFIURXxl7G4TYIGc7ZH/h8+a7R4UxNDkKgA0HNTsiIiJdh8KIr0TEw8ib3ft+us1Xt/iKiEhXpDDiS/ULWXe+B6U5Pm8+TetGRESkC1IY8aWeo6DvZHDWwuaXfd78xP4JhJhNHC2sILvQ93ftiIiIGKFNYeTZZ58lNTUVm83GpEmTyMrKavHcl19+GZPJ1GSz2WxtHnCHV/+8mi9XQK3dp013CwthTEosoEs1IiLSdXgdRlauXElGRgYPPfQQW7ZsYfTo0UydOpW8vLwWXxMdHc3Jkyc925EjR9o16A5t6DTolgxlubDrfZ83P6V+3cgBXaoREZGuwesw8tRTTzFv3jzmzJnD8OHDWbZsGREREaxYsaLF15hMJpKTkz1bUlJSuwbdoYVYYfwc937Wcp83f3FdGFm/Px+n0/e3EIuIiASaV2HEbrezefNm0tPTGxowm0lPT2fDhg0tvq6srIx+/fqRkpLC9ddfzzfffHPOfqqrqykpKWmydSrjbgdzCGRvhJPbfNr0mJRYwkMtFJTb2ZNb6tO2RUREjOBVGMnPz8fhcJw1s5GUlEROTvN3jwwZMoQVK1bw3nvv8dprr+F0OpkyZQrHjh1rsZ8lS5YQExPj2VJSUrwZpvGikmH49e59H8+OWEPMTLogHtC6ERER6Rr8fjfN5MmTmTVrFmPGjOHb3/42b7/9Nt27d+ePf/xji69ZtGgRxcXFni07O9vfw/S9+tt8t/8NKnz7cDs9p0ZERLoSr8JIYmIiFouF3NzcJsdzc3NJTk5uVRuhoaGMHTuW/fv3t3hOWFgY0dHRTbZOJ2USJI+E2ir46jWfNl1f/OyLQ4XUOJw+bVtERCTQvAojVquVcePGkZmZ6TnmdDrJzMxk8uTJrWrD4XCwfft2evbs6d1IOxuTqWF2ZNOfwOnwWdNDk6OIj7RSYXewNbvIZ+2KiIgYwevLNBkZGSxfvpxXXnmFXbt2MX/+fMrLy5kzx30HyaxZs1i0aJHn/IcffpiPPvqIgwcPsmXLFm677TaOHDnC3LlzffcuOqoRN4EtFoqOwL6Pfdas2Wxi8oD6aqy6VCMiIp2b12FkxowZPPnkkyxevJgxY8awdetWVq9e7VnUevToUU6ePOk5//Tp08ybN49hw4ZxzTXXUFJSwvr16xk+fLjv3kVHZY2Ai2a59338vJqL9ZwaERHpIkwulx+ed+9jJSUlxMTEUFxc3PnWj5w+DP87BnDBXZshcaBPmj1aUMGlv/+UELOJbQ9dRWRYiE/aFRER8ZXWfn7r2TT+FpcKg7/r3t/ku9t8+yZEkBIfTq3TRdYh396tIyIiEkgKI4FQ/7yarW9Ate8KlekWXxER6QoURgLhgsshYSBUl8DXK33WbJqeUyMiIl2AwkggmM0woW52JGs5+GiZzpS6O2p2nSwhv6zaJ22KiIgEmsJIoIz5IYRGwqndcPhznzSZ0C2MoclRAGzQ7IiIiHRSCiOBYouB0be49314m69u8RURkc5OYSSQ6hey7v4AinzzvJ2GdSMKIyIi0jkpjARSj2GQegm4nLD5JZ80ObF/PCFmE9mFlRwtqPBJmyIiIoGkMBJok37i/rr5ZaipandzkWEhjO0bC8DbXx1rd3siIiKBpjASaIOvhug+UFEAO9/1SZO3fasfAM+tOcDBU2U+aVNERCRQFEYCzRICE+5w7/toIev3Rvfi0sHdsdc6WfT2dpzODl/hX0RExENhxAgXzQaLFY5vhmOb292cyWTi0ekjCA+18MWhQv622TeLY0VERAJBYcQIkYkw4kb3vo9mR1LiI8i4cjAAj36wi7zS9q9HERERCQSFEaPU3+b7zdtQdsonTc5JS2VE72hKqmr5zT92+qRNERERf1MYMUrvce7NYYctr/ikyRCLmcdvGIXFbOKDr0+SuSvXJ+2KiIj4k8KIkSbe6f765Qpw1PqkyRG9Y/jxxf0B+NW7Oyir9k27IiIi/qIwYqTh0yEiEUqOw55VPmv2vvTBpMSHc7K4iic/3OOzdkVERPxBYcRIoTYYN9u978Pn1YRbLTz2/ZEAvLLhMF8dPe2ztkVERHxNYcRo4+8Ak8X9JN+8XT5r9pJB3blhbG9cLlj09nZqHE6ftS0iIuJLCiNGi+kDQ69172ct92nTv7puOPGRVnbnlPLCZwd92raIiIivKIx0BPULWbe9CVXFPms2PtLKg9cNA+B/M/epVLyIiHRICiMdQerF0H0Y1JTD1r/4tOnpY3pzyaBE7LVO7n9nOy6XSsWLiEjHojDSEZhMDUXQsl4Ap+/Wd7hLxY/EFmpm48FC/vqlSsWLiEjHojDSUYyaAWHRUHgADn7i06b7JjQtFX+qtNqn7YuIiLSHwkhHEdYNxsx07/t4ISvAHWn9G5WK/8bn7YuIiLSVwkhHMmGu++veD6HwkE+bblwq/p9fn+ST3SoVLyIiHYPCSEeSOBAGXAG44MsXfd58k1Lx76hUvIiIdAwKIx1N/W2+W14Fe4XPm783fRAp8eGcUKl4ERHpIBRGOppBV0JsP6gqgh1v+bz5CGsIj05XqXgREek4FEY6GrOl6W2+fqgLcung7nxfpeJFRKSDUBjpiMbMhJBwyNkO2V/4pYtfXTuMuIhQlYoXERHDKYx0RBHxMOpm974Pn+bbWEK3MB68bjjgLhV/KL/cL/2IiIicj8JIRzWh7lLNzvegNMcvXXx/bKNS8W+rVLyIiBhDYaSj6jkK+k4GZy18+ZJfumhcKn7DwQL+9uUxv/QjIiJyLgojHVn9QtbNL0Gt3S9d9E2I4L70ulLxq1QqXkREAk9hpCMbOg26JUNZLux632/d/Pji/lzYK5riyhqVihcRkYBTGOnIQqwwfo573w/Pq/F0U1cq3mxCpeJFRCTgFEY6unG3gzkEsjfCyW1+62Zkn4ZS8Q+++w3lKhUvIiIB0qYw8uyzz5KamorNZmPSpElkZWW16nVvvvkmJpOJ6dOnt6Xb4BSVDMOvd+/7cXYE4L4rB9MnLpzjRZU8+ZFKxYuISGB4HUZWrlxJRkYGDz30EFu2bGH06NFMnTqVvLy8c77u8OHD/OIXv+CSSy5p82CDVv3zarb/DSoK/dZNhDWEx77vLhX/8vrDbM0u8ltfIiIi9bwOI0899RTz5s1jzpw5DB8+nGXLlhEREcGKFStafI3D4WDmzJn85je/4YILLmjXgINSyiRIHgW1VfDVa37tqnGp+IV//1ql4kVExO+8CiN2u53NmzeTnp7e0IDZTHp6Ohs2bGjxdQ8//DA9evTgxz/+cav6qa6upqSkpMkW1EymhtmRTX8Cp8Ov3alUvIiIBJJXYSQ/Px+Hw0FSUlKT40lJSeTkNF8ldO3atbz44ossX9769Q5LliwhJibGs6WkpHgzzK5p5E0QHgdFR2Dfx37tKqFbGL+6VqXiRUQkMPx6N01paSk/+tGPWL58OYmJia1+3aJFiyguLvZs2dnZfhxlJxEaDmN/5N7P+qPfu7vhooZS8Q+8o1LxIiLiP16FkcTERCwWC7m5TetQ5ObmkpycfNb5Bw4c4PDhw0ybNo2QkBBCQkL485//zPvvv09ISAgHDhxotp+wsDCio6ObbAJM+DFgggOfQP4+v3bVuFT8+gMF/G2zSsWLiIh/eBVGrFYr48aNIzMz03PM6XSSmZnJ5MmTzzp/6NChbN++na1bt3q2733ve1x++eVs3bpVl1+8FZcKg7/r3t/0J79316RU/AcqFS8iIv7h9WWajIwMli9fziuvvMKuXbuYP38+5eXlzJnjrhQ6a9YsFi1aBIDNZmPEiBFNttjYWKKiohgxYgRWq9W37yYY1D+vZusbUF3q9+4al4p/+J87/d6fiIgEH6/DyIwZM3jyySdZvHgxY8aMYevWraxevdqzqPXo0aOcPHnS5wOVOhdcDgkDoboEvl7p9+4al4r/x7YTfLr73PVkREREvGVydYKViSUlJcTExFBcXKz1IwAbl8HqX0L3ofBfG923/vrZb/+5kz+tPUTv2HA+uu9SIsNC/N6niIh0bq39/NazaTqjMT+E0Eg4tRsOfx6QLjOuaigV/4eP9gakTxERCQ4KI52RLQZG3+Lez3ohIF1GWEN41FMq/hDbVCpeRER8RGGks6qvyLr7AygKTB2Wbw/uzvQxvXC64JcqFS8iIj6iMNJZ9RgK/S8FlxM2vxSwbh+8brinVPzyz1UqXkRE2k9hpDOrnx3Z/DLUVAWkyyal4v+9j8MqFS8iIu2kMNKZDb4aovtARQF8807Aur3hot5cPDCR6lon96tUvIiItJPCSGdmCYEJd7j3A7SQFepKxX9/hKdU/FsqFS8iIu2gMNLZXTQbLFY4sQW+eTdg3fZLiOTe+lLxq3aRX6ZS8SIi0jYKI51dZCKMudW9/7fZsHoR1AYmGMy9uD/De0ZTVFHDw/9QqXgREWkbhZGu4OrfwaT57v2Nz8Gf0iF/v9+7DbGYeeJGd6n497ed4NM9KhUvIiLeUxjpCkLC4OrH4YcrITwecr6GP14KX70Ofl5cOrJPDHek9QfgV+/soLy61q/9iYhI16Mw0pUM+S7MXw+pl0BNObz3X/D3uVBV4tduVSpeRETaQ2Gkq4nuCbPegysWg8kCO96CZRfDsS/91mWENYTfTh8BqFS8iIh4T2GkKzJb4JKfwx2rIaYvFB2BFVNh7f+A0z8l3C8b0oPr60rFL3x7u0rFi4hIqymMdGUpE+Gnn8OF3wdnLfz71/Da96E0xy/dPXjdcGIjQtl1soQ/fX7IL32IiEjXozDS1YXHwk0vwfeehtAIOLgGnk+DfR/7vKvERqXil/57r0rFi4hIqyiMBAOTCS6aBXeugaSRUJEPr98Eq+/3eU2SGxuVin/gXZWKFxGR81MYCSbdh8Dcf8Okn7q/3/gsvHilT2uSNC4Vv26/SsWLiMj5KYwEm1AbXP0E/PBNd02Sk9vcNUm2vuGzmiQqFS8iIt5QGAlWQ66G+esaapK8Ox/evtNnNUkal4p/5J8qFS8iIi1TGAlm0b3cNUm+8yt3TZLtf4U/XgLHNre76RCLmcdvHInZBO9tVal4ERFpmcJIsDNb4NL/hjn/ctckOX0YVlwFa5e2uybJqD6xzFGpeBEROQ+FEXHrO8ldk2T49LqaJA/BazdAaW67ms24cjC9Y92l4p/6WKXiRUTkbAoj0iA8Fm5+Gab9H4SEw8FP4fkpsO/fbW4yMiyER7/vLhX/0jqVihcRkbMpjEhTJhOMmw0/+Q8kjairSXIjfPgA1Nrb1KRKxYuIyLkojEjzug+BuZkw8U739xuecdckKTjQpuYal4p/ca1KxYuISAOFEWlZqA2u+T3c8hcIj4OTW2HZJbD1L143ldgtjAeuGQbA/3y8lyMFKhUvIiJuCiNyfkOvgfnrod/FdTVJftqmmiQ3jetD2sAEqmud3P+OSsWLiIibwoi0TnQvmP0+XF5Xk+Trle7KrcdbX5PEZDLx6PSRhIW4S8X/fctxPw5YREQ6C4URaT2zBb793zBnFcSkwOlD8OJVsO7/Wl2TJDWxoVT8bz/YqVLxIiKiMCJt0PdbdTVJrnfXJPn4QfcdN62sSTL3kv4MU6l4ERGpozAibRMeBze/AtP+112T5MAnsCwN9p+/JkmoxcwTKhUvIiJ1FEak7UwmGHc73LkGelwI5afgtRvho1+dtybJmaXiK+wqFS8iEqwURqT9egyFeZkwYZ77+/VPt6omSZNS8R+pVLyISLBSGBHfCA2Ha5+EW95oqEnyx0th28oWXxIZFsJv60rFr1h3iK+PFQVmrCIi0qEojIhvDb0WfrrOXZPEXgbv3Alv/wSqS5s9/fIhPfje6LpS8X9XqXgRkWCkMCK+F9O7ribJA2Ayw9dv1tUk2dLs6YunuUvF71SpeBGRoKQwIv5htsC3/x/cvgqi+0DhQXdNkvVPn1WT5MxS8bpcIyISXNoURp599llSU1Ox2WxMmjSJrKysFs99++23GT9+PLGxsURGRjJmzBheffXVNg9YOpl+k2H+Whj2PXDWuO+0ef0mKGt6O2/jUvHXP7uOn/91GyeKKg0atIiIBJLXYWTlypVkZGTw0EMPsWXLFkaPHs3UqVPJy2u+VkR8fDwPPPAAGzZs4Ouvv2bOnDnMmTOHDz/8sN2Dl04iPA5+8Ge4bimE2OBAJjyfBvszPaeYTCb+95axXDeqJy4X/H3LMS5/cg1PrN5NSVWNcWMXERG/M7m8fFrZpEmTmDBhAs888wwATqeTlJQU7r77bhYuXNiqNi666CKuvfZaHnnkkVadX1JSQkxMDMXFxURHR3szXOlo8nbBW3dAXl3l1Sk/g+88CCFWzylfHT3Nkn/tJutQIQBxEaH87IpBzJzUD2uIriyKiHQWrf389upvdrvdzubNm0lPT29owGwmPT2dDRs2nPf1LpeLzMxM9uzZw6WXXupN19JV9BgG8z6BCXPd36//P1hxVZOaJGP7xrHyzm/xp1njGdijG6cravjNP3aS/tR/+OfXJ/S0XxGRLsarMJKfn4/D4SApKanJ8aSkJHJyclp8XXFxMd26dcNqtXLttdfy9NNPc+WVV7Z4fnV1NSUlJU026UJCw+HaP8CM18AWCye+ct9t8/VfPaeYTCbShyex+p5LeOz7I+keFcbRwgrueuMrpj+3ni8OFhg3fhER8amAzHlHRUWxdetWNm3axKOPPkpGRgZr1qxp8fwlS5YQExPj2VJSUgIxTAm0YdNg/jroO8Vdk+Ttee6aJMe3gMO9TiTEYubWSX1Z84vLuC99MBFWC9uyi5jxwkbmvvIl+/Oar18iIiKdh1drRux2OxEREbz11ltMnz7dc3z27NkUFRXx3nvvtaqduXPnkp2d3eIi1urqaqqrGx4tX1JSQkpKitaMdFVOB3z2e/jPE+Cqu+03JBx6jYWUCdBnIqRMhG49OFVazf9m7uUvWdk4nC7MJpgxoS/3pQ+iR7TN2PchIiJN+GXNiNVqZdy4cWRmNtwF4XQ6yczMZPLkya1ux+l0NgkbZwoLCyM6OrrJJl2Y2QKXLXTXJBk01X3pprYSjq6Hdf8LK2fCk4Ng6Si6f7SA3/bcwJpbY7l6WAJOF/wl6yiXPbmG//l4L+XVeuCeiEhnE+LtCzIyMpg9ezbjx49n4sSJLF26lPLycubMmQPArFmz6N27N0uWLAHcl1zGjx/PgAEDqK6uZtWqVbz66qs8//zzvn0n0vn1m+zenE4o2A/HsiA7C45tct+FU3TEvW3/GynA8yHhlPQbyb9L+/GvohReyyzk9S+Ocm/6IGZMSCHUojtvREQ6A6/DyIwZMzh16hSLFy8mJyeHMWPGsHr1as+i1qNHj2I2N3wIlJeX81//9V8cO3aM8PBwhg4dymuvvcaMGTN89y6kazGboftg9zb2NvexqmI4vhmyN7lDyrFNUFVMdG4WN5DFDXV3Bh+x92DLB4N47tMLmXDJd5k8+VJMllDj3ouIiJyX13VGjKA6I3IWpxMK9tXNnGRB9iZcp3Zjoul/zlWmMGqSxhI1cIp73UmfCRCZaNCgRUSCS2s/vxVGpOuoLILjm6k+tIETOz4joWg70aaKs8+Lv6BuUWzd4tgew8Hi9SShiIich8KIBL2TReW88c+PObVrLWNN+xhn2cdA0/GzTwyNhN4X1c2c1M+eJAR+wCIiXYzCiEid3TklPP6v3azZc4poypgcdpi5qae4yLwPy4ktUN1MUb34AQ2XdVLqZk/MlsAPXkSkE1MYETnDuv35LPnXLnYcd4eP5GgbP79yADeklGM5vqlhcWz+3rNfbO3mnj2pr3nSZwJExAf4HYiIdC4KIyLNcDpd/OPrE/xu9R6OF1UCMCQpioXXDOWywd0xmUxQUVh3507d4thjm8HeTKXXhIFnrD0ZptkTEZFGFEZEzqGqxsGrG47w9Cf7KKlyF0qbMiCB+68ZxojeMU1Pdjrg1G53OKkPKAX7z27UGtVo7ckEiOkDEQnuTbcXi0hH5HKBww72cgiL8vnfVQojIq1QVGHnuTUHeHndYewOdyn66WN68fOrhpASH9HyCysK3bVO6sPJ8S3u5+u0JCzGfVknIsF9a3FEQsP3EYkNoSUiwb14NizGXW9FRIKb0+muSF1T6Q4MNZVQU/fVXgE1jTZ7RSt+fua5FeByuPu6c437MRw+pDAi4oXswgr+8NEe3t16AgCrxcztaaksuGwgMRGt+JeC0wF5Oxsqxp7YCuWnoLKw4Xk73jBZ6sLKGcElsnFwiW8aZKznCE8i4h+O2vMEgvKGD/0zA8GZP2/u3NrKwL2X21dBappPm1QYEWmDHceLeWzVLtYfKAAgJjyUuy4fyI8m98MW2ob1IE4nVBVBRYF7K89v2G9uKy9ofn1Ka4SE14WV+EaB5RxhJjxe9VWk83PUQm0V1FbXfW28X/fVYW/+eLPHzvW1+uzjzprAvdcQG4RGuDdrBISGu0sThIbXfV//s7pjTc6t38Jb/rkfLicrjIi0kcvlYs3eUzy+ajd7ct3BoHdsOP89dQjfG90Ls9nk3wHUVrsvA1UUQEV9eClsOciU57f9L0Rb7NmXiJoEmXj3X1qWMLBY3X9ZhYS5v1qsdcfrj1m1gLcrcrnAWQuOGveHev2+s6buWP2+3R0MzjpeU/cae6NjteBo5oO9yX5LAeKMr/WXGAxnOncIaG0gaClshEZ0yku3CiMi7eRwuvj7lmM89dFeckqqABjRO5r7rx7GlIEdqKS8y+Ver1Ke3yjENA4ydTMujQNM5WnAD//rm8wtBJfWhJkzjlmsZ7z+zGPNhKFznYvJfcmsyeZy/zmcdfyMc875fUvH6rYm7bemr/Oc43TUhYKaRh/+9kYf+ucLDTVnhILm2mq07+xET8I2h7pnD0LCvPga1sxxb9qom60ICQOTn/+h0gkpjIj4SKXdwYp1h3h+zQHKqt1/MV82pDsLrx7K0ORO+t+jo/Ycl48KmwaZ+qnp+g85R91+bXVgp6il4zBZ3CHPHFoX9prbD6mbLWtm3xzaQgjwMhRYzmhDM3MdjsKIiI8VlFXz9Cf7eW3jEWqdLswmuGlcHzKuHEJyjM3o4RnD5aoLKY0CSv2/0h2N9j3H7c0ca3Rurf2M81o41mybLZzbWibzOTaT+yum85/T6u/P2DCd/xyTyf2Be64PeYv1jP1QMIc0zBA1t9/s60KaDxvm0E55uUCMoTAi4ieH88v5/Yd7+GD7SQBsoWZ+fHF/fvLtAUTbVE+kQ/GEpbpQ0mKA0PS6iD8ojIj42Zajp1myahebDp8GID7Sys++M5BbJ/XDGqJ/OYqIKIyIBIDL5eLjnbk8vno3B0+VA5CaEMH/++5Qpl6YjMXfd96IiHRgCiMiAVTrcLLyy2z+5+N95JdVAxAbEUragETSBiZy8cBE+iaoKJmIBBeFEREDlFXXsvyzg6xYd4jSqqa3RPaNj/AEkykDEoiLtBo0ShGRwFAYETFQrcPJtmPFrNufz9r9+Ww5cppaZ8P/aiYTjOgVQ9rARC4ZlMi4fnFtq/AqItKBKYyIdCDl1bVkHSpk7f581u7L91R2rRcWYmZCajwXD3LPnAzvGe3/Sq8iIn6mMCLSgeWVVLH+QAGf78tn7f5T5JZUN/l5XEQoU+ou6Vw8MPHcTxAWEemgFEZEOgmXy8WBU2Ws3ZfP2v0FbDxY4Kn0Wq9fQtP1JrERWm8iIh2fwohIJ1XjcPL1sSLW7itg7f5TfHW06Kz1JiN71603GZjIRVpvIiIdlMKISBdRVl1L1iH3JZ11+/PZm1vW5OdhIWYm9o/n4oHu24i13kREOgqFEZEuKq+kyr0Qdr87nJy53iQ+0sqUAQmecKL1JiJiFIURkSDgcrnYn1fmCSYbDhRQbnc0OadfQoRnIexkrTcRkQBSGBEJQjUOJ9uyizy3EH+VXYTjjPUmo+rWm1w8MJFxqXGEhWi9iYj4h8KIiFBaVUPWoULPepN9eU3Xm9hC6+qbDEzk4kGJDEvWehMR8R2FERE5S25JFWvrgsna/fnklTa/3uSSQe71Jn3itN5ERNpOYUREzsnlcrEvr8wTTjYePHu9SWpCBKP6xDIkOYpBPboxOCmKlPgIPY1YRFpFYUREvFLjcLI1u6iu+Fo+W89Yb1LPFmpmYI9uDO4RxeDkKAYnuUNK79hwTCaFFBFpoDAiIu1SWlXDl4dPsyunhL05pezNLWP/qTLstc5mz4+0WhiYFMWQunAyKCmKIUlRJEWHKaSIBCmFERHxOYfTxZGCcvbmlrEvt5Q9uaXsyy3jYH4ZNY7m/yqJsoUwOCmqbqsPKt3o3k0hRaSrUxgRkYCpcTg5nO8OKXtzSz3b4YKKZi/1gPthgPWzJ4OTujGoLrDER6oOikhXoTAiIoarrnVw8FQ5e+tmUNwzKaUcKaygpb95EruFeWZQBjcKKjHhoYEdvIi0m8KIiHRYlXYHB07Vz6I0zKYcO13Z4muSo20MSupWN5PivtQzKCmKbmEhARy5iHhDYUREOp3y6lr25ZXVzaSUsqdubcrJ4qoWX9M7Ntw9k5Ic5b7DJymKgT26EW5VZVkRoymMiEiXUVxZw/680jPWpJRx6oyibfVMJugbH8GgHlEMSXZf8umXEEmfuHASIq1aOCsSIAojItLlnS63u4NJXt3dPTml7Msro7Dc3uJrbKFmesWG0zs2nD5xEfSJc+/3jgunT1w4PaJsKuom4iN+DSPPPvssv//978nJyWH06NE8/fTTTJw4sdlzly9fzp///Gd27NgBwLhx43jsscdaPL85CiMi4o38suq62igNQSW7sJLc0qoWF87WCzGb6Blr84QVT1Cp+z45xoY1xByYNyLSybX289vrlV8rV64kIyODZcuWMWnSJJYuXcrUqVPZs2cPPXr0OOv8NWvW8MMf/pApU6Zgs9l44oknuOqqq/jmm2/o3bu3t92LiJxXYrcwEgeGMWVgYpPj9lonJ4srOX66kmNFlRw77d4/XlTB8aJKThZVUet0kV1YSXZhJVB4VtsmEyRF2TwzKQ2zKnXBJTZc61VEvOT1zMikSZOYMGECzzzzDABOp5OUlBTuvvtuFi5ceN7XOxwO4uLieOaZZ5g1a1ar+tTMiIgEgsPpIrekiuNFdYHltDukHDtd6TlW3UIF2sYSIq3uoFIfVupnWeqORdt0m7IEB7/MjNjtdjZv3syiRYs8x8xmM+np6WzYsKFVbVRUVFBTU0N8fHyL51RXV1Nd3bAwraSkxJthioi0icVsoldsOL1iw5mQevbPXS4X+WX2s8LK8bqwcux0JWXVtRSU2ykot7PtWHGz/UTZQjwzKfWzK43DS7wW2UqQ8SqM5Ofn43A4SEpKanI8KSmJ3bt3t6qNX/7yl/Tq1Yv09PQWz1myZAm/+c1vvBmaiIjfmUwmukeF0T0qjDEpsWf93OVyUVJZy7GiirqwUnlGWKngdEUNpVW17DpZwq6Tzf9DKzzU0jCr0iis9IkLJzkmnMRuVsJCdClIuo6AVgt6/PHHefPNN1mzZg02m63F8xYtWkRGRobn+5KSElJSUgIxRBGRNjOZTMREhBITEcOFvWKaPae8upYTRWeuWank+OkKjp2uJK+0msoaB/vzytifV9ZiX9G2EE8w6h5lo3u3MBKjrHTvFtboeBjxEVZCLFpwKx2bV2EkMTERi8VCbm5uk+O5ubkkJyef87VPPvkkjz/+OP/+978ZNWrUOc8NCwsjLCzMm6GJiHQKkWEhDKp7qnFzqmsdnCyq8syk1C+2rZ9pOVVajd3hpKSqlpKqWg6cKj9nfyaTew1LYuOQ0sx+YrcwYiNCdXlIDOFVGLFarYwbN47MzEymT58OuBewZmZmctddd7X4ut/97nc8+uijfPjhh4wfP75dAxYR6crCQiykJkaSmhjZ7M/rLwWdKqsir7SaU6XV5JfZOVW3f6qs/lg1BWXVOF2QX2Ynv8zO7pzSc/YdajE1hJZuYU0DTFRDaOkeFUak1aLgIj7j9WWajIwMZs+ezfjx45k4cSJLly6lvLycOXPmADBr1ix69+7NkiVLAHjiiSdYvHgxb7zxBqmpqeTk5ADQrVs3unXr5sO3IiLS9TVcCgplYI/mZ1fqOZwuCsvtZ4UUT3CpO55fVk1RRQ01Dhcni6vOWX6/XniopVFAsdYFGNtZxxK7hWEL1foWOTevw8iMGTM4deoUixcvJicnhzFjxrB69WrPotajR49iNjdcn3z++eex2+3cdNNNTdp56KGH+PWvf92+0YuISIss5oYFt+dTXeug4IwZlvxGIabxsXK7g8oaB0cLKzhaWHHetuvXtzSeaam/LBQfYSU2wkp8pJW4iFBiI6wqKheEVA5eRES8Ul5d23SGpbngUvd9jcP7j5iosBBiI5sGFU9wibQSH+EOLnGRVuIi3D/T7EvH5LcKrCIiEtwiw0KIDAuhX0Lz61rqNbe+pT6kFJbZOV1Rw+kKu3srt1NUWYPLBaXVtZRW19ZVwW2dCKuFuAgrcZGh7q+e2Zamx+r34yOtCjAdiMKIiIj4hTfrW8C9xqWksnFAqaGwwk5RhZ3C8pq6r3aKKhqOn66oweF0UWF3UGF33ybdWrZQ89mzL5F13zeaeakPMfGRVsJDtXDXHxRGRESkQ7CYTe4AEGlt9WucThelVbWcrrA3G1xOV9RwutzeEHDqvq91uqiqcXKiuIoTrViwW88aUh9gQj0BJtoWSnR4KNG2kLqvoUSHhzQ67v5eQaZlCiMiItJpmc0Nsy+pnPuyUT2Xy0VZdS2ny2taDDFFFTV1YaZhlsbucGKvdZJTUkVOSesDTL0Qs+k8oSV4w4zCiIiIBBWTyUSULZQoWyh9EyJa9RqXy30pqD6Y1IeUoooaSqtq3EXoKmsoqaqhpLK27mvD8Vqni9q6W60Ly+1tGnd9mImyhTQNLGeGl2aCTLQtlIgOXBtGYUREROQ8TCaTZ+FunzjvXutyuaiscZwRUpoPLf4MMxazqfnZl7r9277V77yLkv1FYURERMSPTCYTEdYQIqwhJMe0/Fy2lngbZko9++6vxXVhxuF01d3BVNNsP1eP7KkwIiIiImfzRZipqnGeN8j0jg33w+hbR2FERESkCzOZTIRbLYRbLSRFex9mAkE1d0VERMRQCiMiIiJiKIURERERMZTCiIiIiBhKYUREREQMpTAiIiIihlIYEREREUMpjIiIiIihFEZERETEUAojIiIiYiiFERERETGUwoiIiIgYSmFEREREDNUpntrrcrkAKCkpMXgkIiIi0lr1n9v1n+Mt6RRhpLS0FICUlBSDRyIiIiLeKi0tJSYmpsWfm1zniysdgNPp5MSJE0RFRWEymXzWbklJCSkpKWRnZxMdHe2zdqVt9PvoePQ76Vj0++hY9Ps4P5fLRWlpKb169cJsbnllSKeYGTGbzfTp08dv7UdHR+s/pA5Ev4+OR7+TjkW/j45Fv49zO9eMSD0tYBURERFDKYyIiIiIoYI6jISFhfHQQw8RFhZm9FAE/T46Iv1OOhb9PjoW/T58p1MsYBUREZGuK6hnRkRERMR4CiMiIiJiKIURERERMZTCiIiIiBgqqMPIs88+S2pqKjabjUmTJpGVlWX0kILSkiVLmDBhAlFRUfTo0YPp06ezZ88eo4cldR5//HFMJhP33nuv0UMJWsePH+e2224jISGB8PBwRo4cyZdffmn0sIKWw+HgwQcfpH///oSHhzNgwAAeeeSR8z5/RVoWtGFk5cqVZGRk8NBDD7FlyxZGjx7N1KlTycvLM3poQec///kPCxYsYOPGjXz88cfU1NRw1VVXUV5ebvTQgt6mTZv44x//yKhRo4weStA6ffo0aWlphIaG8q9//YudO3fyhz/8gbi4OKOHFrSeeOIJnn/+eZ555hl27drFE088we9+9zuefvppo4fWaQXtrb2TJk1iwoQJPPPMM4D7+TcpKSncfffdLFy40ODRBbdTp07Ro0cP/vOf/3DppZcaPZygVVZWxkUXXcRzzz3Hb3/7W8aMGcPSpUuNHlbQWbhwIevWrePzzz83eihS57rrriMpKYkXX3zRc+zGG28kPDyc1157zcCRdV5BOTNit9vZvHkz6enpnmNms5n09HQ2bNhg4MgEoLi4GID4+HiDRxLcFixYwLXXXtvk/xMJvPfff5/x48dz880306NHD8aOHcvy5cuNHlZQmzJlCpmZmezduxeAbdu2sXbtWq6++mqDR9Z5dYoH5flafn4+DoeDpKSkJseTkpLYvXu3QaMScM9Q3XvvvaSlpTFixAijhxO03nzzTbZs2cKmTZuMHkrQO3jwIM8//zwZGRncf//9bNq0iZ/97GdYrVZmz55t9PCC0sKFCykpKWHo0KFYLBYcDgePPvooM2fONHponVZQhhHpuBYsWMCOHTtYu3at0UMJWtnZ2dxzzz18/PHH2Gw2o4cT9JxOJ+PHj+exxx4DYOzYsezYsYNly5YpjBjkr3/9K6+//jpvvPEGF154IVu3buXee++lV69e+p20UVCGkcTERCwWC7m5uU2O5+bmkpycbNCo5K677uKf//wnn332GX369DF6OEFr8+bN5OXlcdFFF3mOORwOPvvsM5555hmqq6uxWCwGjjC49OzZk+HDhzc5NmzYMP7+978bNCL57//+bxYuXMgtt9wCwMiRIzly5AhLlixRGGmjoFwzYrVaGTduHJmZmZ5jTqeTzMxMJk+ebODIgpPL5eKuu+7inXfe4ZNPPqF///5GDymoXXHFFWzfvp2tW7d6tvHjxzNz5ky2bt2qIBJgaWlpZ93qvnfvXvr162fQiKSiogKzuenHp8Viwel0GjSizi8oZ0YAMjIymD17NuPHj2fixIksXbqU8vJy5syZY/TQgs6CBQt44403eO+994iKiiInJweAmJgYwsPDDR5d8ImKijprvU5kZCQJCQlax2OA++67jylTpvDYY4/xgx/8gKysLF544QVeeOEFo4cWtKZNm8ajjz5K3759ufDCC/nqq6946qmnuOOOO4weWuflCmJPP/20q2/fvi6r1eqaOHGia+PGjUYPKSgBzW4vvfSS0UOTOt/+9rdd99xzj9HDCFr/+Mc/XCNGjHCFhYW5hg4d6nrhhReMHlJQKykpcd1zzz2uvn37umw2m+uCCy5wPfDAA67q6mqjh9ZpBW2dEREREekYgnLNiIiIiHQcCiMiIiJiKIURERERMZTCiIiIiBhKYUREREQMpTAiIiIihlIYEREREUMpjIiIiIihFEZERETEUAojIiIiYiiFERERETGUwoiIiIgY6v8DgUb4zfpSHUcAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGgCAYAAACJ7TzXAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUthJREFUeJzt3Xl8VNXB//HPzCQzk4RsEMhGIOzIDoGkKC5VKmqlbkXBDXGrFvuoeayCIuijkGorxSqWn9al7uBSa5Xikqp1QYNEVGRfE5aEJJCdZJKZ+/tjkoFAgAyZyUyS7/v1uq+5uXPvOWcIOl/OPfcck2EYBiIiIiJBzBzoBoiIiIiciAKLiIiIBD0FFhEREQl6CiwiIiIS9BRYREREJOgpsIiIiEjQU2ARERGRoKfAIiIiIkFPgUVERESCngKLiIiIBL2TCiyLFy8mNTUVu91ORkYGOTk5xzy3rq6O//u//6Nfv37Y7XZGjhzJihUrmpzzwAMPYDKZmmyDBw8+maaJiIhIBxTi7QVLly4lMzOTJUuWkJGRwaJFi5g0aRIbN26kR48eR50/Z84cXn75ZZ555hkGDx7MBx98wCWXXMJXX33F6NGjPecNHTqUjz/++FDDQlreNJfLxZ49e4iMjMRkMnn7kURERCQADMOgoqKCpKQkzOYT9KEYXkpPTzdmzpzp+dnpdBpJSUlGVlZWs+cnJiYaTz75ZJNjl156qXHVVVd5fp43b54xcuRIb5vikZ+fbwDatGnTpk2btna45efnn/C73qseFofDwerVq5k9e7bnmNlsZuLEiaxcubLZa2pra7Hb7U2OhYWF8cUXXzQ5tnnzZpKSkrDb7YwfP56srCx69ep1zDJra2s9PxsNC07n5+cTFRXlzUcSERGRACkvLyclJYXIyMgTnutVYCkuLsbpdBIfH9/keHx8PBs2bGj2mkmTJrFw4ULOOOMM+vXrR3Z2Nm+//TZOp9NzTkZGBi+88AKDBg1i7969PPjgg5x++umsXbu22Q+RlZXFgw8+eNTxqKgoBRYREZF2piXDOfz+lNDjjz/OgAEDGDx4MFarldtuu40ZM2Y0uVd1/vnnM2XKFEaMGMGkSZNYvnw5paWlLFu2rNkyZ8+eTVlZmWfLz8/398cQERGRAPIqsMTFxWGxWCgsLGxyvLCwkISEhGav6d69O++88w5VVVXs3LmTDRs20KVLF/r27XvMemJiYhg4cCBbtmxp9n2bzebpTVGvioiISMfnVWCxWq2kpaWRnZ3tOeZyucjOzmb8+PHHvdZut5OcnEx9fT1vvfUWF1100THPraysZOvWrSQmJnrTPBEREemgvH6sOTMzk+nTpzN27FjS09NZtGgRVVVVzJgxA4Brr72W5ORksrKyAPjmm2/YvXs3o0aNYvfu3TzwwAO4XC7uvvtuT5l33XUXkydPpnfv3uzZs4d58+ZhsViYNm2ajz6me2BufX19k7EzIkeyWCyEhITo8XgRkSDjdWC54oorKCoqYu7cuRQUFDBq1ChWrFjhGYibl5fXZHxKTU0Nc+bMYdu2bXTp0oULLriAl156iZiYGM85u3btYtq0aZSUlNC9e3cmTJjA119/Tffu3Vv/CXE/3bR3716qq6t9Up50bOHh4SQmJmK1WgPdFBERaWAyGp8JbsfKy8uJjo6mrKzsqPEsLpeLzZs3Y7FY6N69O1arVf96lmYZhoHD4aCoqAin08mAAQNOPJGRiIictON9fx/J6x6W9sbhcOByuUhJSSE8PDzQzZEgFxYWRmhoKDt37sThcBw1h5CIiARGp/nno/6lLC2lvysiIsFH/2cWERGRoKfAIiIiIkFPgUVERESCngKLeKWuri7QTRARkU5IgSXIrVixggkTJhATE0O3bt248MIL2bp1q+f9xjlsunbtSkREBGPHjuWbb77xvP+vf/2LcePGYbfbiYuL45JLLvG8ZzKZeOedd5rUFxMTwwsvvADAjh07MJlMLF26lDPPPBO73c4rr7xCSUkJ06ZNIzk5mfDwcIYPH85rr73WpByXy8Wjjz5K//79sdls9OrVi/nz5wNw9tlnc9tttzU5v6ioCKvV2mQWZRER8T/DMKisrWdP6UE2FJSzasd+stcX8o/vdvHiyh08+Z/NLFi+noffWxfQdnb4x5qbYxgGB+sCM+NtWKjFq3lgqqqqyMzMZMSIEVRWVjJ37lwuueQS1qxZQ3V1NWeeeSbJycm8++67JCQkkJubi8vlAuD999/nkksu4b777uPFF1/E4XCwfPlyr9s8a9YsHnvsMUaPHo3dbqempoa0tDTuueceoqKieP/997nmmmvo168f6enpgHuBymeeeYY///nPTJgwgb1793pW9L7xxhu57bbbeOyxx7DZbAC8/PLLJCcnc/bZZ3vdPhGRzqze6aKipp7ymjr368E6yht+Lj9Y53mv/GA9FTV1h/ZrDx1ztWBGNmuImTkXDvH/BzqGThlYDtY5GTL3g4DUve7/JhFubfkf+2WXXdbk5+eee47u3buzbt06vvrqK4qKili1ahVdu3YFoH///p5z58+fz9SpU3nwwQc9x0aOHOl1m++44w4uvfTSJsfuuusuz/7vfvc7PvjgA5YtW0Z6ejoVFRU8/vjjPPnkk0yfPh2Afv36MWHCBAAuvfRSbrvtNv75z39y+eWXA/DCCy9w3XXXaVI/EelUDMOgtt7lCRFNQ8ex9huCR8P51Q7f/AM81GIiyh5KVFgoUfYQIu2hRIWFEGUPJdLufnW5DMzmwPx/ulMGlvZk8+bNzJ07l2+++Ybi4mJP70leXh5r1qxh9OjRnrBypDVr1nDTTTe1ug1jx45t8rPT6WTBggUsW7aM3bt343A4qK2t9UzMt379empraznnnHOaLc9ut3PNNdfw3HPPcfnll5Obm8vatWt59913W91WEZG2ZBgGNXUuT29GeU0dZQcPhQlPb8dxQofD6fJJW8KtlkPhotnQcUQACQt1B5SGfVuIOaj/0dgpA0tYqIV1/zcpYHV7o3FRyGeeeYakpCRcLhfDhg3D4XAQFhZ2/LpO8L7JZOLIlRmaG1QbERHR5Oc//vGPPP744yxatIjhw4cTERHBHXfcgcPhaFG94L4tNGrUKHbt2sXzzz/P2WefTe/evU94nYiIrznqXUeFi7KDdU16PdwhxP1+2cE6Kg573xeBw2SiSU9GVFhD2Giyf+i9IwNIF3sIoZaOPSy1UwYWk8nk1W2ZQCkpKWHjxo0888wznH766QB88cUXnvdHjBjB3/72N/bv399sL8uIESPIzs72rKR9pO7du7N3717Pz5s3b27RApFffvklF110EVdffTXgHmC7adMmhgxx39scMGAAYWFhZGdnc+ONNzZbxvDhwxk7dizPPPMMr776Kk8++eQJ6xURaY7TZVDZECSO19NRdoxA4osxjRazydNT0RgqosNCibSFEh1+4t6OCGtIwG61tBfB/63dicXGxtKtWzeefvppEhMTycvLY9asWZ73p02bxoIFC7j44ovJysoiMTGR7777jqSkJMaPH8+8efM455xz6NevH1OnTqW+vp7ly5dzzz33AO6ndZ588knGjx+P0+nknnvuITQ09ITtGjBgAG+++SZfffUVsbGxLFy4kMLCQk9gsdvt3HPPPdx9991YrVZOO+00ioqK+Omnn7jhhhs85TQOvo2IiGjy9JKIdD6GYVB+sJ791Q72Vzk4UOWg7Ihg0TSQNNxaOVhHRW29T9oQaWsIHGGHbpNEHxFADh/j4Q4i7p8jrN49UCHeU2AJYmazmddff53/+Z//YdiwYQwaNIi//OUvnHXWWQBYrVY+/PBD/vd//5cLLriA+vp6hgwZwuLFiwE466yzeOONN3jooYf4wx/+QFRUFGeccYan/Mcee4wZM2Zw+umnk5SUxOOPP87q1atP2K45c+awbds2Jk2aRHh4ODfffDMXX3wxZWVlnnPuv/9+QkJCmDt3Lnv27CExMZFbbrmlSTnTpk3jjjvuYNq0aVpkUKSDqalzcqAhfDRuBxr3qw8/VkdJlYPSagf1LXlU5TjCQi3NBwtPCDk6eDTud7GHYFEPR1AzGUcOYmiHjrc8dU1NDdu3b6dPnz76UgwyO3bsoF+/fqxatYoxY8YEujke+jsj0pTLZVB2sO6IoOGg5IgQcvixqpN8ciXCaqFrFyux4VZiwq3N9nRE2UMPCyGHbsNYQzr2GI6O6Hjf30dSD4u0ubq6OkpKSpgzZw4/+9nPgiqsiHQGBx1Od/ioPDpoeELIYbdmDlQ7WjRPx5FCzCZiI6x0DbfSNcK9xUaE0jXCRtfwUGIjrHSLsBEbEUq3CBsx4aHYvXwwQToPBRZpc19++SU///nPGThwIG+++WagmyPS7rlcBiVVDvaUHmRvWQ0lVbUNPR917K+qZX+1+/VAVR37qxwnPcg00h7iDh3hVrpFWBsCh7VJKDn8WJQ9ROM6xGcUWKTNnXXWWUc9Ti0ix1ZeU8fe0hr2lB10h5LSGvaUHmRPmTug7C2t8frR2lCL6VD46NI0hDT2hnQNt9K1i/s1JtyqWy4SUAosIiIBVFvvpKCsht0NQWRv2UF2N7w2hpOWPAVjMkGPSBuJ0WHEdbHRtfHWy2Gv7lDivgXTxabeD2lfFFhERPzE6TIorqz1hBFPr4int6SG4sraFpUVHRZKUkwYSdF2kmLCSIyxkxwTRmJ0GInRdhKi7R1+4jDp3BRYREROgmG4n5zZ0xBE9pYdZE9ZjadXZHfpQQrLa1r0qK491ExStDuEuF/DSI6xkxgd5g4n0XYibPrftXRu+i9ARKQZNXVOd4/IkWNHGvfLalq06JzFbCI+0tbQKxJGUmMoaegpSYoJIzY8VLdnRE5AgUVEOqV6p4tdBw6yvaSK7UVV7Cyp8owd2VtWw/4qR4vK6RZhJbGhNyQ55vAg4j7WI9JGiG7ViLSaAouIdFgul8He8hq2F1WxvaSKHcVVbC92v+btrz7h7Zpwq8XTC5IU3XiL5lDPSGK0XfOGiLQRBRYRadcMw6CootYdREqq2FZ8KJjsLKmmtv7Yj/vaQsz0iYsgtVsEqXERJMceGtSaFB1GVJiepBEJFgosHVhqaip33HEHd9xxR6CbItJqB6ocnts3O0rcgaSxt+R408CHWkykdA2n72HBpG+c+zUhyq4VckXaCQUWEQkaFTV17CiubnL7pnErO1h3zOvMJugZG05qXAR9uoW7e03iIugTF0FyTJjGkIh0AAosEpScTicmkwmzWV80HU1NnZMdDYGk8fbNjuJqthVXnXBOksRoO6ndIujTPYI+3SI8wSSlaxi2EI0lEenIOue3gWGAoyowWwunpH/66adJSkrC5Wp6//2iiy7i+uuvZ+vWrVx00UXEx8fTpUsXxo0bx8cff3zSfyQLFy5k+PDhREREkJKSwm9/+1sqKyubnPPll19y1llnER4eTmxsLJMmTeLAgQMAuFwuHn30Ufr374/NZqNXr17Mnz8fgE8//RSTyURpaamnrDVr1mAymdixYwcAL7zwAjExMbz77rsMGTIEm81GXl4eq1at4he/+AVxcXFER0dz5plnkpub26RdpaWl/OY3vyE+Ph673c6wYcN47733qKqqIioq6qj1it555x0iIiKoqKg46T8vOT5HvYutRZV8vK6Qv32+jfv+8SNXPvM1p2ZlM/j+FZy36HNueTmXR1dsZNm3u8jZsd8TVuK62BiXGsuUtJ7cfd4g/nrVGP59++ms/7/zWDn7HF67+WcsuGQ4N53Rl4lD4unfo4vCikgn0Dl7WOqqYUFSYOq+dw9YI0542pQpU/jd737HJ598wjnnnAPA/v37WbFiBcuXL6eyspILLriA+fPnY7PZePHFF5k8eTIbN26kV69eXjfLbDbzl7/8hT59+rBt2zZ++9vfcvfdd/PUU08B7oBxzjnncP311/P4448TEhLCJ598gtPpHjswe/ZsnnnmGf785z8zYcIE9u7dy4YNG7xqQ3V1NY888gh/+9vf6NatGz169GDbtm1Mnz6dJ554AsMweOyxx7jgggvYvHkzkZGRuFwuzj//fCoqKnj55Zfp168f69atw2KxEBERwdSpU3n++ef59a9/7amn8efIyEiv/5ykqf1VDtbuLmty62ZHSRW7DhzEeZwncKLsIfTp3uWwcSXh9I3rQmpcOJH20Db8BCLSXnTOwNIOxMbGcv755/Pqq696Asubb75JXFwcP//5zzGbzYwcOdJz/kMPPcQ//vEP3n33XW677Tav6zt8YG5qaioPP/wwt9xyiyewPProo4wdO9bzM8DQoUMBqKio4PHHH+fJJ59k+vTpAPTr148JEyZ41Ya6ujqeeuqpJp/r7LPPbnLO008/TUxMDJ999hkXXnghH3/8MTk5Oaxfv56BAwcC0LdvX8/5N954I6eeeip79+4lMTGRffv2sXz58lb1RnVWTpfB5n0VrN55gNydpeTmHWB7cdUxzw+3Wg6NJTns9k2fuAhNlCYiXuucgSU03N3TEai6W+iqq67ipptu4qmnnsJms/HKK68wdepUzGYzlZWVPPDAA7z//vvs3buX+vp6Dh48SF5e3kk16+OPPyYrK4sNGzZQXl5OfX09NTU1VFdXEx4ezpo1a5gyZUqz165fv57a2lpPsDpZVquVESNGNDlWWFjInDlz+PTTT9m3bx9Op5Pq6mrP51yzZg09e/b0hJUjpaenM3ToUP7+978za9YsXn75ZXr37s0ZZ5zRqrZ2BmUH6/gu7wC5eaXk7jzAmvxSKptZhK9v9wj6d+/SZFxJn7gIukfaFEpExGc6Z2AxmVp0WybQJk+ejGEYvP/++4wbN47PP/+cP//5zwDcddddfPTRR/zpT3+if//+hIWF8etf/xqHo2Wzcx5ux44dXHjhhdx6663Mnz+frl278sUXX3DDDTfgcDgIDw8nLCzsmNcf7z3AM3DWOGz8Tl3d0U98hIWFHfUFN336dEpKSnj88cfp3bs3NpuN8ePHez7nieoGdy/L4sWLmTVrFs8//zwzZszQF+kRXC6DbcWV5O4sdfeg5B1g877Ko86LsFoY1SuGtF6xjO4dy5iUWKLDdQtHRPyvcwaWdsJut3PppZfyyiuvsGXLFgYNGsSYMWMA9wDY6667jksuuQSAyspKzwBWb61evRqXy8Vjjz3mCRfLli1rcs6IESPIzs7mwQcfPOr6AQMGEBYWRnZ2NjfeeONR73fv3h2AvXv3EhsbC7h7Rlriyy+/5KmnnuKCCy4AID8/n+Li4ibt2rVrF5s2bTpmL8vVV1/N3XffzV/+8hfWrVvnuW3VmVXW1vN9/qFw8l1eabOPDad2C2dM71jG9IolrXcsA+MjsWjeEhEJAAWWIHfVVVdx4YUX8tNPP3H11Vd7jg8YMIC3336byZMnYzKZuP/++496oqil+vfvT11dHU888QSTJ0/myy+/ZMmSJU3OmT17NsOHD+e3v/0tt9xyC1arlU8++YQpU6YQFxfHPffcw913343VauW0006jqKiIn376iRtuuIH+/fuTkpLCAw88wPz589m0aROPPfZYi9o2YMAAXnrpJcaOHUt5eTm///3vm/SqnHnmmZxxxhlcdtllLFy4kP79+7NhwwZMJhPnnXce4B4PdOmll/L73/+ec889l549e57Un1N7ZRgGO0qqyW0IJ6t3HmBTYQVHjom1h5oZ2TOGMb1j3T0ovWLo1sUWmEaLiBxBgSXInX322XTt2pWNGzdy5ZVXeo4vXLiQ66+/nlNPPdUTGMrLy0+qjpEjR7Jw4UIeeeQRZs+ezRlnnEFWVhbXXnut55yBAwfy4Ycfcu+995Kenk5YWBgZGRlMmzYNgPvvv5+QkBDmzp3Lnj17SExM5JZbbgEgNDSU1157jVtvvZURI0Ywbtw4Hn744WOOiTncs88+y80338yYMWNISUlhwYIF3HXXXU3Oeeutt7jrrruYNm0aVVVV9O/fnz/84Q9Nzrnhhht49dVXuf7660/qz6g9Oehw8v0ud+9J4xiU5hby6xkb5uk5GdMrlsGJkYRqgjURCVImw2jhxCBBrLy8nOjoaMrKyoiKimryXk1NDdu3b6dPnz7Y7fYAtVAC7aWXXuLOO+9kz549WK3W457bnv7OGIbBrgMHyc070NCDUsq6veVHPVJsDTEzPDm6IZzEMKZXLD2igvuziUjHd7zv7yOph0U6tOrqavbu3csf/vAHfvOb35wwrAS7mjona3eXNQSUUlbnHaCo4ujZYROi7KT1dt/WGdM7lqFJUZpcTUTaNQWWTuCVV17hN7/5TbPv9e7dm59++qmNW9R2Hn30UebPn88ZZ5zB7NmzA90cr+0tO+iZ82T1zgP8tKeMOmfT3pMQs4mhydGenpO03rEkxZz46SkRkfZEt4Q6gYqKCgoLC5t9LzQ0lN69e7dxi4JboP7OOOpdrNtbfujJnZ0H2FNWc9R5cV1s7nDS2x1OhidHYw9V74mItD+6JSRNREZGahr6ILSvoobcnaUNA2MP8MOuMmrrmz7pZTGbGJwQ2WRwbErXo+erERHp6DpNYOkAHUnSRvz5d6Wqtp73ftjDazn5rMkvPer9mPBQTzgZ3SuGkT1jiLB1mv9MRUSOqcP/nzA01D0LZ3V1dYtmRRWprq4GDv3d8YUfd5Xx2qo83l2zxzO9vckEA3tENkzMFkNa71j6xEWo90REpBknFVgWL17MH//4RwoKChg5ciRPPPEE6enpzZ5bV1dHVlYWf//739m9ezeDBg3ikUce8UzqdTJlesNisRATE8O+ffsACA8P1xeCNMswDKqrq9m3bx8xMTFYLK0bF1JeU8c/1+zh9Zw8ftpzaI6c1G7hXDGuF5elJdMjsnOOqxIR8ZbXgWXp0qVkZmayZMkSMjIyWLRoEZMmTWLjxo306NHjqPPnzJnDyy+/zDPPPMPgwYP54IMPuOSSS/jqq68YPXr0SZXprYSEBABPaBE5npiYGM/fGW8ZhkFuXimv5eTx/g97OVjnBMBqMXPesASmpqfwsz7dMGt6exERr3j9lFBGRgbjxo3jySefBMDlcpGSksLvfvc7Zs2addT5SUlJ3HfffcycOdNz7LLLLiMsLIyXX375pMo8UktHGTudzmYX3RNpFBoaelI9K6XVDt7O3c3rq/LYVHho0cD+PbowdVwKl47pSdeI9j0HjIiIr/ntKSGHw8Hq1aubzGdhNpuZOHEiK1eubPaa2traox4NDQsL44svvmhVmbW1hybLaumU9BaLpdXd/CKNDMPgm+37eT0nj+VrC3A0POFjDzXzy+FJTEtPIa13rG5Bioj4gFeBpbi4GKfTSXx8fJPj8fHxbNiwodlrJk2axMKFCznjjDPo168f2dnZvP322zidzpMuMysrq9lVg0XaQnFlLW+t3sXSVflsK67yHD8lMYpp6SlcNCqZ6DDfDdgVEZE2eEro8ccf56abbmLw4MGYTCb69evHjBkzeO655066zNmzZ5OZmen5uby8nJSUFF80V6RZLpfBF1uKeX1VHh+tK/TMNhthtfCrUUlMHdeLET2j1ZsSaIYBzjpwOsBV17Bfd+x9z3n17teOwDAAAwxXw3b4/rG2w85xOY//fkvKOKn3mznHbAFzyGGvISf5c3NbS645xjmW0GNfo/8H+I1XgSUuLg6LxXLUrKmFhYXHHKTYvXt33nnnHWpqaigpKSEpKYlZs2bRt2/fky7TZrNhs2nZe/G/wvIa3vg2n6Xf5pO//6Dn+MiUGKaNS+HCkUl06UzzpBgG1FVDbQXUlENtuXvfEwQch778nY4TB4Zmr6lvGiSa3T9G+DCcgf4Tks7OZG4m5IRCiM0ddCyNr9bDjlkPbU2OHX6utZljzZx7zOsPr98K5va3MrtX/6e1Wq2kpaWRnZ3NxRdfDLgHyGZnZ3Pbbbcd91q73U5ycjJ1dXW89dZbXH755a0uU8QfnC6DTzfu47WcfD7ZuM+z8nGkPYRLRiczdVwvhiQdf3BYUHK5wHFY0KhpCBu15VBT1syxxkBS3jScuOoD/Um8Yw5p+B90KFgO32/YGvc70r+OTebDNtMRPx+5Nfe+pZXXe3tOc++bGnp86t29Pq76I7Yjj7XiZ2ed99cfKxwbrobg7Wjb37m3TBbvA0+IHX79bMCa7PU/DTMzM5k+fTpjx44lPT2dRYsWUVVVxYwZMwC49tprSU5OJisrC4BvvvmG3bt3M2rUKHbv3s0DDzyAy+Xi7rvvbnGZIm1h14Fqln27ize+zWfvYWv4jEuNZeq4XlwwPJEwa4AGbTvrGkJDWdPejeZCxeHh4vBjjgrftcdkBlsk2KLB1qXhf24N/2Nr7DI/4b61aWA4cv+41x/jmuau7yghRIKLYbQg5BwWiBpDjNMB9Y6mPx91vPbQNc0eq22mzGaOHX79kbc8Dae7t9SbO6EhgZ181evAcsUVV1BUVMTcuXMpKChg1KhRrFixwjNoNi8vD/NhXU01NTXMmTOHbdu20aVLFy644AJeeuklYmJiWlymiL/UOV1kry/ktZx8/ru5iMaH/GPDQ7l0TE+mpafQv4eP12E6WAr71sH+be6ejROGjwqoP3jCYlvMYgVblDtw2KPc+/boZo41vB6+3/hqjVAQkM7NZGrosWsnt4RdrkO3XZsLTE0CT3OByQEEdombDr9as0hzdpZU8fqqfN74dhfFlYcekT+1Xzempvdi0tB4bCGt7E1x1sP+rVC4Fgp/OrSV5Z98maHhR4SJkwgdoZpdV0SCg1ZrFmlGbb2TD34q5PWcPL7aWuI5HtfFxpSxPblibAqpcREnV3hV8RHBZC3s2+D+l0pzolMgbiCExTYEicgWhI5I960OEZFOSIFFOrwt+yp4LSeft3N3caDafcPWZIIzBnRnWnoK55wST6ilhSPm6x1QvOlQKGkMKJUFzZ8fGgHxQyB+KMQPc7/2GAJhMb75cCIinYQCi3RIBx1Olv+4l9dX5bFqxwHP8cRoO1PGpnD52J70jA0/dgGGARUFRweT4o3Hfkomtg8kDDsUTOKHQkxqu3x8UEQk2CiwSIeybk85r6/K4x/f7aaixh0sLGYTPx/UgyszUjhzYA8sRy48WHcQija4A0nB2kMB5eD+5iuxRR8KJI09Jz1OcT8tIyIifqHAIu1eVW09//p+D6+tyuf7/FLP8Z6xYUwdl8KUsSnER9ndvSZl+Uf3mpRscc+dcCSTGboNaBpM4odCdE89ISMi0sYUWKRdMgyDH3aV8fqqPN5ds4cqh3sSp1CLiXOHJHDV6Fh+FrEPc9Hn8PlhT+jUHmOhzPBuDYHksNs53QdBaGDnHRARETcFFmlXqmrreTt3F6/l5LNubzkmXPQy7eOymH38KmE/w0N3YSteB8t2NF+AOdQdRI68pdMlXr0mIiJBTIFF2g1HvYs7//o2CUVfcLUpjyG2fE4x78Jm1EANsOOICyITj76d022Ae00OERFpVxRYJPgZBuStZMc7WSw58Dnm0MPmOjRwr2/R45QjHh0eChHdAtZkERHxLQUWCV7OOlj3T1j5JOz5joEAJijuMZ64QacdCijd+rlXRBURkQ5LgUWCz8FSyH0Rvvl/UL4LgFqsvFl/OrsGX8c9V/8qsO0TEZE2p8AiwePADvh6CXz3Ejgq3cciuvNB+K+YlT+OiNh4/v3r0wPaRBERCQwFFgm8/Bz3bZ/1/zo0H0qPITB+Jh+aT+c3r63FZIL/d/koIu1aS0dEpDNSYJHAcNbDhvfcQWXXqkPH+50D42dCv7PZV1nLrEWfA/CbM/qR3qdrgBorIiKBpsAibau2AnJfgm/+CqV57mMWK4y4HH42071QIO6J4e558wf2Vzk4JTGKO38xIICNFhGRQFNgkbZRmg85/w9W//3QbLPh3WDcje6tS48mp7+ak8cnG4uwhphZdMUobCF6CkhEpDNTYBH/2p0LKxfDT/8Awz19Pt0GuG/7jJza7NT324oqefi99QDcPWkQgxIi27LFIiIShBRYxPdcTtj4b3dQyfvq0PE+Z8D426D/L8BsbvbSeqeLO5d9z8E6J6f268b1p/Vpo0aLiEgwU2AR33FUwZpX4eunYP829zFzKAz/Nfzst5A44oRFLP5kK9/nlxJpD+FPU0ZiNmt9HxERUWARXyjfCzlPw7fPQU2p+5g9BsZeD+k3QVRSi4r5Pr+Uv/xnMwAPXzyMpBitlCwiIm4KLHLy9v7gvu2z9i1w1bmPde3r7k0ZdSVYI1pcVLWjnjuXrsHpMrhwRCK/GtmykCMiIp2DAot4x+WCLR+550/Z/t9Dx3udCqfeBgPPO6l1fbKWb2BbcRUJUXYevngYJpNuBYmIyCEKLNIydQfh+9dg5VNQ4r5tg8kCQy+B8b+F5LSTLvqTjft46eudAPxxyghiwq2+aLGIiHQgCixyfJX7IOcZ+PZZqC5xH7NFQdp0SP8NxKS0qvj9VQ7ufvMHAK47NZXTB3RvbYtFRKQDUmCR5hWug68Xww/LwOlwH4vp5R6fMvpqsLV+bhTDMLj37R8pqqilf48uzDp/cKvLFBGRjkmBRQ4xDNj6H/f4lK3/OXS85zj3/CmDLwSL7/7KvJ27mxU/FRBiNrHoilHYQzWbrYiINE+BRaCuBn58w/3ET5F7hllMZjhlsjuopKT7vMr8/dXMe/cnAO78xUCGJUf7vA4REek4FFg6s6pi99wpOU9DVZH7mLULjL4GfnYLxKb6pVqny+B/3/ieytp60nrH8psz+vqlHhER6TgUWDqjok3u8Snfvw71Ne5jUcmQcQuMuRbCYvxa/d8+30bO9v1EWC38+fJRhFian6ZfRESkkQJLZ2EY7nlTVi6GzR8cOp44Ck79HQy5CCyhfm/Guj3l/OnDjQDMnTyEXt3C/V6niIi0fwosncVbN8LaNxt+MMGgC9wTvfUaD200SVtNnZM7l66hzmkw8ZR4Lh/bukeiRUSk81Bg6QwKfnSHFZPFvb7Pz26Fbv3avBmPfbiRjYUVxHWx8ofLhms2WxERaTEFls5g9d/dr6dcCL/8U0Ca8NXWYv72xXYA/nDpCOK62ALSDhERaZ802rGjc1S7J38DSLsuIE0or6njrmXfYxgwLT2FiUPiA9IOERFpvxRYOrp170BtGcT0hj5nBaQJ8/75E3vKaujdLZw5vxwSkDaIiEj7psDS0TXeDhpzDZjb/tf93g97+Md3uzGbYOHlo4iw6S6kiIh4T4GlI9u3AfK/dg+2HXV1m1dfUFbDff9YC8DMn/cnrXdsm7dBREQ6BgWWjiy3oXdl4HkQldimVRuGwe/f/J6yg3UMT47mf84Z0Kb1i4hIx6LA0lHV1cD3r7n306a3efUvrtzJ55uLsYWY+fMVowjVbLYiItIK+hbpqDa8BwcPuKfc7z+xTavesq+SBcvdiyjee8Ep9O/RpU3rFxGRjkeBpaNa/YL7dfQ1YLa0WbV1Thd3Ll1Dbb2L0wfEcc3PerdZ3SIi0nEpsHREJVthx+eACUa37WDbv2Rv5sfdZUSHhfLHX4/EbNZstiIi0noKLB1R42DbAb+AmLZbr2f1zgMs/mQLAAsuGU5CtL3N6hYRkY7tpALL4sWLSU1NxW63k5GRQU5OznHPX7RoEYMGDSIsLIyUlBTuvPNOampqPO8/8MADmEymJtvgwYNPpmlS74DvXnHvj2m7wbZVtfVkLluDy4BLRifzyxFt+1SSiIh0bF7P4rV06VIyMzNZsmQJGRkZLFq0iEmTJrFx40Z69Ohx1Pmvvvoqs2bN4rnnnuPUU09l06ZNXHfddZhMJhYuXOg5b+jQoXz88ceHGhaiCcZOysblUF0MXeJh4KQ2q/bh99ezs6SapGg7D/xqaJvVKyIinYPXPSwLFy7kpptuYsaMGQwZMoQlS5YQHh7Oc8891+z5X331FaeddhpXXnklqampnHvuuUybNu2oXpmQkBASEhI8W1xc3Ml9os6u8XbQ6KvBEtomVX68rpDXcvIwmeCxy0cRHdY29YqISOfhVWBxOBysXr2aiRMPPSZrNpuZOHEiK1eubPaaU089ldWrV3sCyrZt21i+fDkXXHBBk/M2b95MUlISffv25aqrriIvL++Y7aitraW8vLzJJsCBHbD1P+790de0SZXFlbXMevsHAG6c0Ifx/bq1Sb0iItK5eHXfpbi4GKfTSXx809V24+Pj2bBhQ7PXXHnllRQXFzNhwgQMw6C+vp5bbrmFe++913NORkYGL7zwAoMGDWLv3r08+OCDnH766axdu5bIyMijyszKyuLBBx/0pumdQ+5L7te+Z0HXPn6vzjAMZr/9I8WVDgYnRPK/5w7ye50iItI5+f0poU8//ZQFCxbw1FNPkZuby9tvv83777/PQw895Dnn/PPPZ8qUKYwYMYJJkyaxfPlySktLWbZsWbNlzp49m7KyMs+Wn5/v748R/Jz18N3L7v2069qkymXf5vPRukKsFvdstvbQtpvvRUREOhevelji4uKwWCwUFhY2OV5YWEhCQkKz19x///1cc8013HjjjQAMHz6cqqoqbr75Zu677z7MzawgHBMTw8CBA9myZUuzZdpsNmw2mzdN7/g2fwCVBRAeB4N+6ffqdpZU8eC/1gHwv+cO5JTEKL/XKSIinZdXPSxWq5W0tDSys7M9x1wuF9nZ2YwfP77Za6qrq48KJRaL+1/ihmE0e01lZSVbt24lMVGPxrbY6obBtqOmQYjVr1U5XQaZy76n2uEkvU9Xbjy9r1/rExER8frZ4czMTKZPn87YsWNJT09n0aJFVFVVMWPGDACuvfZakpOTycrKAmDy5MksXLiQ0aNHk5GRwZYtW7j//vuZPHmyJ7jcddddTJ48md69e7Nnzx7mzZuHxWJh2rRpPvyoHVjZLtjykXt/zHV+r27JZ1tZvfMAXWwhPDZlJBbNZisiIn7mdWC54oorKCoqYu7cuRQUFDBq1ChWrFjhGYibl5fXpEdlzpw5mEwm5syZw+7du+nevTuTJ09m/vz5nnN27drFtGnTKCkpoXv37kyYMIGvv/6a7t27++AjdgLfvQyGC3pPgLj+fq1q7e4y/vzRJgAe/NVQUrqG+7U+ERERAJNxrPsy7Uh5eTnR0dGUlZURFdXJxlK4nLBoBJTvgkufgRGX+62qmjonFz7xBVv2VXL+sASeumoMJpN6V0RE5OR48/2ttYTau63/cYcVewyc8iu/VvXIig1s2VdJ90gb8y8ZrrAiIiJtRoGlvVv9gvt15DQI9d9ig59vLuL5L3cA8Mdfj6BrhH8H9oqIiBxOgaU9qyiAjf9276f5b6HD0moHd73xPQDX/Kw3Zw06es0oERERf1Jgac/WvAKGE1IyoMcpfqvm/n/+RGF5LX3jIrj3Av/VIyIiciwKLO2Vy3Vo7pUx/utd+eea3fzr+z1YzCb+fMUowqyazVZERNqeAkt7tf0zKN0JtigYerFfqthTepA576wF4H/OHsDIlBi/1CMiInIiCiztVW5D78qIy8Ea4fPiXS6Du974noqaekamxDDz5/18XoeIiEhLKbC0R1XFsP49976fbgc9/9UOvtpaQliohUVXjCLEor8qIiISOPoWao/WvAquOkgaDYkjfF78psIKHlmxAYA5F55Cnzjf9+CIiIh4Q4GlvTEMyH3RvZ92nc+Ld9S7uOP1NTjqXfx8UHeuTO/l8zpERES8pcDS3uz8Cko2Q2gEDLvM58X/+eNNrNtbTtcIK4/8eoRmsxURkaCgwNLeNM5sO/wysEX6tOhVO/az5LOtACy4ZDg9Iv03c66IiIg3FFjak+r9sO6f7n0f3w6qqKnjzqVrMAyYktaT84Yl+LR8ERGR1lBgaU9+WAbOWogfDkljfFr0//1rHbsOHKRnbBhzJw/xadkiIiKtpcDSXhjGodtBadPBh2NLVqwt4I3VuzCZ4M9XjCLSHuqzskVERHxBgaW92LUKitZDSBgMn+KzYvdV1HDvP34E4JYz+zEutavPyhYREfEVBZb2onHdoKGXQFiMT4o0DIN73vyB/VUOTkmM4s6JA31SroiIiK8psLQHNWWw9i33fprvZrZ9NSePTzYWYQ0x8/jUUVhD9NdBRESCk76h2oMf34D6g9B9MKRk+KTI7cVVPPzeegDuOW8wA+N9+4i0iIiILymwBLvDB9uO8c1g23qnizuXruFgnZNT+3VjxqmprS5TRETEnxRYgt2e76DgR7BYYeRUnxS5+JOtrMkvJcoewp+mjMRs1my2IiIS3BRYgl1uw2DbIRdBeOuf4Pk+v5S//GczAA9dPIykmLBWlykiIuJvCizBrLYSfnzTvT+m9YNtDzqc3Ll0DU6XweSRSVw0KrnVZYqIiLQFBZZgtvYtcFRC136QOqHVxS1Yvp5txVUkRNl56KKhPmigiIhI21BgCWaNt4N8MLPtJxv38dLXOwH405SRxIRbW9s6ERGRNqPAEqwKfoTdq8EcCiOvbFVRhmEw758/ATDjtFQmDIjzRQtFRETajAJLsGqc2XbwBdCle6uKyt9/kLz91YRaTNx17iAfNE5ERKRtKbAEI0e1e2Vm8Mlg22+2lwAwPDmaCFtIq8sTERFpawoswWjdP6G2DGJ6Qd+ft7q4VTv2AzCujxY2FBGR9kmBJRh5Zra9Fsyt/xWt2nEAgAwFFhERaacUWILNvg2Q/zWYLDDq6tYXV1HD9uIqTCZI663AIiIi7ZMCS7DJfdH9OvA8iEpsdXHfNvSuDIqPJDostNXliYiIBIICSzCpq4HvX3Xvp7V+sC1Aznb3+JV03Q4SEZF2TIElmGx4Dw4egKhk6D/RJ0V6BtymKrCIiEj7pcASTBoH246+BsyWVhdXXlPHur3lgHpYRESkfVNgCRYlW2HH54AJRrd+sC3A6p0HMAzo3S2c+Ci7T8oUEREJBAWWYNG4blD/iRCT4pMiV23X7SAREekYFFiCQb0D1jQOtr3OZ8U2jl9JV2AREZF2ToElGGxcDlVF0CUeBk7ySZE1dU6+zy8DNMOtiIi0fwoswaDxdtCoq8Dim7lSfthVhsPpIq6LjdRu4T4pU0REJFAUWALtwA7Y+ol7f8y1Pis2p2HBw/Q+sZhMJp+VKyIiEggKLIGW+xJgQN+zoGsfnxWb0zDDrcaviIhIR6DAEkjOeljzint/jG9mtgVwugxyd7oDi8aviIhIR3BSgWXx4sWkpqZit9vJyMggJyfnuOcvWrSIQYMGERYWRkpKCnfeeSc1NTWtKrND2PwhVOyF8DgYfKHPil2/t5zK2noibSEMTojyWbkiIiKB4nVgWbp0KZmZmcybN4/c3FxGjhzJpEmT2LdvX7Pnv/rqq8yaNYt58+axfv16nn32WZYuXcq999570mV2GJ7BttMgxOqzYhvXD0pLjcVi1vgVERFp/7wOLAsXLuSmm25ixowZDBkyhCVLlhAeHs5zzz3X7PlfffUVp512GldeeSWpqamce+65TJs2rUkPirdldghlu909LODT20Gg9YNERKTj8SqwOBwOVq9ezcSJhxbmM5vNTJw4kZUrVzZ7zamnnsrq1as9AWXbtm0sX76cCy644KTLrK2tpby8vMnW7nz3Mhgu6D0B4gb4rFjDMA5NGKfxKyIi0kGEeHNycXExTqeT+Pj4Jsfj4+PZsGFDs9dceeWVFBcXM2HCBAzDoL6+nltuucVzS+hkyszKyuLBBx/0punBxeWE715y76f5tndlW3EVxZUOrCFmRvSM9mnZIiIigeL3p4Q+/fRTFixYwFNPPUVubi5vv/0277//Pg899NBJlzl79mzKyso8W35+vg9b3Aa2/gfK8sEeA6f8yqdFN64fNColBltI61d8FhERCQZe9bDExcVhsVgoLCxscrywsJCEhIRmr7n//vu55ppruPHGGwEYPnw4VVVV3Hzzzdx3330nVabNZsNms3nT9OCy+gX368hpEOrbVZRztH6QiIh0QF71sFitVtLS0sjOzvYcc7lcZGdnM378+Gavqa6uxmxuWo3F4v6Xv2EYJ1Vmu1ZRAJtWuPd9fDsIDhtwq/ErIiLSgXjVwwKQmZnJ9OnTGTt2LOnp6SxatIiqqipmzJgBwLXXXktycjJZWVkATJ48mYULFzJ69GgyMjLYsmUL999/P5MnT/YElxOV2aGseQVc9dAzHXqc4tOiC8pqyN9/ELMJxvSK8WnZIiIigeR1YLniiisoKipi7ty5FBQUMGrUKFasWOEZNJuXl9ekR2XOnDmYTCbmzJnD7t276d69O5MnT2b+/PktLrPDcLkg90X3ftp1Pi++8XbQkKQoIu2+WURRREQkGJgMwzAC3YjWKi8vJzo6mrKyMqKignhm122fwosXgS0K/ncDWCN8Wvycd37k5a/zmHFaKvMmD/Vp2SIiIr7mzfe31hJqS42DbYdP8XlYAVi13b1+UIbGr4iISAejwNJWqoph/XvufT/cDiqtdrCxsAKAsXpCSEREOhgFlrby/WvgqoOk0ZA4wufFf7vD3bvSt3sEcV3a8SPfIiIizVBgaQuGAasbFjr08bpBjVZp/hUREenAFFjaws6voGQzhEbA8F/7pYocLXgoIiIdmAJLW8ht6F0ZfhnYIn1efLWjnh93lQFa8FBERDomBRZ/q94PP73j3h9znV+qWJNXSr3LICHKTs/YML/UISIiEkgKLP72wzJw1kL8cEge45cqPOsH9emKyWTySx0iIiKBpMDiT4Zx6HZQ2nTwU5jQ+kEiItLRKbD4065VsG8dhIS5J4vzgzqni9ydpYCeEBIRkY5LgcWfGh9lHnoJhMX4pYqf9pRzsM5JdFgoA3p08UsdIiIigabA4i81ZfDT2+79NP/MvQKwanvj48yxmM0avyIiIh2TAou//PgG1FVD3CBIyfBbNd9s1/wrIiLS8Smw+Evj7aC06/w22NblMvh256EnhERERDoqBRZ/2PMdFPwAFiuMnOq3arYUVVJaXUdYqIVhydF+q0dERCTQFFj8YfUL7tdTfgXh/uv5yGm4HTS6VwyhFv0qRUSk49K3nK/VVsKPb7r3067za1WrtH6QiIh0EgosvvbT2+CohK79IHWC36oxDMPTw6LxKyIi0tEpsPha4+2gMdf6bbAtwK4DB9lbVkOI2cToXjF+q0dERCQYKLD4UsFa2L0azKEw6iq/VtV4O2hocjTh1hC/1iUiIhJoCiy+1Lhu0OALoEt3v1bVGFgydDtIREQ6AQUWX3FUw/dL3ftj/DezbaMcTRgnIiKdiAKLr6z7J9SWQUwv6Ptzv1ZVUlnL1qIqAMb2jvVrXSIiIsFAgcVXGm8HjbkWzP79Y1214wAAA+O7EBth9WtdIiIiwUCBxRf2bYC8lWCywKir/V6d5l8REZHORoHFF3JfdL8OPA+iEv1eneZfERGRzkaBpbXqa+H719z7af4fbFtZW89Pe8oA9bCIiEjnocDSWuv/BQf3Q1Qy9J/o9+pydx7AZUDP2DCSYsL8Xp+IiEgwUGBprcaZbUdfDWaL36trHL+Srt4VERHpRBRYWqNkK+z4HDDB6GvapErP/CsavyIiIp2IAktrNA627T8RYlL8Xl1tvZM1+aWAxq+IiEjnosBysuodsOYV934bDLYF+HFXGbX1LrpFWOnXPaJN6hQREQkGCiwna9O/oaoIusS7H2duAzkN41fGpsZi8uNK0CIiIsFGgeVkrW6Y2XbUVWAJbZMqV3nmX+nWJvWJiIgECwWWk3FgJ2z9j3t/TNsMtnW6DL7d6Z6SX08IiYhIZ6PAcjK+ewkwoO9Z0LVvm1S5saCCipp6IqwWTkmMbJM6RUREgoUCi7ec9fDdy+79MW0z2BYOzb8ypncsIRb92kREpHPRN5+3Nn8IFXshvBsM/mWbVetZP0i3g0REpBNSYPFWbuNg2yshxNYmVRqG4XlCSBPGiYhIZ6TA4o2y3e4eFmjT20E7S6opqqjFajEzKiWmzeoVEREJFgos3vjuZTBc0Ps0iBvQZtU29q6M6BmNPdT/6xWJiIgEGwWWlnI5G54OAtKua9OqV2n9IBER6eQUWFpq6ydQlg/2GDjlV21atVZoFhGRzu6kAsvixYtJTU3FbreTkZFBTk7OMc8966yzMJlMR22//OWhJ2yuu+66o94/77y2me6+xVY/734dORVC7W1W7b7yGnaUVGMyuR9pFhER6YxCvL1g6dKlZGZmsmTJEjIyMli0aBGTJk1i48aN9OjR46jz3377bRwOh+fnkpISRo4cyZQpU5qcd9555/H88897frbZ2uYJnBapKIRNK9z7bTjYFg6NXxmcEEV0WNssASAiIhJsvO5hWbhwITfddBMzZsxgyJAhLFmyhPDwcJ577rlmz+/atSsJCQme7aOPPiI8PPyowGKz2ZqcFxsbRL0Ja14BVz30TIf4IW1adeP4lQyNXxERkU7Mq8DicDhYvXo1EydOPFSA2czEiRNZuXJli8p49tlnmTp1KhEREU2Of/rpp/To0YNBgwZx6623UlJScswyamtrKS8vb7L5jct1aO6VtLbtXQHI2eFeP2icxq+IiEgn5lVgKS4uxul0Eh8f3+R4fHw8BQUFJ7w+JyeHtWvXcuONNzY5ft555/Hiiy+SnZ3NI488wmeffcb555+P0+lstpysrCyio6M9W0pKijcfwzs7/gsHdoAtCoZe4r96mlF2sI4NBe4wNq5PEPU4iYiItDGvx7C0xrPPPsvw4cNJT09vcnzq1Kme/eHDhzNixAj69evHp59+yjnnnHNUObNnzyYzM9Pzc3l5uf9Cy+qG3pXhU8AacfxzfSx35wEMA1K7hdMjsu0G+oqIiAQbr3pY4uLisFgsFBYWNjleWFhIQkLCca+tqqri9ddf54YbbjhhPX379iUuLo4tW7Y0+77NZiMqKqrJ5hdVxbD+X+79gNwOaph/RbeDRESkk/MqsFitVtLS0sjOzvYcc7lcZGdnM378+ONe+8Ybb1BbW8vVV199wnp27dpFSUkJiYmJ3jTP9wwXZPwG+p0DiSPbvPocTRgnIiICnMQtoczMTKZPn87YsWNJT09n0aJFVFVVMWPGDACuvfZakpOTycrKanLds88+y8UXX0y3bt2aHK+srOTBBx/ksssuIyEhga1bt3L33XfTv39/Jk2a1IqP5gNdesCk+QGpuqbOyQ+7SgFNGCciIuJ1YLniiisoKipi7ty5FBQUMGrUKFasWOEZiJuXl4fZ3LTjZuPGjXzxxRd8+OGHR5VnsVj44Ycf+Pvf/05paSlJSUmce+65PPTQQ8E1F0sbW5NfSp3ToEekjd7dwgPdHBERkYAyGYZhBLoRrVVeXk50dDRlZWX+G8/Sxp7I3sxjH23ilyMSWXzlmEA3R0RExOe8+f7WWkJBKkfrB4mIiHgosASheqeL3J2aME5ERKSRAksQWre3nCqHk0h7CIMSIgPdHBERkYBTYAlCjY8zj+0di8VsCnBrREREAk+BJQitahy/0qfbCc4UERHpHBRYgoxhGHzbsOBhutYPEhERARRYgs7WoipKqhzYQswMT44JdHNERESCggJLkGm8HTQqJQZriH49IiIioMASdFZtbxy/oseZRUREGimwBJlvtmuFZhERkSMpsASRPaUH2V16ELMJxvTWgFsREZFGCixBpHH8yrDkaLrYvF6XUkREpMNSYAkiObodJCIi0iwFliDS2MOiwCIiItKUAkuQOFDlYFNhJQDjUjV+RURE5HAKLEGisXelX/cIunWxBbg1IiIiwUWBJUgcWj9It4NERESOpMASJHI86wcpsIiIiBxJgSUIVDvq+Wl3GaABtyIiIs1RYAkC3+WVUu8ySIq20zM2PNDNERERCToKLEHAM/+KbgeJiIg0S4ElCGj+FRERkeNTYAkwR72L3DwNuBURETkeBZYAW7unjJo6FzHhofTv3iXQzREREQlKCiwBtuqw9YPMZlOAWyMiIhKcFFgCzDNhnMaviIiIHJMCSwC5XAarGiaM0xNCIiIix6bAEkCb91VSdrCOsFALQ5OiAt0cERGRoKXAEkA520sAGNM7hlCLfhUiIiLHom/JAGpcP0jzr4iIiByfAkuAGIbheUJI86+IiIgcnwJLgOw6cJCC8hpCLSZGp8QGujkiIiJBTYElQBrXDxqWHE2Y1RLg1oiIiAQ3BZYA0fwrIiIiLafAEiA527XgoYiISEspsARAUUUt24qrABibqvErIiIiJ6LAEgDfNtwOGhQfSUy4NcCtERERCX4KLAGQs0OPM4uIiHhDgSUAGgfcav0gERGRllFgaWMVNXWs21MO6AkhERGRllJgaWO5eaW4DEjpGkZCtD3QzREREWkXFFjaWOOCh3qcWUREpOUUWNrYqu3uBQ91O0hERKTlTiqwLF68mNTUVOx2OxkZGeTk5Bzz3LPOOguTyXTU9stf/tJzjmEYzJ07l8TERMLCwpg4cSKbN28+maYFtdp6J2t2lQJ6QkhERMQbXgeWpUuXkpmZybx588jNzWXkyJFMmjSJffv2NXv+22+/zd69ez3b2rVrsVgsTJkyxXPOo48+yl/+8heWLFnCN998Q0REBJMmTaKmpubkP1kQ+mFXGY56F3FdrPSJiwh0c0RERNoNrwPLwoULuemmm5gxYwZDhgxhyZIlhIeH89xzzzV7fteuXUlISPBsH330EeHh4Z7AYhgGixYtYs6cOVx00UWMGDGCF198kT179vDOO++06sMFm8On4zeZTAFujYiISPvhVWBxOBysXr2aiRMnHirAbGbixImsXLmyRWU8++yzTJ06lYgIdw/D9u3bKSgoaFJmdHQ0GRkZxyyztraW8vLyJlt74Jl/ReNXREREvOJVYCkuLsbpdBIfH9/keHx8PAUFBSe8Picnh7Vr13LjjTd6jjVe502ZWVlZREdHe7aUlBRvPkZAOF0Gq3c0DLjV+BURERGvtOlTQs8++yzDhw8nPT29VeXMnj2bsrIyz5afn++jFvrP+r3lVNTW08UWwimJUYFujoiISLviVWCJi4vDYrFQWFjY5HhhYSEJCQnHvbaqqorXX3+dG264ocnxxuu8KdNmsxEVFdVkC3aNt4PG9I7FYtb4FREREW94FVisVitpaWlkZ2d7jrlcLrKzsxk/fvxxr33jjTeora3l6quvbnK8T58+JCQkNCmzvLycb7755oRltieNgSVDt4NERES8FuLtBZmZmUyfPp2xY8eSnp7OokWLqKqqYsaMGQBce+21JCcnk5WV1eS6Z599losvvphu3bo1OW4ymbjjjjt4+OGHGTBgAH369OH+++8nKSmJiy+++OQ/WRAxDIOchgnjNOBWRETEe14HliuuuIKioiLmzp1LQUEBo0aNYsWKFZ5Bs3l5eZjNTTtuNm7cyBdffMGHH37YbJl33303VVVV3HzzzZSWljJhwgRWrFiB3d4x1trZUVJNcWUtVouZET2jA90cERGRdsdkGIYR6Ea0Vnl5OdHR0ZSVlQXleJZlq/K5+60fGJcayxu3nBro5oiIiAQFb76/tZZQG/hmu+ZfERERaQ0FljbgmTBOA25FREROigKLnxWW15C3vxqzCdJ6xwa6OSIiIu2SAoufNa4fdEpiFFH20AC3RkREpH1SYPEzrR8kIiLSegosftbYw6L1g0RERE6eAosflVXXsbGwAlAPi4iISGsosPjRtzv3YxjQJy6C7pG2QDdHRESk3VJg8aOchvEr6epdERERaRUFFj9atV3zr4iIiPiCAouf1NQ5+XF3GaAeFhERkdZSYPGT7/JKqXMaxEfZSOkaFujmiIiItGsKLH6Sc9j6QSaTKcCtERERad8UWPykccI4zb8iIiLSegosflDvdJGbdwDQ/CsiIiK+oMDiBz/tKafa4STKHsKg+MhAN0dERKTdU2Dxg8PXDzKbNX5FRESktRRY/CBH86+IiIj4lAKLjxmGoRWaRUREfEyBxce27KvkQHUd9lAzw5OjA90cERGRDkGBxcca1w8alRKDNUR/vCIiIr6gb1Qfa1w/KL1PtwC3REREpONQYPGxVTvc869o/SARERHfUWDxod2lB9ldehCL2cToXjGBbo6IiEiHocDiQ423g4YlRRFhCwlwa0RERDoOBRYf+ma7HmcWERHxBwUWH/LMv6IJ40RERHxKgcVH9lc52LKvElAPi4iIiK8psPhIY+/KgB5d6BphDXBrREREOhYFFh9ZpfWDRERE/EaBxUcae1g0/4qIiIjvKbD4QFVtPWv3lAPqYREREfEHBRYfyM07gNNlkBwTRnJMWKCbIyIi0uEosPiAZ/xKamyAWyIiItIxKbD4QOMKzVrwUERExD8UWFrJUe/iu7xSANL7qIdFRETEHxRYWunH3WXU1rvoGmGlX/cugW6OiIhIh6TA0kqNjzOP7R2LyWQKcGtEREQ6JgWWVsrZ3jh+RY8zi4iI+IsCSyu4XAbf7tAKzSIiIv6mwNIKGwsrKK+pJ9xqYWhSVKCbIyIi0mEpsLRC4/iVtN6xhFj0RykiIuIv+pZthZztuh0kIiLSFk4qsCxevJjU1FTsdjsZGRnk5OQc9/zS0lJmzpxJYmIiNpuNgQMHsnz5cs/7DzzwACaTqck2ePDgk2lamzEMw9PDosAiIiLiXyHeXrB06VIyMzNZsmQJGRkZLFq0iEmTJrFx40Z69Ohx1PkOh4Nf/OIX9OjRgzfffJPk5GR27txJTExMk/OGDh3Kxx9/fKhhIV43rU3l7a+msLyWUIuJ0b1iAt0cERGRDs3rVLBw4UJuuukmZsyYAcCSJUt4//33ee6555g1a9ZR5z/33HPs37+fr776itDQUABSU1OPbkhICAkJCd42J2AabwcNT47GHmoJcGtEREQ6Nq9uCTkcDlavXs3EiRMPFWA2M3HiRFauXNnsNe+++y7jx49n5syZxMfHM2zYMBYsWIDT6Wxy3ubNm0lKSqJv375cddVV5OXlHbMdtbW1lJeXN9namud2kOZfERER8TuvAktxcTFOp5P4+Pgmx+Pj4ykoKGj2mm3btvHmm2/idDpZvnw5999/P4899hgPP/yw55yMjAxeeOEFVqxYwV//+le2b9/O6aefTkVFRbNlZmVlER0d7dlSUlK8+Rg+sWrHAQAyFFhERET8zu8DRVwuFz169ODpp5/GYrGQlpbG7t27+eMf/8i8efMAOP/88z3njxgxgoyMDHr37s2yZcu44YYbjipz9uzZZGZmen4uLy9v09Cyr6KG7cVVmEyQ1luBRURExN+8CixxcXFYLBYKCwubHC8sLDzm+JPExERCQ0OxWA6N8zjllFMoKCjA4XBgtVqPuiYmJoaBAweyZcuWZsu02WzYbDZvmu5T3zb0rgyKjyQ6LDRg7RAREeksvLolZLVaSUtLIzs723PM5XKRnZ3N+PHjm73mtNNOY8uWLbhcLs+xTZs2kZiY2GxYAaisrGTr1q0kJiZ607w2o/WDRERE2pbX87BkZmbyzDPP8Pe//53169dz6623UlVV5Xlq6Nprr2X27Nme82+99Vb279/P7bffzqZNm3j//fdZsGABM2fO9Jxz11138dlnn7Fjxw6++uorLrnkEiwWC9OmTfPBR/Q9TRgnIiLStrwew3LFFVdQVFTE3LlzKSgoYNSoUaxYscIzEDcvLw+z+VAOSklJ4YMPPuDOO+9kxIgRJCcnc/vtt3PPPfd4ztm1axfTpk2jpKSE7t27M2HCBL7++mu6d+/ug4/oW+U1dawvcD+VpB4WERGRtmEyDMMIdCNaq7y8nOjoaMrKyoiK8u8ihJ9s3MeM51fRq2s4/737536tS0REpCPz5vtbawl5aZXGr4iIiLQ5BRYvNU4Yl67xKyIiIm1GgcULNXVOvs8vAzTDrYiISFtSYPHC9/mlOJwu4rrYSO0WHujmiIiIdBoKLF7w3A7qE4vJZApwa0RERDoPBRYv5DTMcKv5V0RERNqWAksLOV0GuTvdgUVPCImIiLQtBZYWWr+3nMraeiJtIQxO8O9cLyIiItKUAksLNU7Hn5Yai8Ws8SsiIiJtSYGlhRoH3Gr8ioiISNtTYGkBwzC0QrOIiEgAKbC0wLbiKkqqHFhDzIzoGR3o5oiIiHQ6Ciwt0Lh+0KiUGGwhlgC3RkREpPNRYGmBHK0fJCIiElAKLC3gGXCr8SsiIiIBocByAnvLDpK//yBmE4zpFRPo5oiIiHRKCiwn0Ph00JCkKCLtoQFujYiISOekwHICmn9FREQk8BRYTmDV9ob1gxRYREREAkaB5ThKqx1sLKwANOBWREQkkEIC3YBgZjKZeGDyEHaUVBPXxRbo5oiIiHRaCizHER0WynWn9Ql0M0RERDo93RISERGRoKfAIiIiIkFPgUVERESCngKLiIiIBD0FFhEREQl6CiwiIiIS9BRYREREJOgpsIiIiEjQU2ARERGRoKfAIiIiIkFPgUVERESCngKLiIiIBD0FFhEREQl6HWK1ZsMwACgvLw9wS0RERKSlGr+3G7/Hj6dDBJaKigoAUlJSAtwSERER8VZFRQXR0dHHPcdktCTWBDmXy8WePXuIjIzEZDL5tOzy8nJSUlLIz88nKirKp2WL9/T7CC76fQQf/U6Ci34fx2cYBhUVFSQlJWE2H3+USofoYTGbzfTs2dOvdURFRekvWxDR7yO46PcRfPQ7CS76fRzbiXpWGmnQrYiIiAQ9BRYREREJegosJ2Cz2Zg3bx42my3QTRH0+wg2+n0EH/1Ogot+H77TIQbdioiISMemHhYREREJegosIiIiEvQUWERERCToKbCIiIhI0FNgOYHFixeTmpqK3W4nIyODnJycQDepU8rKymLcuHFERkbSo0cPLr74YjZu3BjoZkmDP/zhD5hMJu64445AN6XT2r17N1dffTXdunUjLCyM4cOH8+233wa6WZ2S0+nk/vvvp0+fPoSFhdGvXz8eeuihFq2XI8emwHIcS5cuJTMzk3nz5pGbm8vIkSOZNGkS+/btC3TTOp3PPvuMmTNn8vXXX/PRRx9RV1fHueeeS1VVVaCb1umtWrWK//f//h8jRowIdFM6rQMHDnDaaacRGhrKv//9b9atW8djjz1GbGxsoJvWKT3yyCP89a9/5cknn2T9+vU88sgjPProozzxxBOBblq7pseajyMjI4Nx48bx5JNPAu41i1JSUvjd737HrFmzAty6zq2oqIgePXrw2WefccYZZwS6OZ1WZWUlY8aM4amnnuLhhx9m1KhRLFq0KNDN6nRmzZrFl19+yeeffx7opghw4YUXEh8fz7PPPus5dtlllxEWFsbLL78cwJa1b+phOQaHw8Hq1auZOHGi55jZbGbixImsXLkygC0TgLKyMgC6du0a4JZ0bjNnzuSXv/xlk/9OpO29++67jB07lilTptCjRw9Gjx7NM888E+hmdVqnnnoq2dnZbNq0CYDvv/+eL774gvPPPz/ALWvfOsTih/5QXFyM0+kkPj6+yfH4+Hg2bNgQoFYJuHu67rjjDk477TSGDRsW6OZ0Wq+//jq5ubmsWrUq0E3p9LZt28Zf//pXMjMzuffee1m1ahX/8z//g9VqZfr06YFuXqcza9YsysvLGTx4MBaLBafTyfz587nqqqsC3bR2TYFF2p2ZM2eydu1avvjii0A3pdPKz8/n9ttv56OPPsJutwe6OZ2ey+Vi7NixLFiwAIDRo0ezdu1alixZosASAMuWLeOVV17h1VdfZejQoaxZs4Y77riDpKQk/T5aQYHlGOLi4rBYLBQWFjY5XlhYSEJCQoBaJbfddhvvvfce//3vf+nZs2egm9NprV69mn379jFmzBjPMafTyX//+1+efPJJamtrsVgsAWxh55KYmMiQIUOaHDvllFN46623AtSizu33v/89s2bNYurUqQAMHz6cnTt3kpWVpcDSChrDcgxWq5W0tDSys7M9x1wuF9nZ2YwfPz6ALeucDMPgtttu4x//+Af/+c9/6NOnT6Cb1Kmdc845/Pjjj6xZs8azjR07lquuuoo1a9YorLSx00477ajH/Ddt2kTv3r0D1KLOrbq6GrO56derxWLB5XIFqEUdg3pYjiMzM5Pp06czduxY0tPTWbRoEVVVVcyYMSPQTet0Zs6cyauvvso///lPIiMjKSgoACA6OpqwsLAAt67ziYyMPGr8UEREBN26ddO4ogC48847OfXUU1mwYAGXX345OTk5PP300zz99NOBblqnNHnyZObPn0+vXr0YOnQo3333HQsXLuT6668PdNPaN0OO64knnjB69eplWK1WIz093fj6668D3aROCWh2e/755wPdNGlw5plnGrfffnugm9Fp/etf/zKGDRtm2Gw2Y/DgwcbTTz8d6CZ1WuXl5cbtt99u9OrVy7Db7Ubfvn2N++67z6itrQ1009o1zcMiIiIiQU9jWERERCToKbCIiIhI0FNgERERkaCnwCIiIiJBT4FFREREgp4Ci4iIiAQ9BRYREREJegosIiIiEvQUWERERCToKbCIiIhI0FNgERERkaCnwCIiIiJB7/8DP3Q7GyVvN5cAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "history = nnlm_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+    "CLASSES = ['github', 'nytimes', 'techcrunch']\n",
+    "NUM_CLASSES = len(CLASSES)\n",
+    "\n",
+    "# Create a StringLookup layer to map string labels to integer indices\n",
+    "label_lookup = tf.keras.layers.StringLookup(vocabulary=CLASSES, num_oov_indices=0)\n",
+    "\n",
+    "def prepare_dataset(dataset):\n",
+    "    def map_fn(features, label):\n",
+    "        # Extract the title string tensor from the dictionary\n",
+    "        title = features['title']\n",
+    "        # Map string label to integer index, then one-hot encode\n",
+    "        label_idx = label_lookup(label)\n",
+    "        label_one_hot = tf.one_hot(label_idx, depth=NUM_CLASSES)\n",
+    "        return title, label_one_hot\n",
+    "\n",
+    "    # Apply mapping and prefetch for training performance\n",
+    "    return dataset.map(map_fn, num_parallel_calls=tf.data.AUTOTUNE).prefetch(tf.data.AUTOTUNE)\n",
+    "\n",
+    "train_ds_prepared = prepare_dataset(train_ds)\n",
+    "eval_ds_prepared = prepare_dataset(eval_ds)\n",
+    "\n",
+    "# Verify prepared dataset structure\n",
+    "for title_batch, label_batch in train_ds_prepared.take(1):\n",
+    "    print(\"Title batch shape:\", title_batch.shape)\n",
+    "    print(\"Label batch shape:\", label_batch.shape)\n",
+    "    print(\"First label vector:\", label_batch[0].numpy())"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "d0kN6g9vN00f"
+   },
    "source": [
-    "## Training Swivel"
+    "## TF-Hub Pre-trained Embedding Modules\n",
+    "\n",
+    "To represent raw text sentences as numerical vectors, we use a pre-trained embedding model from **TensorFlow Hub** via `tensorflow_hub`. Specifically, we will use a **Universal Sentence Encoder (USE)** or a similar text embedding model (`nnlm-en-dim128`).\n",
+    "\n",
+    "Let's test loading a simple TF-Hub text embedding model and passing a sample sentence to see the generated dense vector."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "e_zMItgXN00f"
    },
    "outputs": [],
    "source": [
-    "swivel_model = build_model(swivel_module, name='swivel')"
+    "import tensorflow_hub as hub\n",
+    "\n",
+    "# Using TF-Hub Universal Sentence Encoder / NNLM as our text embedding module\n",
+    "HUB_HANDLE = \"https://tfhub.dev/google/nnlm-en-dim128/2\"\n",
+    "\n",
+    "print(\"Loading embedding module...\")\n",
+    "hub_layer = hub.KerasLayer(HUB_HANDLE, input_shape=[], dtype=tf.string, trainable=False)\n",
+    "print(\"Embedding module loaded.\")\n",
+    "\n",
+    "sample_sentences = [\"TensorFlow is an open-source machine learning library.\"]\n",
+    "embeddings = hub_layer(sample_sentences)\n",
+    "\n",
+    "print(\"Embedding shape:\", embeddings.shape)\n",
+    "print(\"First 5 embedding values:\", embeddings[0, :5].numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3Z8P1n_zN00f"
+   },
+   "source": [
+    "## Model Architecture with Keras Functional API\n",
+    "\n",
+    "Now we build a Deep Neural Network (DNN) classifier using the `tf.keras.Functional` API.\n",
+    "\n",
+    "Our model consists of:\n",
+    "1. **Input Layer**: Takes 1D raw text strings of shape `()`.\n",
+    "2. **Embedding Layer**: The pre-trained TF-Hub layer `hub_layer` transforms strings into dense feature vectors.\n",
+    "3. **Dense Hidden Layer**: A fully-connected layer with `64` units and `relu` activation.\n",
+    "4. **Dropout Layer**: Drops out `0.2` (20%) of units for regularization to prevent overfitting.\n",
+    "5. **Output Layer**: A `Dense` layer with `NUM_CLASSES` (3) units and `softmax` activation to output class probabilities."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "9Btt0W0KN00g"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/10\n",
-      "63/63 [==============================] - 2s 23ms/step - loss: 1.2382 - accuracy: 0.3374 - val_loss: 0.9483 - val_accuracy: 0.5588\n",
-      "Epoch 2/10\n",
-      "63/63 [==============================] - 1s 21ms/step - loss: 0.8401 - accuracy: 0.6325 - val_loss: 0.7546 - val_accuracy: 0.6802\n",
-      "Epoch 3/10\n",
-      "63/63 [==============================] - 1s 21ms/step - loss: 0.6815 - accuracy: 0.7146 - val_loss: 0.6200 - val_accuracy: 0.7458\n",
-      "Epoch 4/10\n",
-      "63/63 [==============================] - 2s 25ms/step - loss: 0.5628 - accuracy: 0.7696 - val_loss: 0.5232 - val_accuracy: 0.7862\n",
-      "Epoch 5/10\n",
-      "63/63 [==============================] - 2s 35ms/step - loss: 0.4836 - accuracy: 0.8041 - val_loss: 0.4642 - val_accuracy: 0.8081\n",
-      "Epoch 6/10\n",
-      "63/63 [==============================] - 2s 31ms/step - loss: 0.4351 - accuracy: 0.8243 - val_loss: 0.4285 - val_accuracy: 0.8258\n",
-      "Epoch 7/10\n",
-      "63/63 [==============================] - 1s 20ms/step - loss: 0.4035 - accuracy: 0.8380 - val_loss: 0.4047 - val_accuracy: 0.8375\n",
-      "Epoch 8/10\n",
-      "63/63 [==============================] - 1s 20ms/step - loss: 0.3808 - accuracy: 0.8480 - val_loss: 0.3875 - val_accuracy: 0.8434\n",
-      "Epoch 9/10\n",
-      "63/63 [==============================] - 2s 33ms/step - loss: 0.3635 - accuracy: 0.8557 - val_loss: 0.3746 - val_accuracy: 0.8500\n",
-      "Epoch 10/10\n",
-      "63/63 [==============================] - 3s 45ms/step - loss: 0.3499 - accuracy: 0.8620 - val_loss: 0.3652 - val_accuracy: 0.8537\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "swivel_history = train_and_evaluate(data, val_data, swivel_model)"
+    "def build_model(embed_layer):\n",
+    "    # Input for string tensors\n",
+    "    text_input = tf.keras.Input(shape=(), dtype=tf.string, name='title_input')\n",
+    "    \n",
+    "    # Pass strings through the pre-trained embedding layer\n",
+    "    x = embed_layer(text_input)\n",
+    "    \n",
+    "    # Dense hidden layer with ReLU and regularizing Dropout\n",
+    "    x = tf.keras.layers.Dense(64, activation='relu', name='hidden_dense')(x)\n",
+    "    x = tf.keras.layers.Dropout(0.2, name='dropout')(x)\n",
+    "    \n",
+    "    # Output softmax predictions across our 3 source classes\n",
+    "    output = tf.keras.layers.Dense(NUM_CLASSES, activation='softmax', name='predictions')(x)\n",
+    "    \n",
+    "    model = tf.keras.Model(inputs=text_input, outputs=output, name='text_classifier_hub')\n",
+    "    return model\n",
+    "\n",
+    "model = build_model(hub_layer)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e_bT7nB0N00g"
+   },
+   "source": [
+    "## Compile and Train the Model\n",
+    "\n",
+    "We compile our model using the `Adam` optimizer, `CategoricalCrossentropy` loss function (since our labels are one-hot encoded), and track `CategoricalAccuracy`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "y-cI7vE0N00g"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Axes: >"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATIFJREFUeJzt3Xd4VFX+x/H3zKT3BEhIg9B7CVVAXVEUAREEOwoWLPywweou2MsK67oqroAI9oLiIkUFCyBIEZcaeu8tjZJeZ+b3x4RANEDKnUyS+byeZx4md+6cc4ZZyWfv95xzTXa73Y6IiIiIi5hdPQARERFxbwojIiIi4lIKIyIiIuJSCiMiIiLiUgojIiIi4lIKIyIiIuJSCiMiIiLiUgojIiIi4lIerh5AWdhsNo4fP05gYCAmk8nVwxEREZEysNvtZGRkEBUVhdl84esfNSKMHD9+nNjYWFcPQ0RERCrgyJEjxMTEXPD1GhFGAgMDAceHCQoKcvFoREREpCzS09OJjY0t/j1+ITUijJwtzQQFBSmMiIiI1DCXmmKhCawiIiLiUgojIiIi4lIKIyIiIuJSNWLOiIiIuDe73U5hYSFWq9XVQ5HzWCwWPDw8Kr3thsKIiIhUa/n5+Zw4cYLs7GxXD0VK4efnR2RkJF5eXhVuQ2FERESqLZvNxoEDB7BYLERFReHl5aXNL6sJu91Ofn4+KSkpHDhwgGbNml10Y7OLURgREZFqKz8/H5vNRmxsLH5+fq4ejvyBr68vnp6eHDp0iPz8fHx8fCrUjiawiohItVfR/8ctzmfEd6NvV0RERFxKYURERERcSmFERETECa666iqeeOIJVw+jRlAYEREREZdy2zBis9mZvf4oIz9ZR1p2gauHIyIi4rbcNoyYzSamL9/H4h1JLNqR5OrhiIhIGdntdrLzC13ysNvtFRrz6dOnGT58OKGhofj5+dGvXz/27NlT/PqhQ4cYOHAgoaGh+Pv706ZNGxYuXFj83mHDhlGvXj18fX1p1qwZH330kSF/l9WFW+8zMqBdFLuTdrNwywlu7hzj6uGIiEgZ5BRYaf38Ty7pe/vLffHzKv+vznvuuYc9e/bw7bffEhQUxN///nf69+/P9u3b8fT0ZPTo0eTn57N8+XL8/f3Zvn07AQEBADz33HNs376dH374gbp167J3715ycnKM/mgu5d5hpH193lq8mxV7UkjLKSDY19PVQxIRkVrmbAhZtWoVPXv2BOCLL74gNjaWefPmccstt3D48GGGDh1Ku3btAGjcuHHx+w8fPkx8fDxdunQBIC4urso/g7O5dRhpGh5I84gAdidlsmh7kq6OiIjUAL6eFra/3NdlfZfXjh078PDwoHv37sXH6tSpQ4sWLdixYwcAjz32GKNGjeLnn3+mT58+DB06lPbt2wMwatQohg4dyoYNG7juuusYPHhwcaipLdx2zshZ/dtFArBwywkXj0RERMrCZDLh5+Xhkoez7oszcuRI9u/fz913382WLVvo0qUL77zzDgD9+vXj0KFDjBkzhuPHj3PNNdfw5JNPOmUcruL2YWRAURg5W6oRERExUqtWrSgsLOR///tf8bGTJ0+ya9cuWrduXXwsNjaWhx9+mDlz5vDXv/6VGTNmFL9Wr149RowYweeff86kSZOYPn16lX4GZ3P7MNIsIpBm4QEUWO0s3q5VNSIiYqxmzZoxaNAgHnjgAVauXMmmTZu46667iI6OZtCgQQA88cQT/PTTTxw4cIANGzawdOlSWrVqBcDzzz/P/Pnz2bt3L9u2beP7778vfq22cPswAjCgvUo1IiLiPB999BGdO3fmhhtuoEePHtjtdhYuXIinp2PhhNVqZfTo0bRq1Yrrr7+e5s2bM3XqVAC8vLwYP3487du358orr8RisfDVV1+58uMYzmSv6KLpKpSenk5wcDBpaWkEBQUZ3v6epAyufWs5nhYT6569VqtqRESqidzcXA4cOECjRo0qfHt6ca6LfUdl/f2tKyOoVCMiIuJKCiNFtKpGRETENcodRpYvX87AgQOJiorCZDIxb968i54/Z84crr32WurVq0dQUBA9evTgp59cs3PexZydN7JiTyrpuVpVIyIiUlXKHUaysrLo0KEDU6ZMKdP5y5cv59prr2XhwoWsX7+e3r17M3DgQDZu3FjuwTpT86JSTb7VplKNiIhIFSr3Dqz9+vWjX79+ZT5/0qRJJX6eMGEC8+fP57vvviM+Pr683TtV/3aRvL1kDwu3nGBIJ+3GKiIiUhWqfM6IzWYjIyODsLCwC56Tl5dHenp6iUdVOFuqWb5bpRoREZGqUuVh5N///jeZmZnceuutFzxn4sSJBAcHFz9iY2OrZGzNIwJpqlKNiIhIlarSMDJz5kxeeuklvv76a8LDwy943vjx40lLSyt+HDlypMrGqFU1IiIiVavKwshXX33FyJEj+frrr+nTp89Fz/X29iYoKKjEo6qcvVeNSjUiIiJVo0rCyJdffsm9997Ll19+yYABA6qiywprHhFQXKpZskOlGhERcY24uLg/LQK5kLJstVGdlTuMZGZmkpCQQEJCAgAHDhwgISGBw4cPA44Sy/Dhw4vPnzlzJsOHD+eNN96ge/fuJCYmkpiYSFpamjGfwGAmk6m4VLNgs0o1IiIizlbuMLJu3Tri4+OLl+WOHTuW+Ph4nn/+eQBOnDhRHEwApk+fTmFhIaNHjyYyMrL48fjjjxv0EYynUo2IiEjVKXcYueqqq7Db7X96fPzxxwB8/PHHLFu2rPj8ZcuWXfT86qh5RABN6vmrVCMiUh3Z7ZCf5ZpHGe8tO336dKKiorDZbCWODxo0iPvuu499+/YxaNAgIiIiCAgIoGvXrixevNiwv6ItW7Zw9dVX4+vrS506dXjwwQfJzMwsfn3ZsmV069YNf39/QkJC6NWrF4cOHQJg06ZN9O7dm8DAQIKCgujcuTPr1q0zbGylKfemZ+7AZDIxoF0k//llLws2J3JTvDZAExGpNgqyYUKUa/p++jh4+V/ytFtuuYVHH32UpUuXcs011wBw6tQpfvzxRxYuXEhmZib9+/fn1Vdfxdvbm08//ZSBAweya9cuGjRoUKkhZmVl0bdvX3r06MHatWtJTk5m5MiRPPLII3z88ccUFhYyePBgHnjgAb788kvy8/NZs2YNJpMJgGHDhhEfH8+7776LxWIhISEBT0/n3s1eYeQCBrSP4j+/7GX57hQycgsI9HHuFyEiIrVHaGgo/fr1Y+bMmcVhZPbs2dStW5fevXtjNpvp0KFD8fmvvPIKc+fO5dtvv+WRRx6pVN8zZ84kNzeXTz/9FH9/R3CaPHkyAwcO5LXXXsPT05O0tDRuuOEGmjRpAkCrVq2K33/48GGeeuopWrZsCUCzZs0qNZ6yUBi5gLOlmn0pWSzekaSrIyIi1YWnn+MKhav6LqNhw4bxwAMPMHXqVLy9vfniiy+4/fbbMZvNZGZm8uKLL7JgwQJOnDhBYWEhOTk5JeZcVtSOHTvo0KFDcRAB6NWrFzabjV27dnHllVdyzz330LdvX6699lr69OnDrbfeSmSkY77k2LFjGTlyJJ999hl9+vThlltuKQ4tzlLlO7DWFGdLNQALNie6eDQiIlLMZHKUSlzxKCpllMXAgQOx2+0sWLCAI0eOsGLFCoYNGwbAk08+ydy5c5kwYQIrVqwgISGBdu3akZ+f76y/tRI++ugjVq9eTc+ePZk1axbNmzfn999/B+DFF19k27ZtDBgwgF9++YXWrVszd+5cp45HYeQi+p+9V80eR6lGRESkrHx8fBgyZAhffPEFX375JS1atKBTp04ArFq1invuuYebbrqJdu3aUb9+fQ4ePGhIv61atWLTpk1kZWUVH1u1ahVms5kWLVoUH4uPj2f8+PH89ttvtG3blpkzZxa/1rx5c8aMGcPPP//MkCFD+OijjwwZ24UojFxEi4hAGtfzJ7/QxpIdya4ejoiI1DDDhg1jwYIFfPjhh8VXRcAxD2POnDkkJCSwadMm7rzzzj+tvKlMnz4+PowYMYKtW7eydOlSHn30Ue6++24iIiI4cOAA48ePZ/Xq1Rw6dIiff/6ZPXv20KpVK3JycnjkkUdYtmwZhw4dYtWqVaxdu7bEnBJnUBi5iBKlGt2rRkREyunqq68mLCyMXbt2ceeddxYff/PNNwkNDaVnz54MHDiQvn37Fl81qSw/Pz9++uknTp06RdeuXbn55pu55pprmDx5cvHrO3fuZOjQoTRv3pwHH3yQ0aNH89BDD2GxWDh58iTDhw+nefPm3HrrrfTr14+XXnrJkLFdiMluL+OiaRdKT08nODiYtLS0Kr1PDcDOxHSun7QCLw8z65/to1U1IiJVKDc3lwMHDtCoUSN8fHxcPRwpxcW+o7L+/taVkUtQqUZERMS5FEYuQaUaERFxpS+++IKAgIBSH23atHH18AyhfUbKoH+7SN75ZS+/agM0ERGpYjfeeCPdu3cv9TVn74xaVRRGyqBl/UAa1/Vnf2oWv+xMZlDHaFcPSURE3ERgYCCBgYGuHoZTqUxTBiaTiQHtz26AplKNiEhVqwFrLdyWEd+NwkgZ9S+aN7JstzZAExGpKmfLENnZ2S4eiVzI2e+mMiUjlWnKSKUaEZGqZ7FYCAkJITnZsZrRz8+v+O6y4lp2u53s7GySk5MJCQnBYrFUuC2FkTIymUz0bxfJ5KV7WbD5hMKIiEgVqV+/PkBxIJHqJSQkpPg7qiiFkXI4G0aW7U4hM6+QAG/99YmIOJvJZCIyMpLw8HAKClQmr048PT0rdUXkLP02LYdWkYE0quvPgdQsluxI0tUREZEqZLFYDPnFJ9WPJrCWw/kboC3UBmgiIiKGUBgpp7OrapbucpRqREREpHIURsrpbKnGca+aJFcPR0REpMZTGCknx6oax6xhlWpEREQqT2GkAoo3QNuVQpZKNSIiIpWiMFIBrSODaFTXn7xCG0t2at27iIhIZSiMVMD5pZoFm4+7eDQiIiI1m8JIBalUIyIiYgyFkQpqHRlEXB0/lWpEREQqSWGkgs7eqwZg4WatqhEREakohZFKGND+7AZoySrViIiIVJDCSCWoVCMiIlJ5CiOVoFKNiIhI5SmMVNK5e9WoVCMiIlIRCiOV1CYqiIZFpZpfVKoREREpN4WRSipRqtG9akRERMpNYcQAA1SqERERqTCFEQOcLdXkFqhUIyIiUl4KIwZQqUZERKTiFEYMcn6pJjtfpRoREZGyUhgxSJuoIBqEqVQjIiJSXgojBjGZTMXbw6tUIyIiUnYKIwY6W6r5ZadKNSIiImWlMGIglWpERETKT2HEQFpVIyIiUn4KIwZTqUZERKR8FEYM1jY6iNgwX3ILbCzdmeLq4YiIiFR7CiMGM5lMDGgXBahUIyIiUhYKI05wtlSzZGeSSjUiIiKXoDDiBCrViIiIlJ3CiBNoVY2IiEjZKYw4yfmranLyrS4ejYiISPWlMOIk7aKDiQ3zJafAytJd2gBNRETkQhRGnOT8Us2CzSrViIiIXIjCiBOpVCMiInJpCiNO1C46mJhQlWpEREQuRmHEiRwboBWVarSqRkREpFQKI052dt7ILztUqhERESmNwoiTtY9RqUZERORiFEacTKUaERGRi1MYqQIq1YiIiFyYwkgVOL9Us0ylGhERkRIURqpAiQ3QVKoREREpQWGkimgDNBERkdIpjFSRs6Wa7HyVakRERM6nMFJFVKoREREpXbnDyPLlyxk4cCBRUVGYTCbmzZt3yfcsW7aMTp064e3tTdOmTfn4448rMNSar/95pZrcApVqREREoAJhJCsriw4dOjBlypQynX/gwAEGDBhA7969SUhI4IknnmDkyJH89NNP5R5sTdchJpjoEJVqREREzudR3jf069ePfv36lfn8adOm0ahRI9544w0AWrVqxcqVK3nrrbfo27dvebuv0RylmvrMWHGABVsSub5tpKuHJCIi4nJOnzOyevVq+vTpU+JY3759Wb16tbO7rpYGtI8CYMmOJJVqREREqIIwkpiYSERERIljERERpKenk5OTU+p78vLySE9PL/GoLVSqERERKalarqaZOHEiwcHBxY/Y2FhXD8kwZ0s1AAu2JLp4NCIiIq7n9DBSv359kpKSShxLSkoiKCgIX1/fUt8zfvx40tLSih9Hjhxx9jCr1NlVNSrViIiIVEEY6dGjB0uWLClxbNGiRfTo0eOC7/H29iYoKKjEozbpGBtyXqkmxdXDERERcalyh5HMzEwSEhJISEgAHEt3ExISOHz4MOC4qjF8+PDi8x9++GH279/P3/72N3bu3MnUqVP5+uuvGTNmjDGfoAYqWarRBmgiIuLeyh1G1q1bR3x8PPHx8QCMHTuW+Ph4nn/+eQBOnDhRHEwAGjVqxIIFC1i0aBEdOnTgjTfe4P3333e7Zb1/pFKNiIiIg8lut9tdPYhLSU9PJzg4mLS0tFpTsrHb7Vz+2lKOnclh2l2dub5tfVcPSURExFBl/f1dLVfTuAOTyUS/ogCyUKUaERFxYwojLtS/vUo1IiIiCiMuFF+0qiYr38qvu7WqRkRE3JPCiAudX6pZsFmlGhERcU8KIy6mUo2IiLg7hREXi48NISrYR6UaERFxWwojLmYymehXtOeIVtWIiIg7UhipBs5ugLZ4u0o1IiLifhRGqgGVakRExJ0pjFQDZrNKNSIi4r4URqqJc/eqSVapRkRE3IrCyJkjrh4B4CjVRAb7kJlXyHKVakRExI24bxgpyIV5/weTu0LqXlePxlGqaatSjYiIuB/3DSMWL0g7CoU5MO9hsBa6ekQMKNoAbbFKNSIi4kbcN4yYzTB4KngHwdG18Nvbrh6RSjUiIuKW3DeMAATHQL/XHM+XToTELS4djko1IiLijtw7jAB0uANaDABbAcx9GArzXDqcAe0dN85TqUZERNyFwojJBAPfBr86kLQVlv3TpcOJjw2lfpCjVLNiT6pLxyIiIlIVFEYAAurBDZMcz1dNgiNrXDYUxwZojqsjKtWIiIg7UBg5q/WN0P42sNsc5Zr8LJcN5YaiVTWLdK8aERFxAwoj5+v3LwiMglP7YPGLLhuGSjUiIuJOFEbO5xsCg6c4nq+ZDvuXuWQYKtWIiIg7URj5oyZXQ9eRjufzRkNumkuGMaDoXjWLtyeRV6hSjYiI1F4KI6W59mUIawzpR+GHcS4ZQqcGjlJNRl4hK3arVCMiIrWXwkhpvPxh8DQwmWHTTNi5oMqHcH6pZoFKNSIiUospjFxIg+7Q8zHH8+8eh6yqvzqhUo2IiLgDhZGL6f00hLeBrBT4/gmw26u0e5VqRETEHSiMXIyHN9w0DcyesOM72Px1lXZvNpu4vq1W1YiISO2mMHIpke3hqr87ni98CtKOVmn3A87bAE2lGhERqY0URsqi1xiI7gJ5aTD/kSot13RuEEpEkDcZeYWs1AZoIiJSCymMlIXFw1Gu8fCF/Uth7ftV1rXZbKJfW8fVkQWbVaoREZHaR2GkrOo2gz4vOp4veh5O7quyrlWqERGR2kxhpDy6PQhxV0BBNswbBbaqCQYq1YiISG2mMFIeZjMMngpegXDkf/Dbf6qo2/NKNVpVIyIitYzCSHmFNIB+/3Q8XzoBkrZVSbf926lUIyIitZPCSEV0HAbN+4E1H+Y8BIX5Tu+yS8NQwgO9ychVqUZERGoXhZGKMJlg4NvgGwZJW+DX15zepdlsKr46olKNiIjUJgojFRUYATe85Xi+8k04us7pXapUIyIitZHCSGW0GQztbgG7DeY+BPnZTu3u/FLNqr0q1YiISO2gMFJZ/V+HwEg4uReWvOTUrhyrahz3qlmwOdGpfYmIiFQVhZHK8g2FGyc7nv9vGuz/1andnS3V/Lw9kfxCm1P7EhERqQoKI0Zo1gc63+t4Pn805KY5rasucWHnVtXsTXFaPyIiIlVFYcQo1/0DQuMg7Qj8+LTTurGoVCMiIrWMwohRvANg8LuACRI+h10/OK2rc6tqVKoREZGaT2HESA17Qs9HHM+/fQyyTjqlmy5xYdQL9CZdq2pERKQWUBgxWu9noV4ryEqGBWPAbje8ixKlGm2AJiIiNZzCiNE8feCmaWD2gO3zYctsp3Qz4Oyqmm0q1YiISM2mMOIMUR3hyr85ni/8K6QfN7wLlWpERKS2UBhxlivGQlQnxzLfbx81vFyjUo2IiNQWCiPOYvGEm94DDx/YuxjWf2R4F/1VqhERkVpAYcSZ6jWHa15wPP/pWTi139Dmu8aFUTegqFSzT6UaERGpmRRGnK37wxB3BRRkwbz/A5txd9u1mE30b3d2AzSVakREpGZSGHE2sxkGTQGvQDi8GlZPMbR5lWpERKSmUxipCqEN4foJjue/vALJOwxr+vxSzY/btD28iIjUPAojVSX+bmjWF6z5MOdBKMw3pFmL2cStXWIAeHrOFnYnZRjSroiISFVRGKkqJhPc+B/wDYXEzbD8dcOafqJPc7o3CiMzr5D7P1nLqSxjgo6IiEhVUBipSoH1YcCbjucr3oBj6w1p1svDzLS7OtOwjh9HTuXw8GfrNX9ERERqDIWRqtZ2CLQdCnYrzH0YCnIMaTbU34sPRnQh0NuDNQdP8czcLdidcF8cERERoymMuEL/f0NAfUjdDUteNqzZpuGBvHNnPGYT/Hf9Ud5fccCwtkVERJxFYcQV/MLgxnccz3+fCgdWGNb0VS3Cee6G1gBM+GEHS3YkGda2iIiIMyiMuErz66DTCMfzef8HuemGNX1Pzzju7N4Aux0e+3IjuxK1wkZERKovhRFX6vsqhDSEtMPw09OGNWsymXjpxjb0bFKHrHwr93+yltTMPMPaFxERMZLCiCt5B8LgdwETbPwMdv9kWNOeFjNTh3Uiro4fR087VtjkFRq3Fb2IiIhRFEZcLa4X9BjteP7to5B9yrCmQ/y8+OCergT6eLDu0GnGz9EKGxERqX4URqqDq5+Dui0gMwkWjDW06Sb1Apg6rBMWs4k5G47x3nJj7xwsIiJSWRUKI1OmTCEuLg4fHx+6d+/OmjVrLnr+pEmTaNGiBb6+vsTGxjJmzBhyc3MrNOBaydMHbpoGJgtsmwtbZhva/BXN6vHCQMcKm9d+3Mmi7VphIyIi1Ue5w8isWbMYO3YsL7zwAhs2bKBDhw707duX5OTkUs+fOXMm48aN44UXXmDHjh188MEHzJo1i6efNm7CZq0Q3QmufMrxfMFfIf2Eoc0P7xHH3Zc1xG6Hx7/ayI4Txq3eERERqYxyh5E333yTBx54gHvvvZfWrVszbdo0/Pz8+PDDD0s9/7fffqNXr17ceeedxMXFcd1113HHHXdc8mqKW7rySYjsCLlnHPNHDJ7f8fzA1lzetC7Z+VZGfrKOlAytsBEREdcrVxjJz89n/fr19OnT51wDZjN9+vRh9erVpb6nZ8+erF+/vjh87N+/n4ULF9K/f/8L9pOXl0d6enqJh1uweMJN74HFG/Yugg2fGNq8p8XMlDs70biuP8fO5PDQZ+vILdAKGxERca1yhZHU1FSsVisREREljkdERJCYmFjqe+68805efvllLr/8cjw9PWnSpAlXXXXVRcs0EydOJDg4uPgRGxtbnmHWbOEt4ZrnHM9/egZOHzS0+WA/T94f0YUgHw82HD6jFTYiIuJyTl9Ns2zZMiZMmMDUqVPZsGEDc+bMYcGCBbzyyisXfM/48eNJS0srfhw5csTZw6xeLvs/aNAT8jMdu7PajL0Db+N6Abx7V2csZhNzNx5j6rJ9hrYvIiJSHuUKI3Xr1sVisZCUVHI1RlJSEvXr1y/1Pc899xx33303I0eOpF27dtx0001MmDCBiRMnYrvAL1lvb2+CgoJKPNyK2QKDp4KnPxxa5bh/jcF6Na3LSze2AeD1n3bx49bSr2yJiIg4W7nCiJeXF507d2bJkiXFx2w2G0uWLKFHjx6lvic7OxuzuWQ3FosFQOWBiwlr5NguHhx39k3eaXgXd13WkHt6xgEwZlYCW4+lGd6HiIjIpZS7TDN27FhmzJjBJ598wo4dOxg1ahRZWVnce++9AAwfPpzx48cXnz9w4EDeffddvvrqKw4cOMCiRYt47rnnGDhwYHEokQvofA80vRaseTD3IbAWGN7FswNacUWzuuQUWHng03UkZ2j/FxERqVoe5X3DbbfdRkpKCs8//zyJiYl07NiRH3/8sXhS6+HDh0tcCXn22WcxmUw8++yzHDt2jHr16jFw4EBeffVV4z5FbWUywY3vwNTL4EQCrHgDrhpnaBceFjOT7+zEkKmr2JeSxYOfruerBy/Dx1NBUUREqobJXgNqJenp6QQHB5OWluZ+80fAsSPrN/eD2QNGLoaoeMO7OJiaxeCpqziTXcCNHaJ4+/aOmEwmw/sRERH3Udbf37o3TU3Q7mZocxPYCmHuw1BgfCklrq4/U4d1wsNs4ttNx5n8y17D+xARESmNwkhNMeBNCIiAlJ3wy4WXRVdGzyZ1eWVwWwDeWLSbH7YYuyW9iIhIaRRGagq/MMf8EYDVU+DgKqd0c0e3BtzXqxEAY77WChsREXE+hZGapHlfiL8bsMO8UZCX4ZRunu7fkqta1CO3wMbIT9aRlK4VNiIi4jwKIzVN3wkQ3ADOHIKfn3VKFx4WM/+5I55m4QEkpufywKfryMnXPWxERMQ5FEZqGp8gx+6sAOs/hj2LnNJNkI8nH4zoSqifJ5uPpvHk7E3apE5ERJxCYaQmanSF4/41APMfgexTTummQR0/pt3VGU+LiQWbT/D2kj1O6UdERNybwkhNdc3zULc5ZCbCwied1k33xnX4R9EKm0mL9/D95uNO60tERNyTwkhN5ekLN00DkwW2fgNb5zitq9u6NuCBKxwrbP769SY2HTnjtL5ERMT9KIzUZNGd4Yq/Op4vGAvpzrtqMa5fK65uGU5eoY0HPl1HYppW2IiIiDEURmq6K5+C+u0h5zR8OggykpzSjcVs4u3bO9I8IoDkjDxGfrpWK2xERMQQCiM1nYcX3PY5BMVA6m749EbITHFKV4FFK2zC/L3Yeiydv/43AZtNK2xERKRyFEZqg9CGcM93EBjl2C7+0xsh66RTuooN8+O9ux0rbBZuSWTS4t1O6UdERNyHwkhtEdYY7vkeAupD8nZHycZJS367xoUx4aZ2APznl73MTzjmlH5ERMQ9KIzUJnWaOAKJfzgkbXEEkpzTTunqli6xPPSXxgA8NXszGw87px8REan9FEZqm7rNYMR34F8PEjfDZzdBzhmndPW3vi3p0yqC/EIbD362nuNncpzSj4iI1G4KI7VReEsY/i341YHjG+HzIZBr/N13LWYTk27vSMv6gaRk5DHyk3Vk5xca3o+IiNRuCiO1VURrRyDxDYVj6+Hzm51yl98Abw/eH9GFugFebD+RzphZWmEjIiLlozBSm9VvC8Png08IHF0DX9wCeZmGdxMT6lhh42Ux89O2JN5cpBU2IiJSdgojtV1kBxg+D7yD4fBqmHkr5GcZ3k3nhmH8c6hjhc3kpXuZt1ErbEREpGwURtxBVDzcPRe8g+DQKph5G+RnG97NkE4x/N9VTQD42zebWX9IK2xEROTSFEbcRUxnuGsOeAXCwRXw1R1QYPzqlyeva8F1rR0rbB76bB1HTxsfekREpHZRGHEnsV3hrtng6Q/7l8Gsu6DA2Bvemc0m3rqtI60ig0jNzGfkJ+vIytMKGxERuTCFEXfT4DIY9l/w9IO9i+Hr4VCYZ2gX/sUrbLzZmZjBE1phIyIiF6Ew4o7iesGdX4OHL+z5Cf57DxTmG9pFdIgv04d3xsvDzKLtSbz+8y5D2xcRkdpDYcRdNboC7vwKPHxg10KYfS9YCwztolODUF6/uT0A7y7bxzfrjxravoiI1A4KI+6s8VVw+0yweMPO7+Gb+8Fq7PyOQR2jefTqpgCMn7OFdQedc/M+ERGpuRRG3F3Ta+C2z8HiBdvnw9wHDQ8kY/o0p1/b+uRbbTz02XqOnNIKGxEROUdhRKD5dXDrp2D2hK3fwLxRYLMa1rzZbOKNWzvQJiqIk1mOFTaZWmEjIiJFFEbEoUU/uOVjMHvAlq9h/mhDA4mfl2OFTb1Ab3YlZfD4lxuxaoWNiIigMCLna3UD3PwhmCyw6Uv47jGw2QxrPjLYlxnDu+DtYWbJzmT+9eNOw9oWEZGaS2FESmo9CIa+DyYzbPwcvn/C0EDSMTaEf9/SAYD3lu/n63VHDGtbRERqJoUR+bO2Q+Cm6Y5AsuETWPgk2I0rqQzsEMXj1zQD4Jm5W1hzQCtsRETcmcKIlK79LTD4XcAE6z6AH/5uaCB5/JpmDGgXSYHVzkOfrePwSa2wERFxVwojcmEdbodBUwATrHkPfnrasEBiNpv49y0daBcdzOnsAu7/ZC0ZucZuuiYiIjWDwohcXPwwGPi24/nvU2HRc4YFEl8vCzOGdyEiyJs9yZk8phU2IiJuSWFELq3zCLjhLcfz396BJS8ZFkjqB/swY3gXfDzNLN2VwsSFOwxpV0REag6FESmbLvdB/387nq98C5ZOMKzp9jEhvHFLRwDeX3mA937dZ1jbIiJS/SmMSNl1ewCu/6fj+fJ/wbLXDGt6QPtInryuOQATf9jJK99vx6aSjYiIW1AYkfK5bBRc96rj+bIJsPx1w5oe3bspT/dvCcAHKw/w+KwE8gqN2wVWRESqJ4URKb+ej0CflxzPf/mHo2xjAJPJxINXNmHSbR3xMJv4btNx7v1Iq2xERGo7hRGpmMufgKufczxf/KJjYqtBBsdH89G9XfH3svDbvpPc+t7vJKfnGta+iIhULwojUnFXPglXPe14/vOz8Pu7hjV9RbN6zHqoB3UDvNhxIp2bpv7GvpRMw9oXEZHqQ2FEKueqv8OVf3M8/3EcrJlhWNNto4OZM6oXcXX8OHYmh5vf/Y0Nh08b1r6IiFQPCiNSeb2fhsvHOp4vfBLWfmBY0w3q+DF7VE86xDh2ar1zxu8s2ZFkWPsiIuJ6CiNSeSYTXPM89HzM8fOCsbD+E8OarxvgzcwHLuOqFvXILbDx4GfrmbX2sGHti4iIaymMiDFMJrj2ZbhstOPn7x6HjZ8b1ry/twczhnfh5s4xWG12/v7NFv6zZA92A2/eJyIirqEwIsYxmaDvq9DtIcAO8x+BTV8Z1rynxczrN7dndO8mALy5aDfPztuq+9mIiNRwCiNiLJMJ+r0GXe4H7DBvFGz+r4HNm3iqb0teHtQGkwm++N9hRn2+ntwCbY4mIlJTKYyI8Uwmx31sOt8DdhvMfRC2fmNoF8N7xDH1zk54eZj5eXsSd73/P85k5xvah4iIVA2FEXEOsxkGvAXxdzkCyTcPwPb5hnbRr10kn93XjUAfD9YdOs3N01Zz7EyOoX2IiIjzKYyI85jNMPAd6HAn2K0w+z7Y8b2hXXRvXIfZD/ekfpAPe5MzGTr1N3Ymphvah4iIOJfCiDiX2QyDJkO7W8FWCP+9B3b9YGgXLeoHMuf/etIsPIDE9Fxumbaa3/efNLQPERFxHoURcT6zBQa/C22Hgq0Avh4Ou382tIuoEF/++3APusaFkpFbyPAP1rBwywlD+xAREedQGJGqYfGAm6ZD68FgzYdZd8HexYZ2EeLnxWf3d6dvmwjyrTZGz9zAJ78dNLQPERExnsKIVB2LBwx9H1oNBGsefDUM9i01tAsfTwtTh3XmrssaYLfDC99u418/7tTmaCIi1ZjCiFQtiycM/RBaDIDCXPjyDjiw3NguzCZeGdSWJ69rDsDUZft48r+bKbDaDO1HRESMoTAiVc/DC275GJpfD4U5MPM2OLjK0C5MJhOPXN2Mfw1tj8Vs4psNRxn5yTqy8goN7UdERCpPYURcw8MLbv0Uml4LBdnwxS1w+HfDu7m1aywzhnfGx9PMr7tTuGPG76Rm5hnej4iIVJzCiLiOhzfc9jk07g0FWfD5UDiyxvBurm4ZwZcPXEaonyebj6Zx87u/cehkluH9iIhIxSiMiGt5+sAdX0KjKyE/0xFI9i8zvJv4BqHMHtWTmFBfDp7MZui7v7HlaJrh/YiISPkpjIjrefrCHbMg7grIS4dPB8OSl8Fq7PyOJvUCmDOqJ60jg0jNzOf26atZvjvF0D5ERKT8FEakevDygzu/hk4jADuseAM+7g9nDhvaTXiQD7MeuoxeTeuQlW/lvo/XMnfjUUP7EBGR8lEYkerDyw9u/A/c/BF4B8GR/8G0yw2/wV6gjycf3dONGztEUWizM2bWJt77dZ/2IhERcRGFEal+2g6Bh1dAdBfITXNsH//dE1Bg3B15vTzMTLqtIyMvbwTAxB928vL327HZFEhERKpahcLIlClTiIuLw8fHh+7du7NmzcVXQJw5c4bRo0cTGRmJt7c3zZs3Z+HChRUasLiJ0Di470e4fAxggvUfwYyrIXmHYV2YzSaevaE1z/RvBcBHqw7y6FcbySu0GtaHiIhcWrnDyKxZsxg7diwvvPACGzZsoEOHDvTt25fk5ORSz8/Pz+faa6/l4MGDzJ49m127djFjxgyio6MrPXip5Sye0OdFuHsO+IdD8naY3hvWfQQGllQeuLIxb9/eEU+LiQWbT3DPh2tJzy0wrH0REbk4k72chfLu3bvTtWtXJk+eDIDNZiM2NpZHH32UcePG/en8adOm8frrr7Nz5048PT0rNMj09HSCg4NJS0sjKCioQm1IDZeZDHMfhn1LHD+3HgwD3wbfEMO6WLknlYc+W0dWvpWW9QP55L5uRAT5GNa+iIi7Kevv73JdGcnPz2f9+vX06dPnXANmM3369GH16tWlvufbb7+lR48ejB49moiICNq2bcuECROwWi98KTwvL4/09PQSD3FzAeEwbDZc+wqYPWD7PJh2haGbpF3erC6zHupB3QBvdiZmMGTqb+xNzjSsfRERKV25wkhqaipWq5WIiIgSxyMiIkhMTCz1Pfv372f27NlYrVYWLlzIc889xxtvvME//vGPC/YzceJEgoODix+xsbHlGabUVmYz9HoM7vvZMack7TB8eL1jGbDNmJvgtY0OZu7/9aRRXX+Oncnh5mm/sf7QaUPaFhGR0jl9NY3NZiM8PJzp06fTuXNnbrvtNp555hmmTZt2wfeMHz+etLS04seRI0ecPUypSWI6w0MroO3NYLc6Nkj7bDBklB6Iyys2zI/ZD/egQ2wIZ7ILGPb+7yzenmRI2yIi8mflCiN169bFYrGQlFTyH+akpCTq169f6nsiIyNp3rw5Foul+FirVq1ITEwkPz+/1Pd4e3sTFBRU4iFSgk8QDH0fBk0BTz848Cu82wv2LDak+ToB3nz5QHd6t6hHboGNBz9bx1drjN2ATUREHMoVRry8vOjcuTNLliwpPmaz2ViyZAk9evQo9T29evVi79692M67jL57924iIyPx8vKq4LBFAJMJ4u+CB3+FiLaQnQpfDIWfnoHC0oNuefh5eTB9eBdu6RyDzQ7j5mzh7cV7tDmaiIjByl2mGTt2LDNmzOCTTz5hx44djBo1iqysLO69914Ahg8fzvjx44vPHzVqFKdOneLxxx9n9+7dLFiwgAkTJjB69GjjPoW4t3rNYeQS6Pag4+fVk+HD6+Dkvko37Wkx86+b2/NI76YAvLV4N0/P3Uqh1Zg5KiIiAh7lfcNtt91GSkoKzz//PImJiXTs2JEff/yxeFLr4cOHMZvPZZzY2Fh++uknxowZQ/v27YmOjubxxx/n73//u3GfQsTTB/q/Do2vgvmj4fhGeO8vcMNb0P6WSjVtMpl4sm8LIoJ9eH7+Vr5cc5iUjDzeuSMeXy/LpRsQEZGLKvc+I66gfUakXNKOwjcPwOHfHD93HAb9/gXeAZVu+setJ3jsqwTyC210bhjKByO6EOKncqOISGmcss+ISI0QHAMjvoO/jAOTGRK+gOlXwYnNlW76+raRfH5/d4J8PFh/6DRD3/2No6ezKz9mERE3pjAitZPFA3qPd4SSwCg4uQfevwb+916lt5Lv1iiM2aN6Ehnsw76ULIa++xs7E7Uxn4hIRSmMSO0Wdzk8vBKa9wNrPvzwN/jqTsg+Valmm0cE8s2onjSPCCApPY9b3l3N6n0nDRq0iIh7URiR2s+/DtzxJVz/Gli8YNdCx54kB1dWqtmoEF/++1BPusWFkZFXyIgP17Bg8wmDBi0i4j4URsQ9mExw2cMwcjHUaQoZx+GTgbB0IlgLK9xssJ8nn97fjevb1CffauORLzfw8aoDBg5cRKT2UxgR9xLZwbFJWsdhYLfBr/90hJK0oxVu0sfTwpRhnbj7sobY7fDid9v55w87tTmaiEgZKYyI+/EOgMFTYcgM8ApwLAGedjnsXFDhJi1mEy8PasNTfVsAMO3Xfdz9wRrd9VdEpAwURsR9tb8VHloOkR0h57RjYuvCp6Agt0LNmUwmRvduyus3t8fLw8zKvan0e3s5//xhJ1l5FS8FiYjUdtr0TKQwH5a85NhGHiCiHdz8oWOb+Qo6dDKLl7/bzpKdyQBEBvvwzIBWDGgXiclkMmLUIiLVXll/fyuMiJy1ZxHMfdhxwz1PP8f28h2HOSa/VtDi7Um89P02jpzKAaBX0zq8dGMbmoYHGjVqEZFqS2FEpCIyEmHOg3DgV8fPbW923N/Gp+L/u8stsDLt1328u2wfeYU2PMwm7r+8EY9e04wA73LfHkpEpMZQGBGpKJsVVk2CX14FuxVC4xxlm+jOlWr28MlsXv5+G4t3OEo3EUHePDOgNQPbq3QjIrWTwohIZR3+H3wzEtIOg9kDrnkBejwC5srN+/5lZxIvfrudw6cc97Tp0bgOLw1qQ/MIlW5EpHZRGBExQs4Z+O4x2D7f8XOTa+CmaRAQXqlmcwusTF++nylL9xaXbu7tFcfjfZqrdCMitYbCiIhR7HZY/zH8OA4Kc8E/HIa8B02urnTTR05l88r32/l5exIA4YHePDOgFTd2iFLpRkRqPIUREaMlbYfZ90HKDsAElz8BvZ8Bi2elm162K5kXv93GwZOO0k33RmG8PKgtLeqrdCMiNZfCiIgz5GfDT+MdV0oAYrrC0Pcdk1wrKa/Qyozl+5m8dC+5BTYsZhP39IzjiT7NCPSpfOAREalqCiMizrRtLnz7OOSlgXcQDHwb2g4xpOmjp7P5x/c7+HFbIgD1Ar15un9LBneMVulGRGoUhRERZzt9yLHa5ugax8+dRsD1/wQvP0Oa/3V3Ci9+u40DqVkAdIsL46VBbWgVqf8GRKRmUBgRqQrWAlg6AVa+BdihXkvHniQRbQxpPq/QyvsrDjD5l73kFFixmE0M79GQMdc2J0ilGxGp5hRGRKrS/mWOnVszk8DDB/q+Cl3ur9RW8uc7diaHVxdsZ+EWR+mmboA34/u1ZEgnlW5EpPpSGBGpapkpMG8U7F3k+Dkq3rFJWutBhqy4AVixJ4UXvt3G/hRH6aZLw1BeHtSW1lH670JEqh+FERFXsNng9ynwyz8ce5IABEVD94ccc0p8QyrdRX6hjQ9XHeA/S/aQnW/FbILhPeIYc21zgn1VuhGR6kNhRMSVMlNg3YewdgZkpTiOefpDp7uh+8MQ1qjSXZxIy+EfC3awYPMJAOoGePH361sytFMMZrNKNyLiegojItVBQS5snQ2rp0Dy9qKDJmh1A1w2GhpcVul5Jav2pvLCt9vYm5wJQKcGIbw8qC1to4MrOXgRkcpRGBGpTux22L/UEUr2Lj53PKoT9Bhd6Xkl+YU2Plp1gLfPK90M696QJ69rQbCfSjci4hoKIyLVVfIO+H0qbJoF1jzHsaCYonklwys1ryQxLZdXF+7gu03HAQjz92Lc9S25ubNKNyJS9RRGRKq70uaVeAVA/F2Vnlfy275UXpi/jT1FpZuOsSG8Mqgt7WJUuhGRqqMwIlJTFOTClv86SjgpOxzHTGZoOcCxNDi2e4XmlRRYbXzy20EmLd5DZl4hJhPc2a0BT/VtQYifl8EfQkTkzxRGRGoaux32/eIIJfuWnDse3dkxr6TVILB4lLvZ5PRcJizcwbwER+km1M+Tv1/fklu7xKp0IyJOpTAiUpOVNq8kOPbcvBKf8pdbft9/khfmb2NXUgYAHWJDeGVQG9rHhBg4cBGRcxRGRGqDzBRY9wGsmQHZqY5jXgEQfzdc9jCExpWruQKrjU9XH2LSot1kFJVubu/agL/1bUGov0o3ImIshRGR2qQgF7Z8XTSvZKfjmMkMLW8omlfSrVzzSpIzcvnnwp3M2XgMgBA/T57q24LbuzbAotKNiBhEYUSkNrrgvJIuRfNKbizXvJI1B07x/Pyt7Ex0lG7axwTz8qC2dIwNMXjgIuKOFEZEaruk7Y55JZu/rtS8kkKrjc9+P8SbP58r3dzWJZa/Xd+SMJVuRKQSFEZE3EVmMqz9ANa+X3JeSafhjmBSxnklKRl5/POHnXyz4SgAwb6ePNm3BXd2U+lGRCpGYUTE3VxoXkmrgefmlZTBuoOneH7+NrafSAegfpAPg+OjGdIpmuYRgc4avYjUQgojIu7KbnfMJ1k9xTG/5KxyzCsptNr44n+HeWvxbs5kFxQfbxsdxE3xMdzYIYp6gd7O+gQiUksojIhI0bySKUXzSvIdx4JjHdvNd7r7kvNK8gqtLN2ZzDcbjrFsVzIFVsc/FxaziSub1WVIpxiubR2Bj6fF2Z9ERGoghREROad4XskMyD7pOOYVeN68koaXbOJUVj7fbz7OnA3HSDhypvh4oLcH/dtFMqRTNF3jwrSrq4gUUxgRkT8ryHFcJVk9BVJ3OY5VYF7JvpRM5m44xtyNxzh2Jqf4eHSIL0M6RXNTfDSN6wU44xOISA2iMCIiF2a3w94ljhLO+fNKYro65pW0HFim/UpsNjtrDp5izoajLNySSGZeYfFrHWNDGNopmhvaR2l3VxE3pTAiImWTtO28/UrOzitp4NhuPv5u8Cnbf3M5+VYW7Uhi7oajLN+TitXm+KfF02Kid4twhnSKpnfLcLw9NL9ExF0ojIhI+WQmO/YqWft+yXklLfpBk6uh8VUQFFmmppIzcvk24ThzNx5j2/H04uPBvp4M7BDJTfExdGoQgqkcW9iLSM2jMCIiFVOQA5tnweqp5+aVnFWvFTTpDY17Q1wv8PK/ZHM7E9OZu+EY8xKOkZSeV3w8ro4fQzrFcFN8NLFhfkZ/ChGpBhRGRKRybDY4/Jtjbsn+pXA8ATjvnwuzJ8R2d4STJr0hsiOYL1yCsdrs/LYvlbkbjvHD1kRyCqzFr3WLC+OmTtH0bxdJsK+n0z6SiFQthRERMVb2Kdi/zBFM9i2DtMMlX/cJgcZ/cVw1adL7otvQZ+UV8tO2ROZsOMaqfamc/VfIy8PMta0iGNIpmiub18PTYnbShxGRqqAwIiLOY7fDqf2OlTj7l8GB5ZCXXvKc0EbnSjqNrgTfkFKbOpGWw/yE48zZcJTdSZnFx+v4ezGwQxRDO8XQNjpI80tEaiCFERGpOtZCOL7BEU72LYWja8F+rgyDyQzRnc9dNYnpCpaS5Ri73c624+nM2XCMbzcdIzUzv/i1puEBDOkUzeCO0USF+FbVpxKRSlIYERHXyU2HgyuLSjpL4eSekq97BUDc5efCSd3mcN6VjwKrjZV7Uvlmw1F+3p5EfqENcJzSo3EdhnSK4fq29QnwvvReKCLiOgojIlJ9nDlybr7J/mXnlg6fFRR9Lpg0vgr86xa/lJ5bwA9bTvDNhmOsOXCq+LiPp5nr29Tnpk4xXN60LhZtQy9S7SiMiEj1ZLNB4uZzV00O/w7WvJLn1G93Lpw06AGejtLMkVPZzNt4jDkbj3EgNav49PBAbwbHO7ahbxWpfyNEqguFERGpGfKz4fDqc6t0kraUfN3DxxFIzk6GjWiL3WQi4cgZ5mw4xnebj3Mmu6D49FaRQQyJj2ZQxyjCg3yq9rOISAkKIyJSM2UmO0o5+5Y6AkrGiZKv+9V1lHKKwkm+fyRLdyUzZ8NRftmZTIHV8U+a2QSXN6vH0E7RXNe6Pr5e2oZepKopjIhIzWe3Q8qucyWdgyuhIKvkOXWbF21X35vT4d34flcGczYcZePhM8Wn+HtZuKJZPbo2CqNbXBitIgPx0B4mIk6nMCIitU9hPhxdc+6qyfGNYLede93sATHdoElvjte5jFnH6vBNQhJHT+eUaCbA24NODUPpFhdK17gwOsSG4OOpKyciRlMYEZHaL+e0Y8O1s+Hk9MGSr3sHY290BYdDL2N1flMWpQSx5lAmGXmFJU7zsphpHxNcfOWkc1woQT7all6kshRGRMT9nNp/LpgcWA65aSVfN3tgr9uctKDm7KUhv2fXZ0FSHXZk+QPnlgabTNCyfpDjyklRQNFkWJHyUxgREfdmszrKOPuWwoFf4cRmyEsr9VSrdygn/Zuyiwb8llmfVRn12W2PIRfv4nPi6vjRNS6sOJw0rOOnLepFLkFhRETkfHY7pB2F5O2QtBWStjkeqXtKbl1/9nRMnPSOYYetAWtzItlha8AOewOO2etix0y9QG+6xYXRtejqScv6Qdp4TeQPFEZERMqiIBdSd50LJ0lbIXErZKeWenq2yZcd1lh22GLZaW/ADlsDdtljMfkE0blhKN2Krpy0iwnG20OTYsW9KYyIiFRGZnLJKyhJWx3LjK35pZ5+xFbPEU7ssey0NWCfOY6QmBZ0beRYUty5YajupSNuR2FERMRo1gI4ufdcODkbVNKPlXp6rt2TXUXhZBex5IS1IrRRR9o1bUzXRmHUDfAu9X0itYXCiIhIVck+VTQXxRFS7EnbsCdtx1yYU+rpifZQdtoacMK3Cabw1tRp0omWbTsTUzdYk2KlVnFqGJkyZQqvv/46iYmJdOjQgXfeeYdu3bpd8n1fffUVd9xxB4MGDWLevHll7k9hRERqHJvVse9J0dWT3GObKTyxhYCsI6WeXmC3cMgcw+mAZpgj2xLetBPRLbpiDop0rDUWqYGcFkZmzZrF8OHDmTZtGt27d2fSpEn897//ZdeuXYSHh1/wfQcPHuTyyy+ncePGhIWFKYyIiHvKy4DknWQf2cTJ/RuwJ22jTuYe/O1ZpZ6eYQ4iPag5HlHtqNO4Ex7hLSC0IQREKKRItee0MNK9e3e6du3K5MmTAbDZbMTGxvLoo48ybty4Ut9jtVq58sorue+++1ixYgVnzpxRGBEROctuJzf1MAe2/4/T+zdiSt5Gvey9NOI4FlPp/0QXmr3JD4jBo04cXnUbQWgchDR0BJWQhuAbUqUfQaQ0Zf39Xa6p3fn5+axfv57x48cXHzObzfTp04fVq1df8H0vv/wy4eHh3H///axYsaI8XYqI1H4mEz71GtLqLw3hL7cCUGC1sfVwMvu2ryft4EY8U7YTZz1InDmJSE7iYcvDI30fpO+DA39u0u4djCm0oSOknA0oZwNLSAPw1I6yUn2UK4ykpqZitVqJiIgocTwiIoKdO3eW+p6VK1fywQcfkJCQUOZ+8vLyyMvLK/45PT29PMMUEanxPC1mOjSqT4dGA4AB2Gx29qdmsuFEBnuPnybl+D7yUvbjnXGEGFMysaYUYk0pxJiSqWdKx5SXBombHY/SBEaWvJJyfmAJigKz9kiRquPURe8ZGRncfffdzJgxg7p165b5fRMnTuSll15y4shERGoWs9lE0/BAmoYHQocooA0A2fmF7E3OZFdiBguTMtiVlMnRxGQ8Mo4Se15IcTx3/BxgyoWME47Hkd9L6cwTgmNKCSqNHM/96mi+ihiqXHNG8vPz8fPzY/bs2QwePLj4+IgRIzhz5gzz588vcX5CQgLx8fFYLOcSts3muN232Wxm165dNGnS5E/9lHZlJDY2VnNGRETKKC2ngD1JGexKymB3ouPPXYkZnM7OJ5SMEiGlgSmZBuYUGnmkEmFLwYPCizfu6V8yqPxxvop3QJV8Rqn+nDJnxMvLi86dO7NkyZLiMGKz2ViyZAmPPPLIn85v2bIlW7ZsKXHs2WefJSMjg7fffpvY2NhS+/H29sbbW5sBiYhUVLCvJ13iwugSF1Z8zG63k5qZz+6iYLInOYM1iRl8npRJZl4h5IMZGxGcdoQUczKNLKm08jlNnCWVcFsi/nkpmAqyHPuqJG8vvXO/OudKPn+8uhIcCx5eVfOXIDVGucs0Y8eOZcSIEXTp0oVu3boxadIksrKyuPfeewEYPnw40dHRTJw4ER8fH9q2bVvi/SEhIQB/Oi4iIs5lMpmoF+hNvUBvejU9Vzq32+0cT8stvoJy9s9vkzPJz7fBeTvge5NPtCmV5t6n6BSYRkuf0zQwp1C34AR+2Ucx556B7JOOx/ENpQzCDIFRjjJQYAQE1C/lz/rgGwZms/P/UqRaKHcYue2220hJSeH5558nMTGRjh078uOPPxZPaj18+DBm/Q9IRKTGMJlMRIf4Eh3iS++W5/aLstrsHDqZxe6kDHYnZRYHlf2p3uzPjeLH3D+31dC/kF51MukQkEYzr5PEmFIIyz+GR9oROHMYCnMg/ajjcTFmTwgId+ynElj/wn/6h4NF9/yp6bQdvIiIlEteoZUDqVnsSswoKvlksjspgyOns7nQb5ToEF+ah/sTX6eA9v5niPNKox6n8ctLxZSZBJmJkFH0Z/bJcozGBP51L3CF5Q9/ajlzldO9aUREpEqdv7Jnd9HKnt2JGSSml3IJpUiAtwcxob7EhvnRIMyP2FBfGoZ4EOeTTaQlDZ/cFMhIhMykP/+ZmQx2a9kH6BN84bLQ+VdcvAO1WsggCiMiIlItpGUXsDs547wrKRkcPJlFUnreJd9bL9C7OKTEhvk5HqF+NKjjR/0ATyy5p/4QUs67wnL+n9ZL91XM0+/S5aGA+uAXptByCQojIiJSreUWWDl2JofDp7I5eiqbw6eyOXIqp+jPbDLyLr7E2NPimOsSG+ZHTGjRlZUw36Lw4keIn6fjLsh2O+SeKT2k/PHP/IyyfwCzJ/jXc4QS31DHFvy+oY7Jt76h5x5+f/jZ07dSf281icKIiIjUWHa7nbScgnPh5LQjoBw+lc3R0zkcPZ1NgfXiv74CvT2ICfOjQZgvsaF+50pBYb7EhPrh41nKLrP5WRcuC53/Z86pin84D58/BJaQPweW0gJNDQwxCiMiIlJrWW12ktJzi6+iHDmVzZHTOcWBJTnj0mWZ8LMloD+UgRqE+RER5IPFfJESTGG+I5hkp0LOaccj+xTknDn3c86p854XPWyX2FDuYjx8/hBYQi9+BeZsoPH0dVk5SWFERETcVm6BlaOnS5Z9Dp8XWDLLUQI6N7n23JWVYN+iElB52O2Ql3HhsJL9h+By/uuVCTEW71ICS8ifr8DEXe5YmWQghREREZFS2O12zmQXcOR0yXkqR4t+PnY6h0LbJUpAPh7EhvoRHepL/SAfIoK8CQ/yKXru+LlCgaX0AUN+5nlXX/4YWM784erMea+VJ8Tc+yM07FH58Z7HKdvBi4iI1HQmk4lQfy9C/b1oHxPyp9etNjsn0nI4ciqnqPxT8spKSkYeGbmFbD+RzvYTF76rvLeHuTiYRBSFlPpBPoQX/Xw2uPh6XeIOySaTY7mxdyCENCj7Bz0/xJQaVk4XBZmiY4ERZW/bYLoyIiIiUg45+dbiqyjH03JJTs8lMS2XpIw8ktJyScrI5Ux2QZnbC/TxKA4m4UHeJa6unA0x9QK98bTUvN3NdWVERETECXy9LDSLCKRZROAFz8ktsJKcnkdSRi5JRWElOSOvxPPEtFxyCqxk5BaSkZvJnuTMC7ZnMkEdf28iisJKeFFY+WOICfXzwnyxibfVlMKIiIiIwXw8LTSo49ic7ULsdjsZeYVFV1YcQSUpI9dxdeVskCkKLoU2O6mZeaRm5rHt+IVLQ54WE+GBJa+q/PEqS0SQNwHeHsbMZzGIwoiIiIgLmEwmgnw8CfLxpGn4ha+y2Gx2TmXnF11RcQSV0p6nZuZTYLVz7EwOx87kXLRvPy/Ln+av3NGtAXF1/Y3+mGWiMCIiIlKNmc0m6gZ4UzfAGwi+4Hn5hTZSMouusKTlFl1pOTePJSnd8Twjr5DsfCv7U7PYn5pV/P6+besTh8KIiIiIVJCXh5noEF+iQy6+U2tWXmHxnJXk4jkteTQIu3BJydkURkRERNyIv7cHjbw9aOSikkxpat46IREREalVFEZERETEpRRGRERExKUURkRERMSlFEZERETEpRRGRERExKUURkRERMSlFEZERETEpRRGRERExKUURkRERMSlFEZERETEpRRGRERExKUURkRERMSlasRde+12OwDp6ekuHomIiIiU1dnf22d/j19IjQgjGRkZAMTGxrp4JCIiIlJeGRkZBAcHX/B1k/1ScaUasNlsHD9+nMDAQEwmk2HtpqenExsby5EjRwgKCjKsXakYfR/Vj76T6kXfR/Wi7+PS7HY7GRkZREVFYTZfeGZIjbgyYjabiYmJcVr7QUFB+h9SNaLvo/rRd1K96PuoXvR9XNzFroicpQmsIiIi4lIKIyIiIuJSbh1GvL29eeGFF/D29nb1UAR9H9WRvpPqRd9H9aLvwzg1YgKriIiI1F5ufWVEREREXE9hRERERFxKYURERERcSmFEREREXMqtw8iUKVOIi4vDx8eH7t27s2bNGlcPyS1NnDiRrl27EhgYSHh4OIMHD2bXrl2uHpYU+ec//4nJZOKJJ55w9VDc1rFjx7jrrruoU6cOvr6+tGvXjnXr1rl6WG7LarXy3HPP0ahRI3x9fWnSpAmvvPLKJe+/IhfmtmFk1qxZjB07lhdeeIENGzbQoUMH+vbtS3JysquH5nZ+/fVXRo8eze+//86iRYsoKCjguuuuIysry9VDc3tr167lvffeo3379q4eits6ffo0vXr1wtPTkx9++IHt27fzxhtvEBoa6uqhua3XXnuNd999l8mTJ7Njxw5ee+01/vWvf/HOO++4emg1ltsu7e3evTtdu3Zl8uTJgOP+N7GxsTz66KOMGzfOxaNzbykpKYSHh/Prr79y5ZVXuno4biszM5NOnToxdepU/vGPf9CxY0cmTZrk6mG5nXHjxrFq1SpWrFjh6qFIkRtuuIGIiAg++OCD4mNDhw7F19eXzz//3IUjq7nc8spIfn4+69evp0+fPsXHzGYzffr0YfXq1S4cmQCkpaUBEBYW5uKRuLfRo0czYMCAEv+dSNX79ttv6dKlC7fccgvh4eHEx8czY8YMVw/LrfXs2ZMlS5awe/duADZt2sTKlSvp16+fi0dWc9WIG+UZLTU1FavVSkRERInjERER7Ny500WjEnBcoXriiSfo1asXbdu2dfVw3NZXX33Fhg0bWLt2rauH4vb279/Pu+++y9ixY3n66adZu3Ytjz32GF5eXowYMcLVw3NL48aNIz09nZYtW2KxWLBarbz66qsMGzbM1UOrsdwyjEj1NXr0aLZu3crKlStdPRS3deTIER5//HEWLVqEj4+Pq4fj9mw2G126dGHChAkAxMfHs3XrVqZNm6Yw4iJff/01X3zxBTNnzqRNmzYkJCTwxBNPEBUVpe+kgtwyjNStWxeLxUJSUlKJ40lJSdSvX99Fo5JHHnmE77//nuXLlxMTE+Pq4bit9evXk5ycTKdOnYqPWa1Wli9fzuTJk8nLy8NisbhwhO4lMjKS1q1blzjWqlUrvvnmGxeNSJ566inGjRvH7bffDkC7du04dOgQEydOVBipILecM+Ll5UXnzp1ZsmRJ8TGbzcaSJUvo0aOHC0fmnux2O4888ghz587ll19+oVGjRq4eklu75ppr2LJlCwkJCcWPLl26MGzYMBISEhREqlivXr3+tNR99+7dNGzY0EUjkuzsbMzmkr8+LRYLNpvNRSOq+dzyygjA2LFjGTFiBF26dKFbt25MmjSJrKws7r33XlcPze2MHj2amTNnMn/+fAIDA0lMTAQgODgYX19fF4/O/QQGBv5pvo6/vz916tTRPB4XGDNmDD179mTChAnceuutrFmzhunTpzN9+nRXD81tDRw4kFdffZUGDRrQpk0bNm7cyJtvvsl9993n6qHVXHY39s4779gbNGhg9/Lysnfr1s3++++/u3pIbgko9fHRRx+5emhS5C9/+Yv98ccfd/Uw3NZ3331nb9u2rd3b29vesmVL+/Tp0109JLeWnp5uf/zxx+0NGjSw+/j42Bs3bmx/5pln7Hl5ea4eWo3ltvuMiIiISPXglnNGREREpPpQGBERERGXUhgRERERl1IYEREREZdSGBERERGXUhgRERERl1IYEREREZdSGBERERGXUhgRERERl1IYEREREZdSGBERERGXUhgRERERl/p/SiuFJGF5nlQAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUHlJREFUeJzt3Xd4VFX+x/H3TJKZFNIDSQgBQkIR6SWRoqDisiqsXcECUlz7othgFVxXAcuCqKisCLqroljWzs8WawABQRTpnVASUiA9mWTm/v6YEAg1CZPclM/reeZh5s7MOd8UmA/nnnOuxTAMAxERERGTWM0uQERERJo2hRERERExlcKIiIiImEphREREREylMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRU3mYXUBUul4t9+/YRGBiIxWIxuxwRERGpAsMwyMvLo2XLllitJx//aBBhZN++fcTGxppdhoiIiNRAamoqrVq1OunzDSKMBAYGAu4vJigoyORqREREpCpyc3OJjY2t+Bw/mQYRRg6fmgkKClIYERERaWBON8VCE1hFRETEVAojIiIiYiqFERERETFVg5gzUhVOp5PS0lKzy5B6zsfHBy8vL7PLEBGRozSKMJKfn8+ePXswDMPsUqSes1gstGrVimbNmpldioiIlGvwYcTpdLJnzx78/f1p3ry5NkWTkzIMg4yMDPbs2UP79u01QiIiUk80+DBSWlqKYRg0b94cPz8/s8uReq558+bs3LmT0tJShRERkXqi0Uxg1YiIVIV+T0RE6p9GE0ZERESkYVIYEREREVMpjIiIiIipFEakgvZpERERMyiMmOiLL75g4MCBhISEEB4ezrBhw9i2bVvF83v27GHkyJGEhYUREBBAnz59WL58ecXzn376KX379sXX15eIiAiuuOKKiucsFgsfffRRpf5CQkJ4/fXXAdi5cycWi4VFixYxaNAgfH19eeutt8jKymLkyJHExMTg7+9P165defvttyu143K5ePrpp0lISMBut9O6dWumTZsGwAUXXMBdd91V6fUZGRnYbDaSk5M98W0TEZEaKC51su9QEX/szeHHzRl89OteFqTs4F9fbmLy/9aSnltsWm0NfmnvsQzDoKjUaUrffj5e1VqtUVBQwMSJE+nWrRv5+flMnTqVK664gjVr1lBYWMigQYOIiYnhk08+ISoqitWrV+NyuQD4/PPPueKKK3j44Yf573//i8PhYPHixdWuedKkScycOZOePXvi6+tLcXExvXv35qGHHiIoKIjPP/+cm266ifj4eBITEwGYPHky8+bN49lnn2XgwIHs37+fjRs3AjB+/HjuuusuZs6cid1uB+DNN98kJiaGCy64oNr1iYjI8QzDILe4jOwCB9kFJWQXlJJdUEJWgYODBQ6yChxkH3O/0HHqz8are8cQGeRbR19BZY0ujBSVOuk89UtT+l7/z6H426r+Lb3qqqsqPV6wYAHNmzdn/fr1LF26lIyMDFauXElYWBgACQkJFa+dNm0aI0aM4LHHHqs41r1792rXfM8993DllVdWOnb//fdX3L/77rv58ssveffdd0lMTCQvL4/nnnuOOXPmMHr0aADi4+MZOHAgAFdeeSV33XUXH3/8Mddeey0Ar7/+OjfffLOW1YqInESp08XBQkd5uDhyy8p3cLCwPFAcdf9ggYMyV/V3Hfe2WggNsBEeYCMswFbpfotAc4IINMIw0pBs2bKFqVOnsnz5cjIzMytGPXbv3s2aNWvo2bNnRRA51po1a7jlllvOuIY+ffpUeux0Opk+fTrvvvsue/fuxeFwUFJSgr+/PwAbNmygpKSECy+88ITt+fr6ctNNN7FgwQKuvfZaVq9ezR9//MEnn3xyxrWKiDQEh0fos/LLQ0WhO0gcfT+rwFERPrLyS8gtLqtRXwE2r5OECzthAT7lf9oqbkG+3vXyP4aNLoz4+Xix/p9DTeu7OoYPH06bNm2YN28eLVu2xOVy0aVLFxwOx2l3kz3d8xaL5bhr9ZxogmpAQEClx8888wzPPfccs2fPpmvXrgQEBHDPPffgcDiq1C+4T9X06NGDPXv28Nprr3HBBRfQpk2b075PRKS+MgyDQ4WlpOcVcyC3hAN5JaTnFpcHjpIj4aI8aJSUuardh8UCof42Qv19CC8PEUcHjRPdfKv5uVNfNbowYrFYqnWqxCxZWVls2rSJefPmce655wKQkpJS8Xy3bt149dVXyc7OPuHoSLdu3UhOTmbMmDEnbL958+bs37+/4vGWLVsoLCw8bV1Llizhsssu48YbbwTck1U3b95M586dAWjfvj1+fn4kJyczfvz4E7bRtWtX+vTpw7x581i4cCFz5sw5bb8iImZwuQyyCx2k5xZzIK+EjNySivsH8opJzy0hI899czirFzBsXtaK0BDezEaof/n9k4SMEH8bXtY6GLUwDCgrAUcBOPLL/yyAyM5gCzj9+2tB/f/UbqRCQ0MJDw/nlVdeITo6mt27dzNp0qSK50eOHMn06dO5/PLLmTFjBtHR0fz666+0bNmSfv368eijj3LhhRcSHx/PiBEjKCsrY/HixTz00EOAe1XLnDlz6NevH06nk4ceeggfH5/T1tW+fXvef/99li5dSmhoKLNmzSI9Pb0ijPj6+vLQQw/x4IMPYrPZGDBgABkZGaxbt45x48ZVtHN4ImtAQEClVT4iInWhzOkiq8BRPopRXDGScSCv5Mix3BIy80uqNfcixN+HyEBfWgTZaR7ovoUHuINGeLPy0yP+NsKa2QiwVW9RwwkZBpQVHx8cDt8vyT/m+OHnTvDao19vnGAy6y3fQUyvM6u3hhRGTGK1WnnnnXf429/+RpcuXejYsSPPP/88gwcPBsBms/HVV19x3333cckll1BWVkbnzp158cUXARg8eDDvvfcejz/+OE8++SRBQUGcd955Fe3PnDmTMWPGcO6559KyZUuee+45Vq1addq6HnnkEbZv387QoUPx9/fnr3/9K5dffjk5OTkVr5kyZQre3t5MnTqVffv2ER0dzW233VapnZEjR3LPPfcwcuRIfH3NmxQlIo1LqdNFRl5JeagorvznUYEjK7+E6szvjGhmo3mgLy0C7UQG2WlRHjhaBNppEeQ+3jzQjt37FKdFjg4OBelw8ARhoCpB4dhgcaLg4Ck+/u7REFsAUP0JsZ5iMY6dWFAP5ebmEhwcTE5ODkFBQZWeKy4uZseOHcTFxelDrx7ZuXMn8fHxrFy5kl69zEnaJ6LfF5H6qaTMWTEXI6P89MiBY+ZnZOSVkF3ooKqfWlYLRDSzl4cKXyKD7EcFDt/yoGEnopkdH69jtt0qK4GCTCjMhIIMKMhy/3ns4+JDxwSH6s8VqbKK4NCs/BZw1K0Z2JtVflxxP/AkxwPAWrtzTk71+X00jYyIR5WWlpKVlcUjjzzCOeecU6+CiIiYo9TpYt+hIlKzi9hzsJDUg4Xsz3GHi8MjGYcKq74DtLfVQvPAyqMWh0cyKkY1Au2EN7MfmYPhLIXC8gBRsNcdNPZmwuYM9/2CzKPCRiaU5J7ZF+0TcHwAqAgLxwaJk4QF+1HHffxrPTiYSWFEPGrJkiWcf/75dOjQgffff9/sckSkDjhdBum5xaRmF5J6sDxwZBeRerCQPdmFpOUWV+mUic3L6g4ZQfaKeRknChxh/jashhOKso+EiIIMd9jYl3FUsDgcPjLdIxjVZfUG/wgIKL/5R0BAcwgId//pHwF+oeUh46gQ4RMAVm1wXh0KI+JRgwcPPm5JsYg0bIZhkJnvIPVgIanZhew5JnDsO1REqfPUf+/t3lZahfoRG+ZPbKg/0SG+RwUOXyKbeRNMPpbDAaJw95ERi7QM2J5ZeQSj6CDVnuNgsYJ/eZCoFC6ODRvlj31D3OttpdYpjIiICDmFpe6RjKNCxtEjHcWlp54L4W210DLEj9gwP2JD/IgLMogLcBDrW0S0rZBgIw9L4S73aEZhNmRkws7MI/MyCrNqMN/CAv5hR0YpDoeIgOaVQ8fRoxgasaiXFEZERJqAQkfZkTkb5SHj8ChH6sFC8k6yA6gFF0EUEm3NIz7AQUKAg9b+xbS0FRHpnU+YpYAgIxff0kNYig7CoWzYlwWuGl4F3C/0+NMhJwwbEe4g0ojnUTQlCiMiIo1ASZmTvQeLKsJFxZyNg0XsyS4kq8CBN2WEUECIJY9Q8gm15NHVks955BHinU9LnwIifYqI8MonxMgjwJmLvSwHy+ERi1LgUPmtKrx93SMUfmHgH3rU/bATny7xDwOv0++HJI2PwoiISANgGAZpucXszCxfjZJ5kIOZ6eQfTKcoJxOKsggljxDyCbXk08GSRxJ5hFryCSWPUHs+QZbT7MJsAI6TPGcLdAcKv/Ig4R9W+X7F47AjocPm7+lvgzRSCiMiIvVMTlEpW1LTSdvxB/n7NmJkbaNZ/g5aufYTazlEd/Lwt5RUflN1BhR8QyqHhopwEXrioOEXCt52T36JIpUojIiImKTEUcLubRvJ2LWOwn2bsGZvJahgFy1de+ljyT7+DcfMvXThRak9BJdfKN4B4XgHRmA5dnTi2Pu+IeClf/qlftFvpIhIbTIMXHnpZOxcR+au9ZSkbcL70DZCinYT5dxPe4uT9se+p3w1aZ41iBz/NrhC4/GN6kBo67PwCW1dMYJhtQdh1+oQaQQURhqwtm3bcs8993DPPfeYXYqIlORB1jby920ie/c6Sg9sxpazg7Di3QQYhUQCkce+xwLF+JDuHUNeQFuM8AQCWnaiRduzadayE4H+YQSa8KWI1DWFERGRqnKWwsFdkLWV0gObyN27EWfGFnxzdxBUmglAs/Lb0VyGhb00J80nlqLAtlgiEgiM6UR0fFdaxLSjjZanShOnMCKmcDqdWCwWrBpilvrGMCAvDbK2QtYWXJlbKUrbhJG5Fb+CVLzKr6DqA4Qf89ZMI4jtRjQZPq0oDo7Du3kHglqdRWy7s2gTFU7ssRdjExHguOlQjYBhHHP55Tq8VWMb9FdeeYWWLVviclXecfCyyy5j7NixbNu2jcsuu4zIyEiaNWtG3759+eabb2r8bZk1axZdu3YlICCA2NhY7rjjDvLz8yu9ZsmSJQwePBh/f39CQ0MZOnQoBw8eBMDlcvH000+TkJCA3W6ndevWTJs2DYDvv/8ei8XCoUOHKtpas2YNFouFnTt3AvD6668TEhLCJ598QufOnbHb7ezevZuVK1dy0UUXERERQXBwMIMGDWL16tWV6jp06BC33norkZGR+Pr60qVLFz777DMKCgoICgo67ho4H330EQEBAeTl5dX4+yVNQHEu7F0Nv78L303HeH8spS+dS9m0GJjVCf4zDD67F+vPLxKw8xua5e/Ey3BSaNhZ52rDZ85zmGe5ihdDHmRex1f54KIUUsf9ztkPL+XSKf/jqr/N5LKRt3L+ueeRENP8+KvCikiFxjcyUloI01ua0/ff97kvklQF11xzDXfffTffffcdF154IQDZ2dl88cUXLF68mPz8fC655BKmTZuG3W7nv//9L8OHD2fTpk20bt262qVZrVaef/554uLi2L59O3fccQcPPvggL730EuAODxdeeCFjx47lueeew9vbm++++w6n0/2/wMmTJzNv3jyeffZZBg4cyP79+9m4cWO1aigsLOSpp57i1VdfJTw8nBYtWrB9+3ZGjx7NCy+8gGEYzJw5k0suuYQtW7YQGBiIy+Xi4osvJi8vjzfffJP4+HjWr1+Pl5cXAQEBjBgxgtdee42rr766op/DjwMDdbZdcF/qfe8vkLGxfLRjG67MLVgLDlR6mYUjq2PLDCupRnN2GNFsN6JJtbbEGeKeRBrVqh2dooNJigokopkNi65dInLGGl8YaSBCQ0O5+OKLWbhwYUUYef/994mIiOD888/HarXSvXv3itc//vjjfPjhh3zyySfcdddd1e7v6Emubdu25YknnuC2226rCCNPP/00ffr0qXgMcPbZZwOQl5fHc889x5w5cxg9ejQA8fHxDBw4sFo1lJaW8tJLL1X6ui644IJKr3nllVcICQnhhx9+YNiwYXzzzTesWLGCDRs20KFDBwDatWtX8frx48fTv39/9u/fT3R0NAcOHGDx4sVnNIokDZjL5Q4dqcshdQXsWeEOIMc4PEZxwAhhhxHFNlc0O4xodhKNI6QdQdEJJESF0zEqkAujAmkd5n/kUvQi4nGNL4z4+LtHKMzquxpuuOEGbrnlFl566SXsdjtvvfUWI0aMwGq1kp+fzz/+8Q8+//xz9u/fT1lZGUVFRezevbtGpX3zzTfMmDGDjRs3kpubS1lZGcXFxRQWFuLv78+aNWu45pprTvjeDRs2UFJSUhGaaspms9GtW7dKx9LT03nkkUf4/vvvOXDgAE6nk8LCwoqvc82aNbRq1aoiiBwrMTGRs88+m//85z9MmjSJN998kzZt2nDeeeedUa3SQBTnukc9Ule6A8ieX6Ak57iXbXHFsN5oww4jiu0u92hHYbM2xERF0ikqkI5RQVwWFUhCi2b4+mgyqUhda3xhxGKp8qkSsw0fPhzDMPj888/p27cvP/30E88++ywA999/P19//TX/+te/SEhIwM/Pj6uvvhqH42R7NZ/czp07GTZsGLfffjvTpk0jLCyMlJQUxo0bh8PhwN/fHz8/v5O+/1TPARWTUI2j5syUlh5/kSw/P7/jhrRHjx5NVlYWzz33HG3atMFut9OvX7+Kr/N0fYN7dOTFF19k0qRJvPbaa4wZM0ZD542RYUD2dtiz8sjIR/o6jr2MfIFhZ40rgVVGe1a7OrDalUDLqGh6tg6lU1Qg10cF0jEykNAAmzlfh4gcp/GFkQbE19eXK6+8krfeeoutW7fSsWNHevXqBbgnk958881cccUVAOTn51dMBq2uVatW4XK5mDlzZkVwePfddyu9plu3biQnJ/PYY48d9/727dvj5+dHcnIy48ePP+755s2bA7B//35CQ0MB94hGVSxZsoSXXnqJSy65BIDU1FQyMzMr1bVnzx42b9580tGRG2+8kQcffJDnn3+e9evXV5xKkgautAj2rTkSPFKXuy81f4xUowW/uNqzytWB1a72bDJiaRMRRL/4cK5NiGBWu3DCFDxE6jWFEZPdcMMNDBs2jHXr1nHjjTdWHG/fvj3/+9//GD58OBaLhSlTphy38qaqEhISKC0t5YUXXmD48OEsWbKEuXPnVnrN5MmT6dq1K3fccQe33XYbNpuN7777jmuuuYaIiAgeeughHnzwQWw2GwMGDCAjI4N169Yxbtw4EhISiI2N5R//+AfTpk1j8+bNzJw5s0q1tW/fnjfeeIM+ffqQm5vLAw88UGk0ZNCgQZx33nlcddVVzJo1i4SEBDZu3IjFYuHPf/4z4J5/c+WVV/LAAw/wpz/9iVatWtXo+yQmy91XOXjs//24y9CX4sNaI46VzsOjHu3JIISWwb70T4hgfHw4/eLDiQ4+/YiaiNQfCiMmu+CCCwgLC2PTpk1cf/31FcdnzZrF2LFj6d+/f0UYyM3NrVEf3bt3Z9asWTz11FNMnjyZ8847jxkzZjBq1KiK13To0IGvvvqKv//97yQmJuLn50dSUhIjR44EYMqUKXh7ezN16lT27dtHdHQ0t912GwA+Pj68/fbb3H777XTr1o2+ffvyxBNPnHQOytHmz5/PX//6V3r16kVsbCzTp0/n/vvvr/SaDz74gPvvv5+RI0dSUFBAQkICTz75ZKXXjBs3joULFzJ27NgafY+kjjlLIW3tkeCxZyXkpB73skNeYaxwtmd5aQK/utrzhxGHAx/CA2z0iw/n3vgI+seH0ybcX6fmRBowi2FUY3MMk+Tm5hIcHExOTg5BQUGVnisuLmbHjh3ExcXh6+trUoVitjfeeIN7772Xffv2YbOdfEhevy8mKchyr2xJXe6ebLp3FZQVVXqJy+LFHls8yxzxLClpx2qjA3uMCMBCoN2bpHbhDEgIp398BB0imyl8iDQAp/r8PppGRqRBKywsZP/+/Tz55JPceuutpwwiUkeOXl57eLLpCZbXOnyC2GbvzI/F7fi+MI7fXPEUFrkDoq+Plb5tw7ihfOTj7JZBeGvTMJFGS2GkEXjrrbe49dZbT/hcmzZtWLduXR1XVHeefvpppk2bxnnnncfkyZPNLqdpquLy2rzAeDb5nMW3hXF8mdOa7cXRGHnugOHjZaFn21D6xYfTPz6cHq1DsHtria1IU6HTNI1AXl4e6enpJ3zOx8eHNm3a1HFF9Zd+X85QFZfXGj4BHAztyjqvTnyd15aPM1uSc9Tl46wW6BITTP/ykY8+bUPxt+n/RiKNjU7TNCGBgYHa+lxqRxWX17pC2pAV0oPfLB1ZfCiWz9JDceRVPq3SMTKwYuQjKS6cYH+f49oRkaap0YSRBjDAI/WAfk9OwzDgwHrY+g1sTYbdy8B5zEZ7XjZc0T04ENKd1c72fJrdiuS9VhxplZeetwn3p398OP3iI+jXLpzmgfY6/EJEpCFp8GHEy8t9XtnhcFRpt05p2g7v7Hr490aAwmzY/h1s/Ra2JUPe/srPN4vEiE0iLagbK8oS+CyjOUt35lOw1XnUi1xEBtkrTrv0iw+nVWj1Lo8gIk1XjcLIiy++yDPPPENaWhrdu3fnhRdeIDEx8aSvnz17Ni+//DK7d+8mIiKCq6++mhkzZnjknL23tzf+/v5kZGTg4+NTscOoyLFcLhcZGRn4+/vj7d3gc3jNuZywd7V79GNbsnuZrXHUqIa3H8SdS3GbwXxVfDaL9zXj503ZHCo8vAGZe3JqqL8P/cpHPvrHh9MuIkDLbUWkRqr9L/KiRYuYOHEic+fOJSkpidmzZzN06FA2bdpEixYtjnv9woULmTRpEgsWLKB///5s3ryZm2++GYvFwqxZs874C7BYLERHR7Njxw527dp1xu1J42a1WmndunXT+9DM3e8OHlu/gW3fQfGhys83PwsSLoSEIexq1o3Xlqfx3lepFDgKgAIAAmxeJLULrxj5OCsqCKuuZCsiHlDt1TRJSUn07duXOXPmAO7/bcbGxnL33XczadKk415/1113sWHDBpKTkyuO3XfffSxfvpyUlJQq9VmV2bgul6tGF5GTpsVmszWN0bOyEvd8j63fuE+/HDhmebdvMLQ73x1A4i/ECGrJ8h3ZzE/ZwTcb0jn8r0KHyGb8pXtL+idE0DUmGB/t9SEi1VArq2kcDgerVq2qtJ+D1WplyJAhLFu27ITv6d+/P2+++SYrVqwgMTGR7du3s3jxYm666aaT9lNSUkJJSUmlL+Z0rFarlmpK03V4ye3hiac7f4LSwqNeYIGYXpAwxH1r2Qu8vCkpc/LZb/tZsCSFdfuO/D0b3LE5YwfEcW77iKY3iiQida5aYSQzMxOn00lkZGSl45GRkWzcuPGE77n++uvJzMxk4MCBGIZBWVkZt912G3//+99P2s+MGTNOePVYETlKSR7s+Kk8gHwDh445Tdks0h084i9w3/zDKp7Kyi/hreU7eOPnXWTkuYO/r4+VK3u1YuyAtiS00FJxEak7tT6L7/vvv2f69Om89NJLJCUlsXXrViZMmMDjjz/OlClTTvieyZMnM3HixIrHubm5xMbG1napIvWbYbgvLrf1G9j2Lez+ufJVba0+0PqcI6MfkWfDMaMam9PzWJCygw9/3UtJmXvSamSQnVH92nJ9YmtCA7SdvojUvWqFkYiICLy8vI7b7TM9PZ2oqKgTvmfKlCncdNNNjB8/HoCuXbtSUFDAX//6Vx5++OETnr+32+3Y7dqTQISCTPeE023J7tMvBQcqPx8aVx4+LoS254K92XFNuFwGP2zJYEHKDn7acmTDsm6tghk3MI6Lu0Rj89ZcEBExT7XCiM1mo3fv3iQnJ3P55ZcD7omjycnJ3HXXXSd8T2Fh4XGB4/AeD9qASuQYzjL3dV4On3rZt4ZKW637BEDcuUdOv4THn7SpIoeTD1bv4bUlO9iW4V4RY7XAnzpHMe7cOPq0CdV8EBGpF6p9mmbixImMHj2aPn36kJiYyOzZsykoKGDMmDEAjBo1ipiYGGbMmAHA8OHDmTVrFj179qw4TTNlyhSGDx+ujadEAA6lHhn52P7D8ReZi+ziDh4JQ9ynYbxPPWqYllPMf5ftZOGK3RV7gzSze3Nd31hu7t+W2DBtRiYi9Uu1w8h1111HRkYGU6dOJS0tjR49evDFF19UTGrdvXt3pZGQRx55BIvFwiOPPMLevXtp3rw5w4cPZ9q0aZ77KkQaktIi2LXUHT62JUPGMZO//ULLl92Wj34ERVep2d/3HGJByg4++30/ZS73aEpsmB8394/j2j6tCPTVtWBEpH5q8FftFan3DAMytxzZ8XRnCpQVH3neYoWYPkfmfrTsCdaqjRo6XQZfr09jfsoOVu48WHE8sW0YYwfGcVHnSLy0MZmImERX7RUxU3EO7PjxyL4fOamVnw9sCQnlp17iBlVadlsVecWlLFqZyutLd7LnYBEA3lYLw7u3ZOyAOLq2CvbUVyIiUusURkQ8KWcv/PgM/Ppm5WW3XjZo0x/i3Vuu0+Ks45bdVkVqdiGvLdnJu7+kkl9SBkCIvw83JLVmVL+2RAZp4z8RaXgURkQ8If8ApDwLK+eDs3z34PCEI+Gj7QCwBdSoacMwWLnzIPNTtvP1+nTKp4OQ0KIZYwfEcUXPGPxsmgwuIg2XwojImSjMhqXPw/J/H9l+vc0AuOAR90jIGXCUufh87T4WpOxk7d4jK2zO69CcsQPacl775rpQnYg0CgojIjVRnAs/vwzL5kBJ+TVdYnq7Q0i782t0CuawgwUOFq7YzX+X7SQ91z3KYve2cmWvGMYOiKN9pLZqF5HGRWFEpDochbDiFVgyG4rKV69EdoHzH4aOF59RCNl6II/5KTv58Nc9FJe6t2pvEWhnVL82XJ/UhjBt1S4ijZTCiEhVlJXAqtfhx38d2ZI9vD2cPxk6XwEnuKxBVRiGwY9bMlmQsoMfNmdUHO8SE8S4gXFc2rWltmoXkUZPYUTkVJylsGYh/PA05O5xHwtpDYMnQ9drwatmf4WKS518+OteFqTsYMuBfMA9qHLRWZGMGxhHYlyYtmoXkSZDYUTkRFxO+OMD+H4GZG93HwuMhvMegJ43gXfNTpkcyC3mjZ938dby3WQXOAAIsHlxbd9YxvSPo3W4tmoXkaZHYUTkaIYBGz6F76ZDxgb3Mf8IOHci9BkLPn41avaPvTksSNnBp7/vo9TpXpsbE+LHmAFtubZvLEHaql1EmjCFERFwh5AtX8N3T8D+39zHfINhwARIvBXszardpNNl8M2GdOan7GDFjuyK433ahDKufKt2by/NBxERURgR2fEjfPsEpC53P7Y1g3PugH53gl9ItZsrKXOycPluXl+6k11Z7r1HvK0WLu0WzdgBcXSPrX6bIiKNmcKINF2pK+Hbx2HHD+7H3r6QeAsMuBcCwmvU5Ka0PCa88ysb0/IA91bt1ye25qZ+bYgOrtkpHhGRxk5hRJqe/b/Bt9Ngy5fux1Yf6H0znHc/BEbVqEmXy+C1pTt56ouNOMpchAfYuOeiDlzdq5W2ahcROQ2FEWk6DmyE76fD+o/djy1e0ON6GPSge7luDaXnFnP/e7/x05ZMAC7o1IKnrupG80C7J6oWEWn0FEak8cveDt8/Cb+/CxiABbpeDYMmQUTCGTX9f2v3M/nDtRwqLMXXx8ojl3bmhqTW2iNERKQaFEak8crZ496s7Nc3wXC6j3Ua5t66PbLzGTWdV1zKY5+u5/1V7o3QusYEM3tED+KbV3/VjYhIU6cwIo1PXjqkzIJfFoDTvbEYCRfBBQ9Dy55n3PwvO7O59901pGYXYbXAHYMT+NuF7bVtu4hIDSmMSONRmA1LnnNfyK7UvaSWNgPdV9Jt0++Mmy91ung+eQsvfrcVlwGtQv149roe9G0bdsZti4g0ZQoj0vAV58LPL8GyF6Ek130spg9cOAXiBp3RlXQP256Rz72L1vDbnhwAruwVwz/+crZ2ThUR8QCFEWm4HAXuUZAlz0HRQfexyK7ukZAOQz0SQgzD4O0VqTz+2XqKSp0E+/kw7YouDOvW8ozbFhERN4URaXjKSuCX1+CnmVBwwH0sogOc/3c46zKwembuRmZ+CZM++J1vNrj7GJAQzr+u6a7Ny0REPExhRBoOZymseQt+eAZy3atYCGkDgydDt2vB6rnNxb7dmM6D7/9OZr4Dm5eVB//ckbED4rBatWRXRMTTFEak/nM5Ye378P0MOLjDfSwoBs57AHreCF6em7dR5HAybfF63vx5NwAdIwOZPaIHZ0UHeawPERGpTGFE6i+XCzZ+Ct9Nh4yN7mMBzeHc+6D3GPDx9Wh3a/fkMGHRr2zPKABg3MA4HhjaEV8fbecuIlKbFEak/jEM2PKV+0q6ab+7j/mGwIAJkHQr2AI82p3TZTD3h208+/VmylwGkUF2Zl7Tg4HtIzzaj4iInJjCiNQv239wh5A9K9yPbYHQ707odwf4Bnu8u9TsQia+u4aVO92rcS7pGsX0K7oS4m/zeF8iInJiCiNSP5Q54POJ8Osb7sfefpD0V+g/AQLCPd6dYRh8tGYvUz9aR15JGQE2Lx67rAtX9YrRdWVEROqYwoiYryAL3r0Jdi0BixX6jnfPCwmMqpXucgpLefijtXz2+34AercJ5dlre9A63L9W+hMRkVNTGBFzZWyChdfCwZ1gD4KrX4P2Q2qtu6VbM7nvvd/Yn1OMt9XCPUPac9ugeLy9dF0ZERGzKIyIebZ+A++NcW/hHtoWRi6CFp1qpauSMif/+nIT835yLw1uFxHAs9f1oHtsSK30JyIiVacwIuZY/gp88RAYLmjdH657s1bmhgBsSstjwju/sjEtD4Abklrz8KVn4W/Tr7+ISH2gf42lbjlL4YtJsPJV9+MeN8CwZ8Hb7vGuXC6D15fu5MkvNuIocxEeYOOpq7oxpHOkx/sSEZGaUxiRulN0CN4bDdu/Byxw0WPQ/28euaDdsdJzi7n/vd/4aUsmABd0asFTV3WjeaDnQ4+IiJwZhRGpG1nbYOF1kLUFfALgqnnQ6dJa6er/1u5n8odrOVRYiq+PlUcu7cwNSa21ZFdEpJ5SGJHat+MnWHQjFB+CoFYw8m2I7ubxbvKKS3ns0/W8v8p9Eb2uMcHMHtGD+ObNPN6XiIh4jsKI1K5V/3FvZuYqg5g+MGIhBHp+zsaqXdncs2gNqdlFWCxwx+B4JlzYAZu3luyKiNR3CiNSO1xO+HoqLJvjftzlarhsDvj4ebSbUqeLF5K3MOe7rbgMiAnx49nrepAYF+bRfkREpPYojIjnFefCB+Nhy5fux4P/DoMe9PhE1e0Z+dy7aA2/7ckB4MpeMfzjL2cT5Ovj0X5ERKR2KYyIZx3cBW+PgAPrwdsXLn8Zulzp0S4Mw+DtFak8/tl6ikqdBPv5MO2KLgzr1tKj/YiISN1QGBHP2b0c3rkeCjOhWRSMXAgxvT3aRWZ+CZM++J1vNhwAoH98ODOv7U50sGdP/4iISN1RGBHP+G0RfHIXOB0Q1Q1GvgPBMR7t4ruNB3jg/d/IzHdg87Ly4J87MnZAHFarluyKiDRkCiNyZlwu+O4J+Gmm+3GnYXDlK2AL8FgXRQ4n0xdv4I2fdwHQMTKQ2SN6cFZ0kMf6EBER8yiMSM05CuDDW2HDp+7H594H5z8CVs8tp127J4cJi35le0YBAOMGxvHA0I74+nh5rA8RETGXwojUTO4+90TV/b+Blw3+8gJ0H+Gx5p0ug7k/bOPZrzdT5jKIDLLzr2u6c2775h7rQ0RE6geFEam+vavh7ZGQnwb+ETDiLWh9jseaT80u5L53f2PFzmwALu4SxfQruhIaYPNYHyIiUn8ojEj1rPsQPrwdyoqg+Vlw/SIIbeORpg3D4KM1e5n60TrySsoIsHnx2GVduKpXjK4rIyLSiCmMSNUYBvz4DHw3zf24/Z/gqvng65lJpIZhMO3zDbyasgOA3m1CefbaHrQO9/dI+yIiUn8pjMjplRa7l+2ufc/9+Jw74U+Pg9Vzk0if/XpzRRCZeFEH7hgcj7eXrisjItIUKIzIqeWluzcy2/sLWL3h0pnQ+2aPdvHy99t4/tutADz2l7MZ3b+tR9sXEZH6TWFETi5tLSwcAbl7wDcErnsD4s7zaBf/XbaTp77YCMBDf+6kICIi0gQpjMiJbVzsvthdaQGEJ8D170J4vEe7eO+XVKZ+vA6Auy9I4PbBnm1fREQaBoURqcwwYOnz8PWjgAFxg+Da/4BfqEe7+fS3fTz0we8AjB0Qx8SLOni0fRERaThqNEPwxRdfpG3btvj6+pKUlMSKFStO+trBgwdjsViOu1166aU1LlpqSZkDPr4Lvp4KGNBnHNz4gceDyDfr07l30RpcBoxMbM2UYWdp6a6ISBNW7TCyaNEiJk6cyKOPPsrq1avp3r07Q4cO5cCBAyd8/f/+9z/2799fcfvjjz/w8vLimmuuOePixYMKsuCNy2HNm2CxwsVPuyerevl4tJuULZncsXA1ZS6Dy3u05InLuyiIiIg0cdUOI7NmzeKWW25hzJgxdO7cmblz5+Lv78+CBQtO+PqwsDCioqIqbl9//TX+/v4KI/XJgY3w6gWwawnYg+D69yDpVvBwSPhlZza3/PcXHGUuhp4dyb+u6Y6XrrgrItLkVSuMOBwOVq1axZAhQ440YLUyZMgQli1bVqU25s+fz4gRIwgIOPlVXUtKSsjNza10k1qy9RuYfxEc3AmhbWHc19B+yOneVW1r9+Qw5rWVFJU6Oa9Dc54f2VP7iIiICFDNMJKZmYnT6SQyMrLS8cjISNLS0k77/hUrVvDHH38wfvz4U75uxowZBAcHV9xiY2OrU6ZU1fJX4K1roCQXWveH8d9Ci04e72ZTWh43LVhOXkkZiXFh/PvG3ti9ddVdERFxq9P/ms6fP5+uXbuSmJh4ytdNnjyZnJyciltqamodVdhEOEvh8/vg/x4AwwU9boBRH0FAuMe72pFZwI3zl3OosJTusSEsuLkvfjYFEREROaJaS3sjIiLw8vIiPT290vH09HSioqJO+d6CggLeeecd/vnPf562H7vdjt1ur05pUlVFB+G9m2H794AFLnoM+v/N4/NDAPYcLOSGeT+TkVdCp6hA/jOmL83sWk0uIiKVVWtkxGaz0bt3b5KTkyuOuVwukpOT6dev3ynf+95771FSUsKNN95Ys0rlzGVtg1cvcgcRnwAY8RYMmFArQeRAbjE3vrqcfTnFtGsewBvjkgjxt3m8HxERafiq/d/UiRMnMnr0aPr06UNiYiKzZ8+moKCAMWPGADBq1ChiYmKYMWNGpffNnz+fyy+/nPBwz58KkCrY8RMsuhGKD0FQKxj5NkR3q5Wusgsc3Dh/OTuzCmkV6sdb45NoHqiRLhERObFqh5HrrruOjIwMpk6dSlpaGj169OCLL76omNS6e/durNbKAy6bNm0iJSWFr776yjNVS/Ws+g98PhFcZRDTB0YshMDI07+vBnKLSxm1YDmb0/OJDLKzcPw5RAf71UpfIiLSOFgMwzDMLuJ0cnNzCQ4OJicnh6CgILPLaThcTvduqsvmuB93uRoumwM+tRMOCh1l3DR/Bat2HSQ8wMaiW/uR0KJZrfQlIiL1X1U/vzWbsLEqznVf6G7Ll+7Hg/8Ogx6slfkhAMWlTm757y+s2nWQIF9v/jsuUUFERESqRGGkMTq4C94eAQfWg7cvXP4ydLmy1rordbq4863VLNmaRYDNi9fHJnJ2y+Ba609ERBoXhZHGZvdyeOd6KMyEZlEwciHE9K617pwug3sWrSF54wHs3lZeHd2XXq09e2E9ERFp3BRGGpPf3oFP7ganA6K6wch3IDim1rpzuQwe+uB3Pv99Pz5eFv59U2/6xWu1lIiIVI/CSGPgcsG3j0PKLPfjTsPgylfAdvLr/5wpwzD4x6freH/VHrysFl4Y2YvBHVvUWn8iItJ4KYw0Bl89DD+/5L5/7n1w/iNgrb2d/g3D4MkvNvLfZbuwWOBf13Tjz11OvQOviIjIySiMNHS7lh0JIpe9BD1vqPUu53y7lX//sB2AaZd35YqerWq9TxERabx0DfeGrLTYPUcEoOeNdRJEXv1pOzO/3gzAI5eexfVJrWu9TxERadwURhqyH5+BrC3QLBL+9EStd7dw+W6e+HwDABMv6sD4c9vVep8iItL4KYw0VGl/wJLZ7vuXPAN+tbuc9qNf9/LwR2sBuHVQO+6+IKFW+xMRkaZDYaQhcpbBJ3e5rzXTaRh0vqxWu/vijzTue+83DANuOqcNk/7cCUst7eQqIiJNj8JIQ7T8Zdj3K9iD4ZJ/1WpX3286wN1vr8bpMriqVyse+8vZCiIiIuJRCiMNTfZ2+Haa+/6fHoeg6Frr6uftWdz6xipKnQaXdo3mqau6YrUqiIiIiGcpjDQkhgGfToCyImh7LvQaVWtdrUk9xLjXV1JS5uKCTi149roeeHvp10VERDxPny4Nya9vwo4f3Re/G/5crV2Bd/2+XEbNX06Bw0n/+HBeuqEXNm/9qoiISO3QJ0xDkZfu3mkV4Py/Q3h8rXSz9UA+N81fTm5xGb1ahzBvVB98fbxqpS8RERFQGGk4/u8BKM6B6B5wzp210kVqdiE3vrqcrAIHZ7cM4rUxiQTYtUmviIjULoWRhmDDZ7D+Y7B4wV9eAC/PB4T9OUVc/+rPpOUW075FM94Yl0Swn4/H+xERETmWwkh9V3QIPr/PfX/ABIju5vEuMvNLuOHV5aRmF9Em3J83xycRFmDzeD8iIiInojBS3309FfLTIDwBBj3k8eYPFTq48dXlbM8ooGWwL2+NTyIyyNfj/YiIiJyMwkh9tuMnWP0f9/3hz4OPZ0NCfkkZo19byca0PCKa2XnrlnNoFerv0T5EREROR2Gkviotgk//5r7fZyy0HeDR5oscTsa+vpLfUg8R4u/DW+OTiIsI8GgfIiIiVaEwUl99P8O922pgSxjymEebLilzctubq1ixI5tAuzdvjE2iY1SgR/sQERGpKoWR+mjfGlg6x31/2CzwDfJY02VOF397+1d+2JyBn48XC8b0pWurYI+1LyIiUl0KI/WNs9R9RV7DCWdfCR0v9ljTLpfB/e/9xpfr0rF5WZk3qg9924Z5rH0REZGaUBipb5a+AGlrwS8ULn7aY80ahsHDH/3BR2v24W218NINvRjYPsJj7YuIiNSUwkh9krkVvn/SfX/oDGjW3CPNGobBE59v4O0Vu7FY4NnrejCkc6RH2hYRETlTCiP1hcvlXj3jLIH4C6D7CI81/ew3W5ifsgOAp67sxvDuLT3WtoiIyJlSGKkvVr8Ou5aATwAMm+2xK/LO/WEbzydvAeAfwztzbd9Yj7QrIiLiKQoj9UHuPvj6Uff9C6dAaBuPNPvGsp08+X8bAXjwzx25eUCcR9oVERHxJIURsxmG+9ozJbkQ0wcS/+qRZt9ftYcpH68D4K7zE7hjcIJH2hUREfE0hRGzrfsQNi0Gq4/7irxWrzNu8vPf9/Pg+78BMGZAW+77U4czblNERKS2KIyYqTAb/u9B9/1zJ0Jk5zNuMnlDOhPe+RWXASP6xjJ1WGcsHpp/IiIiUhsURsz01SNQkAERHeHc+864uSVbM7n9rdWUuQz+0r0l067oqiAiIiL1nsKIWbZ9C2veAixw2Rzwtp9Rc7/szGb8f37BUebios6RzLy2O15WBREREan/FEbM4CiATye47yf+FWITz6i59ftyGfPaSopKnZzbPoI51/fEx0s/WhERaRj0iWWGb6fBod0QHAsXTj3j5p75ciN5JWUktg3jlZv6YPc+80mwIiIidUVhpK7tWQXLX3bfHzYb7M3OqDlHmYuft2cD8NhlZ+NnUxAREZGGRWGkLpU5yq/I64Ju10H7IWfc5K+7D1JU6iSimY1OUYEeKFJERKRuKYzUpSWz4cB68A93XwjPE01uzQSgf3yEVs6IiEiDpDBSVzI2wY/PuO9f/DQEhHuk2ZTyMDIwIcIj7YmIiNQ1hZG64HLBJ3eD0wHth0KXqzzSbG5xKb/tyQFgQHuFERERaZgURurCylchdTnYAmHYLI9dkXf59mycLoO4iABiQvw80qaIiEhdUxipbYdSIfkx9/0hj0JwK481fXi+yIAEz5zyERERMYPCSG0yDPjsXnDkQ+t+0GecR5vXfBEREWkMFEZq09r3YOvX4GWD4c+D1XPf7vTcYrYeyMdigX7tFEZERKThUhipLQWZ8H8Pue8PehCad/Bo84dP0XSNCSbY38ejbYuIiNQlhZHa8sUkKMqGyC4w4B6PN59SMV9EoyIiItKwKYzUhs1fuk/RWKzwlxfAy7MjF4ZhVIyMaL6IiIg0dAojnlaSB59NdN8/5w6I6eXxLrZl5JOeW4Ld20rvNqEeb19ERKQuKYx4WvI/IXcPhLaF8x+ulS5StrhHRfq2DcPXRxfGExGRhk1hxJN2L4cV89z3hz8HNv9a6SZlaxag+SIiItI4KIx4SlmJe8t3DOhxI7QbXDvdOF0s3+4OI5ovIiIijUGNwsiLL75I27Zt8fX1JSkpiRUrVpzy9YcOHeLOO+8kOjoau91Ohw4dWLx4cY0Krrd+/BdkboKAFjD0iVrr5ve9OeSVlBHs50PnlkG11o+IiEhd8a7uGxYtWsTEiROZO3cuSUlJzJ49m6FDh7Jp0yZatGhx3OsdDgcXXXQRLVq04P333ycmJoZdu3YREhLiifrrh/R1kDLLff+SZ8Cv9iaVLimfL9I/Phwvq2eucSMiImKmaoeRWbNmccsttzBmzBgA5s6dy+eff86CBQuYNGnSca9fsGAB2dnZLF26FB8f9xLXtm3bnlnV9YnL6T494yqDTsOg82W12p32FxERkcamWqdpHA4Hq1atYsiQIUcasFoZMmQIy5YtO+F7PvnkE/r168edd95JZGQkXbp0Yfr06TidzpP2U1JSQm5ubqVbvbV8LuxdBfZguORfHrsi74kUOspYvfsgoPkiIiLSeFQrjGRmZuJ0OomMjKx0PDIykrS0tBO+Z/v27bz//vs4nU4WL17MlClTmDlzJk88cfJ5FTNmzCA4OLjiFhsbW50y687BnfBt+dfxp39CUHStdrdiRzalToOYED/ahNfOSh0REZG6VuuraVwuFy1atOCVV16hd+/eXHfddTz88MPMnTv3pO+ZPHkyOTk5FbfU1NTaLrP6DAM+nQClhdD2XOg1uta7PHrXVUstjsCIiIjUpWrNGYmIiMDLy4v09PRKx9PT04mKijrhe6Kjo/Hx8cHL68jmXGeddRZpaWk4HA5sNttx77Hb7djt9uqUVvfWLITt34O3r3tPkToIBxX7i7TXKRoREWk8qjUyYrPZ6N27N8nJyRXHXC4XycnJ9OvX74TvGTBgAFu3bsXlclUc27x5M9HR0ScMIg1C/gH48u/u+4MnQ3h8rXeZlV/Chv3uuTP948NrvT8REZG6Uu3TNBMnTmTevHn85z//YcOGDdx+++0UFBRUrK4ZNWoUkydPrnj97bffTnZ2NhMmTGDz5s18/vnnTJ8+nTvvvNNzX0VdW/wAFB+C6O7Q76466XLpNveoSKeoQCKa1fNRIxERkWqo9tLe6667joyMDKZOnUpaWho9evTgiy++qJjUunv3bqzWIxknNjaWL7/8knvvvZdu3boRExPDhAkTeOihhzz3VdSljZ/D+o/A4gV/mQNe1f4W1oiu0isiIo2VxTAMw+wiTic3N5fg4GBycnIICjJx19HiHHgxCfL2w8B7Ycg/6qRbwzAY+NR37D1UxGtj+nJ+x+M3lxMREalvqvr5rWvTVMfXU91BJCweBtXdyM7u7EL2HirCx8tCYtuwOutXRESkLiiMVNXOFFj1uvv+X14AH7866/rwrqs9W4cSYK+b00IiIiJ1RWGkKkqLyq/IC/QeA20H1Gn3mi8iIiKNmcJIVXz/JGRvh8BouOixOu3a5TIqVtLoejQiItIYKYyczv7fYOkL7vuXzgLf4Drtfv3+XA4VltLM7k33VnXbt4iISF1QGDkVZ5n79IzhhLOvgE6X1HkJh+eLnNMuDG8v/bhERKTx0afbqSyb4x4Z8Q2Bi582pYTD80V0ikZERBorhZGTydoG389w3//zDGhW93t7FJc6WbEjG9DkVRERabwURk7k8BV5y4oh/gLoPtKUMlbvOkhJmYsWgXYSWjQzpQYREZHapjByIqv/Azt/Ah9/GDa7Tq7IeyIpRy3ptZhUg4iISG1TGDlW7n74aqr7/gVTILSNaaVovoiIiDQFCiNHMwxYfD+U5EBMb0i61bRScgpL+X1vDqAwIiIijZvCyNHWfwwbPwOrt3vLd6uXaaUs256FYUB88wCign1Nq0NERKS2KYwcVpgNix9w3x84ESLPNrUcbQEvIiJNhcLIYV9NgYIDENERzrvf7Go0X0RERJoMhRGAbd/BmjcBi/v0jLfd1HL2Hipie2YBVgucEx9uai0iIiK1TWHEUeDeUwQg8RZonWRuPRwZFekeG0KQr4/J1YiIiNQuhZHvpsOhXRDUCi6canY1gOaLiIhI09K0w8jeVfDzS+77w2eDPdDUcgAMw2DJ1ixA80VERKRpaLphpMwBH98Nhgu6XgvtLzK7IgA2p+eTmV+Cr4+Vnq1DzC5HRESk1jXdMGKxQvfrIDgW/vyk2dVUOLwFfGJcOHZv8/Y5ERERqSveZhdgGi9vGDABkm4zffXM0Y7MF9EqGhERaRqa7sjIYfUoiJQ6Xfy8XfNFRESkaVEYqUfWpB6i0OEkLMDGWVFBZpcjIiJSJxRG6pGULe5TNP3jw7FaLSZXIyIiUjcURuoR7S8iIiJNkcJIPZFfUsaa1EOA5ouIiEjTojBST6zYkUWZy6B1mD+xYf5mlyMiIlJnFEbqiZQtWkUjIiJNk8JIPaH5IiIi0lQpjNQDB/KK2ZSeh8UC/eK12ZmIiDQtCiP1wNLyC+Od3TKIsACbydWIiIjULYWReuDw9Wg0X0RERJoihRGTGYah+SIiItKkKYyYbEdmAftzirF5WenTJszsckREROqcwojJDo+K9G4Tip/Ny+RqRERE6p7CiMkOzxcZ2F6naEREpGlSGDGR02WwdJs2OxMRkaZNYcREa/fmkFdcRqCvN11jgs0uR0RExBQKIyY6PF+kf3w4XlaLydWIiIiYQ2HERClbtKRXREREYcQkRQ4nq3YdBDRfREREmjaFEZP8sisbh9NFdLAvcREBZpcjIiJiGoURkxy9BbzFovkiIiLSdCmMmERbwIuIiLgpjJggu8DBun25APRPCDe5GhEREXMpjJhg2bYsDAM6RgbSItDX7HJERERMpTBigqPni4iIiDR1CiMmqJgv0l6naERERBRG6lhqdiG7swvxtlpIjFMYERERURipY4dHRXrEhtDM7m1yNSIiIuZTGKljmi8iIiJSmcJIHXK5DJZuywJgYHuFEREREahhGHnxxRdp27Ytvr6+JCUlsWLFipO+9vXXX8disVS6+fo2zeWsG9JyyS5wEGDzokdsiNnliIiI1AvVDiOLFi1i4sSJPProo6xevZru3bszdOhQDhw4cNL3BAUFsX///orbrl27zqjohurwfJGkduH4eGlQSkREBGoQRmbNmsUtt9zCmDFj6Ny5M3PnzsXf358FCxac9D0Wi4WoqKiKW2Rk5BkV3VClbHWfotF8ERERkSOqFUYcDgerVq1iyJAhRxqwWhkyZAjLli076fvy8/Np06YNsbGxXHbZZaxbt+6U/ZSUlJCbm1vp1tCVlDlZsaN8vojCiIiISIVqhZHMzEycTudxIxuRkZGkpaWd8D0dO3ZkwYIFfPzxx7z55pu4XC769+/Pnj17TtrPjBkzCA4OrrjFxsZWp8x66dfdhygudRHRzE6HyGZmlyMiIlJv1PrEhX79+jFq1Ch69OjBoEGD+N///kfz5s3597//fdL3TJ48mZycnIpbampqbZdZ65ZULOkNx2KxmFyNiIhI/VGtXbciIiLw8vIiPT290vH09HSioqKq1IaPjw89e/Zk69atJ32N3W7HbrdXp7R6T/uLiIiInFi1RkZsNhu9e/cmOTm54pjL5SI5OZl+/fpVqQ2n08natWuJjo6uXqUNWG5xKb+lHgIURkRERI5V7f3IJ06cyOjRo+nTpw+JiYnMnj2bgoICxowZA8CoUaOIiYlhxowZAPzzn//knHPOISEhgUOHDvHMM8+wa9cuxo8f79mvpB77eVsWLgPaRQQQE+JndjkiIiL1SrXDyHXXXUdGRgZTp04lLS2NHj168MUXX1RMat29ezdW65EBl4MHD3LLLbeQlpZGaGgovXv3ZunSpXTu3NlzX0U9t0SnaERERE7KYhiGYXYRp5Obm0twcDA5OTkEBQWZXU61XTjze7ZlFDD3xt78uUvV5taIiIg0dFX9/NY2oLUsLaeYbRkFWC3Qr1242eWIiIjUOwojtezwKZquMcEE+/uYXI2IiEj9ozBSyzRfRERE5NQURmqRYRgV+4toC3gREZETUxipRVsP5HMgrwS7t5VebULNLkdERKReUhipRYdHRRLjwvD18TK5GhERkfpJYaQWab6IiIjI6SmM1JIyp4uft2cDmi8iIiJyKgojteS3PTnkl5QR4u9D5+iGt1GbiIhIXVEYqSWHT9H0jw/HarWYXI2IiEj9pTBSS1I0X0RERKRKFEZqQUFJGb/uPghovoiIiMjpKIzUghU7syl1GrQK9aN1mL/Z5YiIiNRrCiO1YMmWI7uuWiyaLyIiInIqCiO1QPNFREREqk5hxMMy80vYmJYHuFfSiIiIyKkpjHjY0m1ZAJwVHUR4M7vJ1YiIiNR/CiMedmS+iEZFREREqkJhxIMMw9B8ERERkWpSGPGgXVmF7D1UhI+XhcS4MLPLERERaRAURjzo8KhIr9ah+Nu8Ta5GRESkYVAY8aDD16PRrqsiIiJVpzDiIU6XUbGSZkB7hREREZGqUhjxkHX7csgpKiXQ7k23mGCzyxEREWkwFEY8ZMlW96hIUrtwvL30bRUREakqfWp6yJH5ItpfREREpDoURjyguNTJip3ZAAzUfBEREZFqURjxgFW7DuIocxEZZCe+eTOzyxEREWlQFEY84OhdVy0Wi8nViIiINCwKIx6g/UVERERqTmHkDB0qdLB2bw6g69GIiIjUhMLIGfp5exaGAQktmhEZ5Gt2OSIiIg2OwsgZStEpGhERkTOiMHKGDm92plM0IiIiNaMwcgb2HCxkR2YBXlYLSe3CzC5HRESkQVIYOQNLy0dFurcKJsjXx+RqREREGiaFkTOg+SIiIiJnTmGkhlwuo2J/Ec0XERERqTmFkRralJ5HVoEDPx8verYONbscERGRBkthpIYOj4okxoVh89a3UUREpKb0KVpD2gJeRETEMxRGasBR5mL5jmxA80VERETOlMJIDaxJPUShw0l4gI1OUYFmlyMiItKgKYzUwOElvf0TIrBaLSZXIyIi0rApjNTAkfki4SZXIiIi0vApjFRTXnEpa1IPAZovIiIi4gkKI9W0Ykc2TpdBm3B/WoX6m12OiIhIg6cwUk0p2nVVRETEoxRGqkn7i4iIiHiWwkg1HMgtZnN6PhYL9GunyasiIiKeoDBSDUu2uUdFurQMJjTAZnI1IiIijYPCSDWkbMkCNF9ERETEkxRGqsgwDM0XERERqQU1CiMvvvgibdu2xdfXl6SkJFasWFGl973zzjtYLBYuv/zymnRrqm0ZBaTlFmPzttKnbajZ5YiIiDQa1Q4jixYtYuLEiTz66KOsXr2a7t27M3ToUA4cOHDK9+3cuZP777+fc889t8bFmmlp+XyRPm1C8fXxMrkaERGRxqPaYWTWrFnccsstjBkzhs6dOzN37lz8/f1ZsGDBSd/jdDq54YYbeOyxx2jXrt0ZFWyWlC3aX0RERKQ2VCuMOBwOVq1axZAhQ440YLUyZMgQli1bdtL3/fOf/6RFixaMGzeuSv2UlJSQm5tb6WamMqeLZdvdk1c1X0RERMSzqhVGMjMzcTqdREZGVjoeGRlJWlraCd+TkpLC/PnzmTdvXpX7mTFjBsHBwRW32NjY6pTpcWv35pBXXEaQrzddYoJNrUVERKSxqdXVNHl5edx0003MmzePiIiqjyhMnjyZnJyciltqamotVnl6h1fR9I+PwMtqMbUWERGRxsa7Oi+OiIjAy8uL9PT0SsfT09OJioo67vXbtm1j586dDB8+vOKYy+Vyd+ztzaZNm4iPjz/ufXa7HbvdXp3SalXF9Wja6xSNiIiIp1VrZMRms9G7d2+Sk5MrjrlcLpKTk+nXr99xr+/UqRNr165lzZo1Fbe//OUvnH/++axZs8b00y9VUegoY/WuQ4Dmi4iIiNSGao2MAEycOJHRo0fTp08fEhMTmT17NgUFBYwZMwaAUaNGERMTw4wZM/D19aVLly6V3h8SEgJw3PH6auXOgzicLloG+9I23N/sckRERBqdaoeR6667joyMDKZOnUpaWho9evTgiy++qJjUunv3bqzWxrOx69KtR5b0WiyaLyIiIuJpFsMwDLOLOJ3c3FyCg4PJyckhKCioTvu+9PmfWLcvl+dG9OCyHjF12reIiEhDVtXP78YzhFELsgscrNvn3uOkf7zmi4iIiNQGhZFTOLwFfKeoQJoH1p/VPSIiIo2JwsgpLNmqLeBFRERqm8LIKRzeX0RLekVERGqPwshJ7M4qJDW7CG+rhcS4MLPLERERabQURk5iSfl8kZ6tQwiwV3sFtIiIiFSRwshJpGi+iIiISJ1QGDkBl8uo2OxM80VERERql8LICazfn8vBwlICbF50jw0xuxwREZFGTWHkBA4v6T2nXTg+XvoWiYiI1CZ90p6A5ouIiIjUHYWRYxSXOlm5MxuAge0VRkRERGqbwsgxVu8+SHGpi+aBdtq3aGZ2OSIiIo2ewsgxlm7NAmBAfDgWi8XkakRERBo/hZFjaL6IiIhI3VIYOUpOUSm/7zkEKIyIiIjUFYWRo/y8PQuXAe2aB9AyxM/sckRERJoEhZGjLNGuqyIiInVOYeQomi8iIiJS9xRGyu3PKWJ7RgFWi3vnVREREakbCiPllpQv6e3aKoRgPx+TqxEREWk6FEbKHZkvolERERGRuqQwAhiGofkiIiIiJlEYAbYcyCcjrwRfHyu9WoeaXY6IiEiTojACpGxxj4r0bRuGr4+XydWIiIg0LQojaH8RERERMzX5MFLqdPHz9vKL4ymMiIiI1LkmH0Z+Sz1EgcNJqL8PnaODzC5HRESkyWnyYeTw/iL94yOwWi0mVyMiItL0KIxoSa+IiIipmnQYKSgpY/Xug4Amr4qIiJilSYeRFTuyKXMZxIb50Trc3+xyREREmqQmHUZStKRXRETEdE06jGi+iIiIiPm8zS7ALIZhcPvgeFK2ZNKvnS6OJyIiYpYmG0YsFguX9Yjhsh4xZpciIiLSpDXp0zQiIiJiPoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIipFEZERETEVAojIiIiYiqFERERETGVwoiIiIiYSmFERERETKUwIiIiIqZqEFftNQwDgNzcXJMrERERkao6/Ll9+HP8ZBpEGMnLywMgNjbW5EpERESkuvLy8ggODj7p8xbjdHGlHnC5XOzbt4/AwEAsFovH2s3NzSU2NpbU1FSCgoI81q7UjH4e9Y9+JvWLfh71i34ep2cYBnl5ebRs2RKr9eQzQxrEyIjVaqVVq1a11n5QUJB+keoR/TzqH/1M6hf9POoX/TxO7VQjIodpAquIiIiYSmFERERETNWkw4jdbufRRx/FbrebXYqgn0d9pJ9J/aKfR/2in4fnNIgJrCIiItJ4NemRERERETGfwoiIiIiYSmFERERETKUwIiIiIqZq0mHkxRdfpG3btvj6+pKUlMSKFSvMLqlJmjFjBn379iUwMJAWLVpw+eWXs2nTJrPLknJPPvkkFouFe+65x+xSmqy9e/dy4403Eh4ejp+fH127duWXX34xu6wmy+l0MmXKFOLi4vDz8yM+Pp7HH3/8tNdfkZNrsmFk0aJFTJw4kUcffZTVq1fTvXt3hg4dyoEDB8wurcn54YcfuPPOO/n555/5+uuvKS0t5U9/+hMFBQVml9bkrVy5kn//+99069bN7FKarIMHDzJgwAB8fHz4v//7P9avX8/MmTMJDQ01u7Qm66mnnuLll19mzpw5bNiwgaeeeoqnn36aF154wezSGqwmu7Q3KSmJvn37MmfOHMB9/ZvY2FjuvvtuJk2aZHJ1TVtGRgYtWrTghx9+4LzzzjO7nCYrPz+fXr168dJLL/HEE0/Qo0cPZs+ebXZZTc6kSZNYsmQJP/30k9mlSLlhw4YRGRnJ/PnzK45dddVV+Pn58eabb5pYWcPVJEdGHA4Hq1atYsiQIRXHrFYrQ4YMYdmyZSZWJgA5OTkAhIWFmVxJ03bnnXdy6aWXVvp7InXvk08+oU+fPlxzzTW0aNGCnj17Mm/ePLPLatL69+9PcnIymzdvBuC3334jJSWFiy++2OTKGq4GcaE8T8vMzMTpdBIZGVnpeGRkJBs3bjSpKgH3CNU999zDgAED6NKli9nlNFnvvPMOq1evZuXKlWaX0uRt376dl19+mYkTJ/L3v/+dlStX8re//Q2bzcbo0aPNLq9JmjRpErm5uXTq1AkvLy+cTifTpk3jhhtuMLu0BqtJhhGpv+68807++OMPUlJSzC6lyUpNTWXChAl8/fXX+Pr6ml1Ok+dyuejTpw/Tp08HoGfPnvzxxx/MnTtXYcQk7777Lm+99RYLFy7k7LPPZs2aNdxzzz20bNlSP5MaapJhJCIiAi8vL9LT0ysdT09PJyoqyqSq5K677uKzzz7jxx9/pFWrVmaX02StWrWKAwcO0KtXr4pjTqeTH3/8kTlz5lBSUoKXl5eJFTYt0dHRdO7cudKxs846iw8++MCkiuSBBx5g0qRJjBgxAoCuXbuya9cuZsyYoTBSQ01yzojNZqN3794kJydXHHO5XCQnJ9OvXz8TK2uaDMPgrrvu4sMPP+Tbb78lLi7O7JKatAsvvJC1a9eyZs2ailufPn244YYbWLNmjYJIHRswYMBxS903b95MmzZtTKpICgsLsVorf3x6eXnhcrlMqqjha5IjIwATJ05k9OjR9OnTh8TERGbPnk1BQQFjxowxu7Qm584772ThwoV8/PHHBAYGkpaWBkBwcDB+fn4mV9f0BAYGHjdfJyAggPDwcM3jMcG9995L//79mT59Otdeey0rVqzglVde4ZVXXjG7tCZr+PDhTJs2jdatW3P22Wfz66+/MmvWLMaOHWt2aQ2X0YS98MILRuvWrQ2bzWYkJiYaP//8s9klNUnACW+vvfaa2aVJuUGDBhkTJkwwu4wm69NPPzW6dOli2O12o1OnTsYrr7xidklNWm5urjFhwgSjdevWhq+vr9GuXTvj4YcfNkpKSswurcFqsvuMiIiISP3QJOeMiIiISP2hMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRUCiMiIiJiKoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIip/h/W4GepSlrWmQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "history = swivel_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+    "model.compile(\n",
+    "    optimizer=tf.keras.optimizers.Adam(learning_rate=0.001),\n",
+    "    loss=tf.keras.losses.CategoricalCrossentropy(),\n",
+    "    metrics=[tf.keras.metrics.CategoricalAccuracy(name='accuracy')]\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "jVzN1EgzN00g"
+   },
    "source": [
-    "Swivel trains faster but achieves a lower validation accuracy, and requires more epochs to train on."
+    "Let's train the model for 5 epochs using our prepared `train_ds_prepared` and validating on `eval_ds_prepared`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9KlA8W0LN00h"
+   },
+   "outputs": [],
+   "source": [
+    "EPOCHS = 5\n",
+    "\n",
+    "history = model.fit(\n",
+    "    train_ds_prepared,\n",
+    "    validation_data=eval_ds_prepared,\n",
+    "    epochs=EPOCHS\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "0DkO4p8ON00h"
+   },
    "source": [
-    "## Bonus"
+    "## Evaluate and Test Predictions\n",
+    "\n",
+    "Let's inspect our trained model's final accuracy on the evaluation dataset and test some sample headline predictions."
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f5kC8V0tN00h"
+   },
+   "outputs": [],
    "source": [
-    "Try to beat the best model by modifying the model architecture, changing the TF-Hub embedding, and tweaking the training parameters."
+    "loss, acc = model.evaluate(eval_ds_prepared, verbose=0)\n",
+    "print(f\"Final Evaluation Accuracy: {acc * 100:.2f}%\")\n",
+    "print(f\"Final Evaluation Loss: {loss:.4f}\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d0kN6g9vN00h"
+   },
+   "outputs": [],
    "source": [
-    "Copyright 2023 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
+    "# Test on new arbitrary headline strings\n",
+    "test_headlines = tf.constant([\n",
+    "    \"New Python library released on Github with 10k stars and open source license.\",\n",
+    "    \"The New York Times reports major geopolitical shifts and economic policy updates in Washington.\",\n",
+    "    \"TechCrunch startup raises $50M Series A funding round led by top Silicon Valley venture capital firms.\"\n",
+    "])\n",
+    "\n",
+    "preds = model.predict(test_headlines)\n",
+    "\n",
+    "for headline, pred in zip(test_headlines.numpy(), preds):\n",
+    "    pred_idx = pred.argmax()\n",
+    "    pred_class = CLASSES[pred_idx]\n",
+    "    confidence = pred[pred_idx] * 100\n",
+    "    print(f\"\\nHeadline: {headline.decode('utf-8')}\")\n",
+    "    print(f\"Predicted Source: '{pred_class}' ({confidence:.1f}% confidence)\")"
    ]
   }
  ],
  "metadata": {
-  "environment": {
-   "kernel": "conda-env-tensorflow-tensorflow",
-   "name": "workbench-notebooks.m131",
-   "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m131"
+  "colab": {
+   "collapsed_sections": [],
+   "name": "reusable_embeddings.ipynb",
+   "provenance": []
   },
   "kernelspec": {
-   "display_name": "TensorFlow 2-11 (Local)",
+   "display_name": "Python 3 (Local)",
    "language": "python",
-   "name": "conda-env-tensorflow-tensorflow"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1760,9 +749,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }

--- a/courses/machine_learning/deepdive2/text_classification/solutions/reusable_embeddings.ipynb
+++ b/courses/machine_learning/deepdive2/text_classification/solutions/reusable_embeddings.ipynb
@@ -2,7 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "7SN5USFEIIK3"
+   },
    "source": [
     "# Reusable Embeddings\n",
     "\n",
@@ -16,16 +18,36 @@
     "\n",
     "In this notebook, we will implement text models to recognize the probable source (Github, Tech-Crunch, or The New-York Times) of the titles we have in the title dataset.\n",
     "\n",
-    "First, we will load and pre-process the texts and labels so that they are suitable to be fed to sequential Keras models with first layer being TF-hub pre-trained modules. Thanks to this first layer, we won't need to tokenize and integerize the text before passing it to our models. The pre-trained layer will take care of that for us, and consume directly raw text. However, we will still have to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
+    "First, we will load and pre-process the texts and labels so that they are suitable to be fed to sequential Keras models with first layer being TF-Hub pre-trained modules. Thanks to this first layer, we won't need to tokenize and integerize the text before passing it to our models. The pre-trained layer will take care of that for us, and consume directly raw text. However, we will still have to one-hot-encode each of the 3 classes into a 3 dimensional basis vector.\n",
     "\n",
-    "Then we will build, train and compare simple DNN models starting with different pre-trained TF-Hub layers."
+    "Then we will build, train and compare simple DNN models starting with one more pre-trained TF-Hub layers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Environment Setup\n",
+    "If you are running this notebook in an on-demand lab environment (such as Vertex AI Workbench / Qwiklabs), ensure the **Python 3 (Local)** kernel is selected. Run the first code cell below to install required packages (`setuptools<70.0.0`, `protobuf==3.20.3`, and `tensorflow==2.12.*`) before importing libraries to prevent `ModuleNotFoundError: No module named 'pkg_resources'`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade pip\n",
+    "!pip install \"setuptools<70.0.0\"\n",
+    "!pip install --upgrade \"tensorflow==2.12.*\" \"tensorflow-hub==0.12.0\" \"keras==2.12.*\"\n",
+    "!pip install protobuf==3.20.3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "J1xI7nLzO8z4"
    },
    "outputs": [],
    "source": [
@@ -37,27 +59,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "e_zMItgXN00Y"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The google.cloud.bigquery extension is already loaded. To reload it, use:\n",
-      "  %reload_ext google.cloud.bigquery\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext google.cloud.bigquery"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "hBfO-t8TfK74"
+   },
    "source": [
     "Replace the variable values in the cell below:"
    ]
@@ -66,7 +81,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "3Z8P1n_zN00Y"
    },
    "outputs": [],
    "source": [
@@ -80,8 +95,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9Btt0W0KN00Y"
+   },
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "gcloud config set project $PROJECT\n",
+    "gcloud config set compute/region $REGION"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "1mYgQcTf9w1r"
+   },
    "source": [
     "## Create a Dataset from BigQuery \n",
     "\n",
@@ -92,173 +122,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "e_bT7nB0N00a"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "127f4f32dadb442baba84f204c527933",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2438: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2452: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2466: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a557f5309ba94a0ba7bdf154e189502c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>url</th>\n",
-       "      <th>title</th>\n",
-       "      <th>score</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>https://blog.amigocloud.com/sub-meter-data-col...</td>\n",
-       "      <td>Entire Golf Course at Centimeter Accuracy – Fr...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>http://perspectives.mvdirona.com/2009/10/14/Re...</td>\n",
-       "      <td>Does it make sense to replace all disks with S...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>https://www.aclu.org/blog/national-security-te...</td>\n",
-       "      <td>ACLU-Obtained Documents Reveal Breadth of Secr...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>https://git.kernel.org/cgit/linux/kernel/git/t...</td>\n",
-       "      <td>Hurr durr I'ma sheep</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>http://bit-player.org/2015/mrs-nguyens-prestid...</td>\n",
-       "      <td>Mrs. Nguyen’s prestidigitation</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>http://parametricity.com/posts/2015-02-19-anim...</td>\n",
-       "      <td>Animating Abstractly</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>http://www.reuters.com/article/2015/02/16/us-f...</td>\n",
-       "      <td>Small farmers hold the key to seed diversity: ...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>http://digitalcommons.unl.edu/cgi/viewcontent....</td>\n",
-       "      <td>Are Political Orientations Genetically Transmi...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>http://www.psmag.com/health-and-behavior/how-t...</td>\n",
-       "      <td>How the American opiate epidemic was started b...</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>http://www.bloomberg.com/news/videos/2015-02-2...</td>\n",
-       "      <td>Check Out Washio on Bloomberg West Today</td>\n",
-       "      <td>11</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                 url  \\\n",
-       "0  https://blog.amigocloud.com/sub-meter-data-col...   \n",
-       "1  http://perspectives.mvdirona.com/2009/10/14/Re...   \n",
-       "2  https://www.aclu.org/blog/national-security-te...   \n",
-       "3  https://git.kernel.org/cgit/linux/kernel/git/t...   \n",
-       "4  http://bit-player.org/2015/mrs-nguyens-prestid...   \n",
-       "5  http://parametricity.com/posts/2015-02-19-anim...   \n",
-       "6  http://www.reuters.com/article/2015/02/16/us-f...   \n",
-       "7  http://digitalcommons.unl.edu/cgi/viewcontent....   \n",
-       "8  http://www.psmag.com/health-and-behavior/how-t...   \n",
-       "9  http://www.bloomberg.com/news/videos/2015-02-2...   \n",
-       "\n",
-       "                                               title  score  \n",
-       "0  Entire Golf Course at Centimeter Accuracy – Fr...     11  \n",
-       "1  Does it make sense to replace all disks with S...     11  \n",
-       "2  ACLU-Obtained Documents Reveal Breadth of Secr...     11  \n",
-       "3                               Hurr durr I'ma sheep     11  \n",
-       "4                     Mrs. Nguyen’s prestidigitation     11  \n",
-       "5                               Animating Abstractly     11  \n",
-       "6  Small farmers hold the key to seed diversity: ...     11  \n",
-       "7  Are Political Orientations Genetically Transmi...     11  \n",
-       "8  How the American opiate epidemic was started b...     11  \n",
-       "9           Check Out Washio on Bloomberg West Today     11  "
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bigquery --project $PROJECT\n",
     "\n",
@@ -275,171 +143,25 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "P5yH9GvKAB-p"
+   },
    "source": [
     "Let's do some regular expression parsing in BigQuery to get the source of the newspaper article from the URL. For example, if the url is http://mobile.nytimes.com/...., I want to be left with <i>nytimes</i>"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "y-cI7vE0N00a"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b136e3f911e24562a0ba523e9babef00",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Query is running:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2438: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2452: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2466: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f013b318450c4b5ca0adc81418ca93cb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading:   0%|          |"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>source</th>\n",
-       "      <th>num_articles</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>github</td>\n",
-       "      <td>183581</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>medium</td>\n",
-       "      <td>134373</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>youtube</td>\n",
-       "      <td>129422</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>nytimes</td>\n",
-       "      <td>84901</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>blogspot</td>\n",
-       "      <td>62136</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>itworld</td>\n",
-       "      <td>3163</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>nextplatform</td>\n",
-       "      <td>3155</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>atlasobscura</td>\n",
-       "      <td>3078</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>anandtech</td>\n",
-       "      <td>3015</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>99</th>\n",
-       "      <td>oreilly</td>\n",
-       "      <td>2988</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>100 rows × 2 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "          source  num_articles\n",
-       "0         github        183581\n",
-       "1         medium        134373\n",
-       "2        youtube        129422\n",
-       "3        nytimes         84901\n",
-       "4       blogspot         62136\n",
-       "..           ...           ...\n",
-       "95       itworld          3163\n",
-       "96  nextplatform          3155\n",
-       "97  atlasobscura          3078\n",
-       "98     anandtech          3015\n",
-       "99       oreilly          2988\n",
-       "\n",
-       "[100 rows x 2 columns]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bigquery --project $PROJECT\n",
     "\n",
     "SELECT\n",
-    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source,\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[SAFE_OFFSET(1)] AS source,\n",
     "    COUNT(title) AS num_articles\n",
     "FROM\n",
     "    `bigquery-public-data.hacker_news.full`\n",
@@ -449,48 +171,25 @@
     "GROUP BY\n",
     "    source\n",
     "ORDER BY num_articles DESC\n",
-    "  LIMIT 100"
+    "  LIMIT 10"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "eJjI8nJcAAu1"
+   },
    "source": [
     "Now that we have good parsing of the URL to get the source, let's put together a dataset of source and titles. This will be our labeled dataset for machine learning."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "jVzN1EgzN00a"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "SELECT \n",
-      "    LOWER(REGEXP_REPLACE(title, '[^a-zA-Z0-9 $.-]', ' ')) AS title,\n",
-      "    source\n",
-      "FROM\n",
-      "  (\n",
-      "SELECT\n",
-      "    title,\n",
-      "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.'))[safe_offset (1)] AS source\n",
-      "    \n",
-      "FROM\n",
-      "    `bigquery-public-data.hacker_news.full`\n",
-      "WHERE\n",
-      "    REGEXP_CONTAINS(REGEXP_EXTRACT(url, '.*://(.[^/]+)/'), '.com$')\n",
-      "    AND LENGTH(title) > 10\n",
-      ")\n",
-      "WHERE (source = 'github' OR source = 'nytimes' OR source = 'techcrunch')\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "regex = '.*://(.[^/]+)/'\n",
     "\n",
@@ -498,7 +197,7 @@
     "sub_query = \"\"\"\n",
     "SELECT\n",
     "    title,\n",
-    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '{0}'), '.'))[safe_offset (1)] AS source\n",
+    "    ARRAY_REVERSE(SPLIT(REGEXP_EXTRACT(url, '{0}'), '.'))[SAFE_OFFSET(1)] AS source\n",
     "    \n",
     "FROM\n",
     "    `bigquery-public-data.hacker_news.full`\n",
@@ -522,7 +221,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "RLeT3m3N9w1r"
+   },
    "source": [
     "For ML training, we usually need to split our dataset into training and evaluation datasets (and perhaps an independent test dataset if we are going to do model or feature selection based on the evaluation dataset). AutoML however figures out on its own how to create these splits, so we won't need to do that here. \n",
     "\n"
@@ -530,92 +231,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "8PqC8QEzN00b"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2438: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2452: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n",
-      "/opt/conda/envs/tensorflow/lib/python3.10/site-packages/google/cloud/bigquery/table.py:2466: UserWarning: Unable to represent RANGE schema as struct using pandas ArrowDtype. Using `object` instead. To use ArrowDtype, use pandas >= 1.5 and pyarrow >= 10.0.1.\n",
-      "  warnings.warn(_RANGE_PYARROW_WARNING)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>title</th>\n",
-       "      <th>source</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>the new face of committing in github for mac</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>a git notifier for mac os x written in go</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>show hn  hue-wheel for html5 browsers</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>send ripples from salesforce</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>grind polishes go programs</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                          title  source\n",
-       "0  the new face of committing in github for mac  github\n",
-       "1     a git notifier for mac os x written in go  github\n",
-       "2         show hn  hue-wheel for html5 browsers  github\n",
-       "3                  send ripples from salesforce  github\n",
-       "4                    grind polishes go programs  github"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bq = bigquery.Client(project=PROJECT)\n",
     "title_dataset = bq.query(query).to_dataframe()\n",
@@ -624,7 +244,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "f5fP2k_C9w1s"
+   },
    "source": [
     "AutoML for text classification requires that\n",
     "* the dataset be in csv form with \n",
@@ -636,1101 +258,486 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "jGkE1B00N00b"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The full dataset contains 328310 titles\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(\"The full dataset contains {n} titles\".format(n=len(title_dataset)))"
+    "print(\"The full dataset has %d titles\" % len(title_dataset))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "B3eA2k3C9w1s"
+   },
    "source": [
     "Let's make sure we have roughly the same number of labels for each of our three labels:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "9KlA8W0LN00b"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        183581\n",
-       "nytimes        84901\n",
-       "techcrunch     59828\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "title_dataset.source.value_counts()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "t7eK3F8G9w1s"
+   },
    "source": [
-    "Finally we will save our data, which is currently in-memory, to disk.\n",
-    "\n",
-    "We will create a csv file containing the full dataset and another containing only 1000 articles for development.\n",
-    "\n",
-    "**Note:** It may take a long time to train AutoML on the full dataset, so we recommend to use the sample dataset for the purpose of learning the tool. \n"
+    "Finally, let's save what we have to our Elasticsearch instance."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "0DkO4p8ON00b"
    },
    "outputs": [],
    "source": [
     "DATADIR = './data/'\n",
     "\n",
     "if not os.path.exists(DATADIR):\n",
-    "    os.makedirs(DATADIR)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "    os.makedirs(DATADIR)\n",
+    "    \n",
     "FULL_DATASET_NAME = 'titles_full.csv'\n",
     "FULL_DATASET_PATH = os.path.join(DATADIR, FULL_DATASET_NAME)\n",
     "\n",
     "# Let's shuffle the data before writing it to disk.\n",
-    "title_dataset = title_dataset.sample(n=len(title_dataset))\n",
+    "title_dataset = title_dataset.sample(n=len(title_dataset)).reset_index(drop=True)\n",
     "\n",
-    "title_dataset.to_csv(\n",
-    "    FULL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
+    "title_dataset.to_csv(FULL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's sample 1000 articles from the full dataset and make sure we have enough examples for each label in our sample dataset (see [here](https://cloud.google.com/natural-language/automl/docs/beginners-guide) for further details on how to prepare data for AutoML)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
    "metadata": {
-    "tags": []
+    "id": "w3vU4d1r9w1t"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        550\n",
-       "nytimes       269\n",
-       "techcrunch    181\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "sample_title_dataset = title_dataset.sample(n=1000)\n",
-    "sample_title_dataset.source.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's write the sample datatset to disk."
+    "Now let's check the first few lines of our CSV file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "f5kC8V0tN00c"
    },
    "outputs": [],
    "source": [
-    "SAMPLE_DATASET_NAME = 'titles_sample.csv'\n",
-    "SAMPLE_DATASET_PATH = os.path.join(DATADIR, SAMPLE_DATASET_NAME)\n",
-    "\n",
-    "sample_title_dataset.to_csv(\n",
-    "    SAMPLE_DATASET_PATH, header=False, index=False, encoding='utf-8')"
+    "!head -n 5 {FULL_DATASET_PATH}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "d0kN6g9vN00c"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-16 09:42:15.362055: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2025-07-16 09:42:21.637920: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer.so.7'; dlerror: libnvinfer.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/lib/x86_64-linux-gnu/:/opt/conda/lib\n",
-      "2025-07-16 09:42:21.638164: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libnvinfer_plugin.so.7'; dlerror: libnvinfer_plugin.so.7: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/lib/x86_64-linux-gnu/:/opt/conda/lib\n",
-      "2025-07-16 09:42:21.638176: W tensorflow/compiler/tf2tensorrt/utils/py_utils.cc:38] TF-TRT Warning: Cannot dlopen some TensorRT libraries. If you would like to use Nvidia GPU with TensorRT, please make sure the missing libraries mentioned above are installed properly.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.11.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import datetime\n",
-    "import os\n",
-    "import shutil\n",
+    "gcs_path = f\"gs://{BUCKET}/{FULL_DATASET_NAME}\"\n",
+    "!gsutil cp {FULL_DATASET_PATH} {gcs_path}\n",
+    "print(f\"Copied {FULL_DATASET_PATH} to {gcs_path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8PqC8QEzN00c"
+   },
+   "source": [
+    "## Sampling and spliting the dataset\n",
     "\n",
-    "import pandas as pd\n",
+    "Before training, we need to split our dataset into train and evaluation splits.\n",
+    "Let's create a custom splitting logic using pandas, where:\n",
+    "- 80% of the data goes to `train` split\n",
+    "- 20% goes to `eval` split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "e_zMItgXN00c"
+   },
+   "outputs": [],
+   "source": [
+    "# Splitting function\n",
+    "def split_dataset(df, train_ratio=0.8):\n",
+    "    # Shuffle dataframe\n",
+    "    df_shuffled = df.sample(frac=1, random_state=42).reset_index(drop=True)\n",
+    "    \n",
+    "    split_idx = int(len(df_shuffled) * train_ratio)\n",
+    "    \n",
+    "    train_df = df_shuffled.iloc[:split_idx]\n",
+    "    eval_df = df_shuffled.iloc[split_idx:]\n",
+    "    \n",
+    "    return train_df, eval_df\n",
+    "\n",
+    "train_dataset, eval_dataset = split_dataset(title_dataset)\n",
+    "\n",
+    "print(f\"Train dataset size: {len(train_dataset)}\")\n",
+    "print(f\"Eval dataset size: {len(eval_dataset)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3Z8P1n_zN00c"
+   },
+   "source": [
+    "Let's save the splits to disk so we can use them later."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9Btt0W0KN00d"
+   },
+   "outputs": [],
+   "source": [
+    "TRAIN_DATASET_NAME = 'titles_train.csv'\n",
+    "TRAIN_DATASET_PATH = os.path.join(DATADIR, TRAIN_DATASET_NAME)\n",
+    "train_dataset.to_csv(TRAIN_DATASET_PATH, header=False, index=False, encoding='utf-8')\n",
+    "\n",
+    "EVAL_DATASET_NAME = 'titles_eval.csv'\n",
+    "EVAL_DATASET_PATH = os.path.join(DATADIR, EVAL_DATASET_NAME)\n",
+    "eval_dataset.to_csv(EVAL_DATASET_PATH, header=False, index=False, encoding='utf-8')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e_bT7nB0N00d"
+   },
+   "source": [
+    "Let's verify our CSV files:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "y-cI7vE0N00d"
+   },
+   "outputs": [],
+   "source": [
+    "!head -n 3 {TRAIN_DATASET_PATH}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "jVzN1EgzN00d"
+   },
+   "outputs": [],
+   "source": [
+    "!head -n 3 {EVAL_DATASET_PATH}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "jGkE1B00N00e"
+   },
+   "source": [
+    "## Data Loading with `tf.data.Dataset`\n",
+    "\n",
+    "Now that we have our CSV files (`titles_train.csv` and `titles_eval.csv`), we need to load them into TensorFlow. We will use `tf.data.experimental.make_csv_dataset`, which is efficient for streaming data from disk directly into a neural network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9KlA8W0LN00e"
+   },
+   "outputs": [],
+   "source": [
     "import tensorflow as tf\n",
-    "from tensorflow.keras.callbacks import TensorBoard, EarlyStopping\n",
-    "from tensorflow_hub import KerasLayer\n",
-    "from tensorflow.keras.layers import Dense\n",
-    "from tensorflow.keras.models import Sequential\n",
-    "from tensorflow.keras.preprocessing.text import Tokenizer\n",
-    "from tensorflow.keras.utils import to_categorical\n",
     "\n",
+    "BATCH_SIZE = 64\n",
     "\n",
-    "print(tf.__version__)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's start by specifying where the information about the trained models will be saved as well as where our dataset is located:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "MODEL_DIR = \"./text_models\"\n",
-    "DATA_DIR = \"./data\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Loading the dataset"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As in the previous labs, our dataset consists of titles of articles along with the label indicating from which source these articles have been taken from (GitHub, Tech-Crunch, or the New-York Times):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "titles_full.csv  titles_sample.csv\n"
-     ]
-    }
-   ],
-   "source": [
-    "ls ./data/"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>title</th>\n",
-       "      <th>source</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>purple flares got you down  camhoodie case for...</td>\n",
-       "      <td>techcrunch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>stacey 2.2.2 - html5boilerplate edition</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>an argument against cloud-based applications</td>\n",
-       "      <td>techcrunch</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>show hn  list and selectively download files f...</td>\n",
-       "      <td>github</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>the type of practice matters more than hours</td>\n",
-       "      <td>nytimes</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                               title      source\n",
-       "0  purple flares got you down  camhoodie case for...  techcrunch\n",
-       "1            stacey 2.2.2 - html5boilerplate edition      github\n",
-       "2       an argument against cloud-based applications  techcrunch\n",
-       "3  show hn  list and selectively download files f...      github\n",
-       "4       the type of practice matters more than hours     nytimes"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "DATASET_NAME = \"titles_full.csv\"\n",
-    "TITLE_SAMPLE_PATH = os.path.join(DATA_DIR, DATASET_NAME)\n",
-    "COLUMNS = ['title', 'source']\n",
+    "# Column names and defaults since we saved without headers\n",
+    "COLUMN_NAMES = ['title', 'source']\n",
+    "COLUMN_DEFAULTS = [[''], ['']]\n",
     "\n",
-    "titles_df = pd.read_csv(TITLE_SAMPLE_PATH, header=None, names=COLUMNS)\n",
-    "titles_df.head()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's look again at the number of examples per label to make sure we have a well-balanced dataset:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        183581\n",
-       "nytimes        84901\n",
-       "techcrunch     59828\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "titles_df.source.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Preparing the labels"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this lab, we will use pre-trained [TF-Hub embeddings modules for english](https://tfhub.dev/s?q=tf2%20embeddings%20text%20english) for the first layer of our models. One immediate\n",
-    "advantage of doing so is that the TF-Hub embedding module will take care for us of processing the raw text. \n",
-    "This also means that our model will be able to consume text directly instead of sequences of integers representing the words.\n",
-    "\n",
-    "However, as before, we still need to preprocess the labels into one-hot-encoded vectors:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "CLASSES = {\n",
-    "    'github': 0,\n",
-    "    'nytimes': 1,\n",
-    "    'techcrunch': 2\n",
-    "}\n",
-    "N_CLASSES = len(CLASSES)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def encode_labels(sources):\n",
-    "    classes = [CLASSES[source] for source in sources]\n",
-    "    one_hots = to_categorical(classes, num_classes=N_CLASSES)\n",
-    "    return one_hots"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0., 0., 1.],\n",
-       "       [1., 0., 0.],\n",
-       "       [0., 0., 1.],\n",
-       "       [1., 0., 0.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "encode_labels(titles_df.source[:4])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Preparing the train/test splits"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's split our data into train and test splits:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "N_TRAIN = int(len(titles_df) * 0.95)\n",
-    "\n",
-    "titles_train, sources_train = (\n",
-    "    titles_df.title[:N_TRAIN], titles_df.source[:N_TRAIN])\n",
-    "\n",
-    "titles_valid, sources_valid = (\n",
-    "    titles_df.title[N_TRAIN:], titles_df.source[N_TRAIN:])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To be on the safe side, we verify that the train and test splits\n",
-    "have roughly the same number of examples per class.\n",
-    "\n",
-    "Since it is the case, accuracy will be a good metric to use to measure\n",
-    "the performance of our models."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        174432\n",
-       "nytimes        80605\n",
-       "techcrunch     56857\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sources_train.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "source\n",
-       "github        9149\n",
-       "nytimes       4296\n",
-       "techcrunch    2971\n",
-       "Name: count, dtype: int64"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "sources_valid.value_counts()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now let's create the features and labels we will feed our models with:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "X_train, Y_train = titles_train.values, encode_labels(sources_train)\n",
-    "X_valid, Y_valid = titles_valid.values, encode_labels(sources_valid)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array(['purple flares got you down  camhoodie case for iphone 5 can help',\n",
-       "       'stacey 2.2.2 - html5boilerplate edition',\n",
-       "       'an argument against cloud-based applications'], dtype=object)"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "X_train[:3]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[0., 0., 1.],\n",
-       "       [1., 0., 0.],\n",
-       "       [0., 0., 1.]], dtype=float32)"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "Y_train[:3]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## NNLM Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We will first try a word embedding pre-trained using a [Neural Probabilistic Language Model](http://www.jmlr.org/papers/volume3/bengio03a/bengio03a.pdf). TF-Hub has a 50-dimensional one called \n",
-    "[nnlm-en-dim50-with-normalization](https://tfhub.dev/google/tf2-preview/nnlm-en-dim50/1), which also\n",
-    "normalizes the vectors produced. \n",
-    "\n",
-    "Once loaded from its url, the TF-hub module can be used as a normal Keras layer in a sequential or functional model. Since we have enough data to fine-tune the parameters of the pre-trained embedding itself, we will set `trainable=True` in the `KerasLayer` that loads the pre-trained embedding:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-16 09:54:19.348113: W tensorflow/compiler/xla/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/cuda/lib64:/usr/local/nccl2/lib:/usr/local/cuda/extras/CUPTI/lib64:/usr/lib/x86_64-linux-gnu/:/opt/conda/lib\n",
-      "2025-07-16 09:54:19.351379: W tensorflow/compiler/xla/stream_executor/cuda/cuda_driver.cc:265] failed call to cuInit: UNKNOWN ERROR (303)\n",
-      "2025-07-16 09:54:19.353872: I tensorflow/compiler/xla/stream_executor/cuda/cuda_diagnostics.cc:156] kernel driver does not appear to be running on this host (cloudlearningservices): /proc/driver/nvidia/version does not exist\n",
-      "2025-07-16 09:54:19.358256: I tensorflow/core/platform/cpu_feature_guard.cc:193] This TensorFlow binary is optimized with oneAPI Deep Neural Network Library (oneDNN) to use the following CPU instructions in performance-critical operations:  AVX2 FMA\n",
-      "To enable them in other operations, rebuild TensorFlow with the appropriate compiler flags.\n",
-      "2025-07-16 09:54:19.729375: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n"
-     ]
-    }
-   ],
-   "source": [
-    "# TODO \n",
-    "NNLM = \"https://tfhub.dev/google/nnlm-en-dim50/2\"\n",
-    "\n",
-    "nnlm_module = KerasLayer(\n",
-    "    NNLM, output_shape=[50], input_shape=[], dtype=tf.string, trainable=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that this TF-Hub embedding produces a single 50-dimensional vector when passed a sentence:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<tf.Tensor: shape=(1, 50), dtype=float32, numpy=\n",
-       "array([[ 0.19331802,  0.05893906,  0.15330684,  0.2505918 ,  0.19369544,\n",
-       "         0.03578748,  0.07387847, -0.10962156, -0.11377034,  0.07172022,\n",
-       "         0.12458669, -0.02289705, -0.18177685, -0.07084437, -0.00225849,\n",
-       "        -0.36875236,  0.05772953, -0.14222091,  0.08765972, -0.14068899,\n",
-       "        -0.07005888, -0.20634466,  0.07220475,  0.04258814,  0.0955702 ,\n",
-       "         0.19424029, -0.42492998, -0.00706906, -0.02095   , -0.05055764,\n",
-       "        -0.18988201, -0.02841404,  0.13222624, -0.01459922, -0.31255388,\n",
-       "        -0.09577855,  0.05469003, -0.13858607,  0.01141668, -0.12352604,\n",
-       "        -0.07250367, -0.11605677, -0.06976165,  0.14313601, -0.15183711,\n",
-       "        -0.06836402,  0.03054246, -0.13259597, -0.14599673,  0.05094011]],\n",
-       "      dtype=float32)>"
-      ]
-     },
-     "execution_count": 33,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# TODO\n",
-    "nnlm_module(tf.constant([\"The dog is happy to see people in the street.\"]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Swivel Model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Then we will try a word embedding obtained using [Swivel](https://arxiv.org/abs/1602.02215), an algorithm that essentially factorizes word co-occurrence matrices to create the words embeddings. \n",
-    "TF-Hub hosts the pretrained [gnews-swivel-20dim-with-oov](https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1) 20-dimensional Swivel module."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "\n",
-    "# TODO\n",
-    "SWIVEL = \"https://tfhub.dev/google/tf2-preview/gnews-swivel-20dim-with-oov/1\"\n",
-    "swivel_module = KerasLayer(\n",
-    "    SWIVEL, output_shape=[20], input_shape=[], dtype=tf.string, trainable=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Similarly as the previous pre-trained embedding, it outputs a single vector when passed a sentence:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<tf.Tensor: shape=(1, 20), dtype=float32, numpy=\n",
-       "array([[ 0.9967701 , -0.3100155 ,  0.5889897 , -0.16765082, -0.6171738 ,\n",
-       "        -1.1586996 , -0.8619045 ,  0.7281645 ,  0.32575002,  0.4754492 ,\n",
-       "        -0.9272241 ,  0.41090095, -0.75389475, -0.31525993, -1.8918804 ,\n",
-       "         0.6423996 ,  0.6801622 , -0.1335669 , -1.0017993 , -0.11908641]],\n",
-       "      dtype=float32)>"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# TODO\n",
-    "swivel_module(tf.constant([\"The dog is happy to see people in the street.\"]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Building the models"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's write a function that \n",
-    "\n",
-    "* takes as input an instance of a `KerasLayer` (i.e. the `swivel_module` or the `nnlm_module` we constructed above) as well as the name of the model (say `swivel` or `nnlm`)\n",
-    "* returns a compiled Keras sequential model starting with this pre-trained TF-hub layer, adding one or more dense relu layers to it, and ending with a softmax layer giving the probability of each of the classes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def build_model(hub_module, name):\n",
-    "    model = Sequential([\n",
-    "        hub_module, # TODO\n",
-    "        Dense(16, activation='relu'),\n",
-    "        Dense(N_CLASSES, activation='softmax')\n",
-    "    ], name=name)\n",
-    "\n",
-    "    model.compile(\n",
-    "        optimizer='adam',\n",
-    "        loss='categorical_crossentropy',\n",
-    "        metrics=['accuracy']\n",
-    "    )\n",
-    "    return model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's also wrap the training code into a `train_and_evaluate` function that \n",
-    "* takes as input the training and validation data, as well as the compiled model itself, and the `batch_size`\n",
-    "* trains the compiled model for 100 epochs at most, and does early-stopping when the validation loss is no longer decreasing\n",
-    "* returns an `history` object, which will help us to plot the learning curves"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "def train_and_evaluate(train_data, val_data, model, batch_size=5000):\n",
-    "    X_train, Y_train = train_data\n",
-    "\n",
-    "    tf.random.set_seed(33)\n",
-    "\n",
-    "    model_dir = os.path.join(MODEL_DIR, model.name)\n",
-    "    if tf.io.gfile.exists(model_dir):\n",
-    "        tf.io.gfile.rmtree(model_dir)\n",
-    "\n",
-    "    history = model.fit(\n",
-    "        X_train, Y_train,\n",
-    "        epochs=10,\n",
+    "def load_dataset(file_path, batch_size=BATCH_SIZE, shuffle=True):\n",
+    "    return tf.data.experimental.make_csv_dataset(\n",
+    "        file_pattern=file_path,\n",
     "        batch_size=batch_size,\n",
-    "        validation_data=val_data,\n",
-    "        callbacks=TensorBoard(model_dir),\n",
+    "        column_names=COLUMN_NAMES,\n",
+    "        column_defaults=COLUMN_DEFAULTS,\n",
+    "        label_name='source',\n",
+    "        shuffle=shuffle,\n",
+    "        num_epochs=1\n",
     "    )\n",
-    "    return history"
+    "\n",
+    "train_ds = load_dataset(TRAIN_DATASET_PATH, shuffle=True)\n",
+    "eval_ds = load_dataset(EVAL_DATASET_PATH, shuffle=False)\n",
+    "\n",
+    "# Inspect one batch of data\n",
+    "for x, y in train_ds.take(1):\n",
+    "    print(\"Sample titles:\", x['title'][:3].numpy())\n",
+    "    print(\"Sample labels:\", y[:3].numpy())"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "0DkO4p8ON00e"
+   },
    "source": [
-    "## Training NNLM"
+    "## One-Hot Encoding Target Labels\n",
+    "\n",
+    "Our labels (`source`) are strings (`'github'`, `'nytimes'`, `'techcrunch'`). Neural networks expect numeric inputs and targets, so we map these strings to integer indices (`0`, `1`, `2`) and then convert those integers into one-hot vectors (`[1, 0, 0]`, `[0, 1, 0]`, `[0, 0, 1]`)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "f5kC8V0tN00f"
    },
    "outputs": [],
    "source": [
-    "data = (X_train, Y_train)\n",
-    "val_data = (X_valid, Y_valid)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 42,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/10\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2025-07-16 10:03:31.331673: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n",
-      "2025-07-16 10:03:31.564477: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n",
-      "2025-07-16 10:03:32.473034: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n",
-      "2025-07-16 10:03:32.485175: W tensorflow/tsl/framework/cpu_allocator_impl.cc:82] Allocation of 192762400 exceeds 10% of free system memory.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "63/63 [==============================] - 43s 661ms/step - loss: 0.8547 - accuracy: 0.6257 - val_loss: 0.6109 - val_accuracy: 0.7477\n",
-      "Epoch 2/10\n",
-      "63/63 [==============================] - 38s 599ms/step - loss: 0.4683 - accuracy: 0.8199 - val_loss: 0.3699 - val_accuracy: 0.8649\n",
-      "Epoch 3/10\n",
-      "63/63 [==============================] - 37s 594ms/step - loss: 0.3084 - accuracy: 0.8865 - val_loss: 0.2958 - val_accuracy: 0.8857\n",
-      "Epoch 4/10\n",
-      "63/63 [==============================] - 78s 1s/step - loss: 0.2526 - accuracy: 0.9048 - val_loss: 0.2732 - val_accuracy: 0.8940\n",
-      "Epoch 5/10\n",
-      "63/63 [==============================] - 75s 1s/step - loss: 0.2255 - accuracy: 0.9152 - val_loss: 0.2651 - val_accuracy: 0.8967\n",
-      "Epoch 6/10\n",
-      "63/63 [==============================] - 81s 1s/step - loss: 0.2083 - accuracy: 0.9220 - val_loss: 0.2626 - val_accuracy: 0.8977\n",
-      "Epoch 7/10\n",
-      "63/63 [==============================] - 81s 1s/step - loss: 0.1958 - accuracy: 0.9273 - val_loss: 0.2633 - val_accuracy: 0.8977\n",
-      "Epoch 8/10\n",
-      "63/63 [==============================] - 74s 1s/step - loss: 0.1864 - accuracy: 0.9310 - val_loss: 0.2654 - val_accuracy: 0.8980\n",
-      "Epoch 9/10\n",
-      "63/63 [==============================] - 84s 1s/step - loss: 0.1786 - accuracy: 0.9339 - val_loss: 0.2686 - val_accuracy: 0.8973\n",
-      "Epoch 10/10\n",
-      "63/63 [==============================] - 81s 1s/step - loss: 0.1723 - accuracy: 0.9368 - val_loss: 0.2728 - val_accuracy: 0.8961\n"
-     ]
-    }
-   ],
-   "source": [
-    "nnlm_model = build_model(nnlm_module, 'nnlm')\n",
-    "nnlm_history = train_and_evaluate(data, val_data, nnlm_model)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 43,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Axes: >"
-      ]
-     },
-     "execution_count": 43,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASvhJREFUeJzt3Xl8VPW9//HXzCSTSUL2QMISCLIjq2yFqNUapS5U6lKsWBALtly0atr7K2jFVqtoa73c60alotal0lq3VoraKFU2gyAIsu9hSUISsi+TzMzvj0kmCSSQSWbmJJn38/E4j5ycnPl+v0OUefM93/M5JpfL5UJERETEIGajByAiIiLBTWFEREREDKUwIiIiIoZSGBERERFDKYyIiIiIoRRGRERExFAKIyIiImIohRERERExVIjRA2gNp9PJiRMniIqKwmQyGT0cERERaQWXy0VpaSm9evXCbG55/qNThJETJ06QkpJi9DBERESkDbKzs+nTp0+LP+8UYSQqKgpwv5no6GiDRyMiIiKtUVJSQkpKiudzvCWdIozUX5qJjo5WGBEREelkzrfEQgtYRURExFAKIyIiImIohRERERExVKdYMyIiIsHN5XJRW1uLw+EweijSiMViISQkpN1lNxRGRESkQ7Pb7Zw8eZKKigqjhyLNiIiIoGfPnlit1ja3oTAiIiIdltPp5NChQ1gsFnr16oXValXxyw7C5XJht9s5deoUhw4dYtCgQecsbHYuCiMiItJh2e12nE4nKSkpREREGD0cOUN4eDihoaEcOXIEu92OzWZrUztawCoiIh1eW//FLf7ni9+NfrsiIiJiKIURERERMZTCiIiIiB9cdtll3HvvvUYPo1NQGBERERFDBW0Ycblc/CXrKAte38Kp0mqjhyMiIhK0gjaMmEwmXtt4hA+2n2T9gXyjhyMiIq3kcrmosNcasrlcrjaN+fTp08yaNYu4uDgiIiK4+uqr2bdvn+fnR44cYdq0acTFxREZGcmFF17IqlWrPK+dOXMm3bt3Jzw8nEGDBvHSSy/55M+yowjqOiNpAxP55kQJ6/cXcP2Y3kYPR0REWqGyxsHwxR8a0vfOh6cSYfX+o/P2229n3759vP/++0RHR/PLX/6Sa665hp07dxIaGsqCBQuw2+189tlnREZGsnPnTrp16wbAgw8+yM6dO/nXv/5FYmIi+/fvp7Ky0tdvzVBBH0Ze+Owga/fn43K5VNVPRER8rj6ErFu3jilTpgDw+uuvk5KSwrvvvsvNN9/M0aNHufHGGxk5ciQAF1xwgef1R48eZezYsYwfPx6A1NTUgL8HfwvqMDIhNY5Qi4njRZUcLaygX0Kk0UMSEZHzCA+1sPPhqYb17a1du3YREhLCpEmTPMcSEhIYMmQIu3btAuBnP/sZ8+fP56OPPiI9PZ0bb7yRUaNGATB//nxuvPFGtmzZwlVXXcX06dM9oaarCNo1IwAR1hAu6hsHwNr9WjciItIZmEwmIqwhhmz+mkGfO3cuBw8e5Ec/+hHbt29n/PjxPP300wBcffXVHDlyhPvuu48TJ05wxRVX8Itf/MIv4zBKUIcRcF+qAVi/v8DgkYiISFc0bNgwamtr+eKLLzzHCgoK2LNnD8OHD/ccS0lJ4ac//Slvv/02P//5z1m+fLnnZ927d2f27Nm89tprLF26lBdeeCGg78HfFEYGJgCw/kA+TmfbVkmLiIi0ZNCgQVx//fXMmzePtWvXsm3bNm677TZ69+7N9ddfD8C9997Lhx9+yKFDh9iyZQuffvopw4YNA2Dx4sW899577N+/n2+++YZ//vOfnp91FUEfRkb1iaVbWAinK2rYebLE6OGIiEgX9NJLLzFu3Diuu+46Jk+ejMvlYtWqVYSGhgLgcDhYsGABw4YN47vf/S6DBw/mueeeA8BqtbJo0SJGjRrFpZdeisVi4c033zTy7ficydXWm6YDqKSkhJiYGIqLi4mOjvZ5+z9+eROZu/O4/5qh3HnpAJ+3LyIibVNVVcWhQ4fo379/mx9PL/51rt9Raz+/g35mBBrWjazVuhEREZGAUxihIYxsOlRIda3D4NGIiIgEF4URYHBSNxK7hVFZ4+Cro0VGD0dERCSoKIzgvmfdc1eN6o2IiIgElMJInbQB9etGFEZEREQCSWGkTtogdxjZdqyY0qoag0cjIiISPBRG6vSODSc1IQKH00XWoUKjhyMiIhI0FEYaabjFV5dqREREAkVhpBE9p0ZERCTwFEYamXxBAiYT7MktJa+0yujhiIhIEEtNTWXp0qWtOtdkMvHuu+/6dTz+pDDSSFyklQt7ucvVbjig2REREZFAUBg5g+cW331aNyIiIhIICiNn8KwbOVBAJ3iGoIhI8HG5wF5uzNbKz4UXXniBXr164XQ6mxy//vrrueOOOzhw4ADXX389SUlJdOvWjQkTJvDvf//bZ39E27dv5zvf+Q7h4eEkJCRw5513UlZW5vn5mjVrmDhxIpGRkcTGxpKWlsaRI0cA2LZtG5dffjlRUVFER0czbtw4vvzyS5+NrTkhfm29E5qQGo/VYuZ4USVHCipITYw0ekgiItJYTQU81suYvu8/Adbzfy7cfPPN3H333Xz66adcccUVABQWFrJ69WpWrVpFWVkZ11xzDY8++ihhYWH8+c9/Ztq0aezZs4e+ffu2a4jl5eVMnTqVyZMns2nTJvLy8pg7dy533XUXL7/8MrW1tUyfPp158+bxl7/8BbvdTlZWFiaTCYCZM2cyduxYnn/+eSwWC1u3biU0NLRdYzqfNs2MPPvss6SmpmKz2Zg0aRJZWVnnPH/p0qUMGTKE8PBwUlJSuO+++6iq6pgLRMOtFi7qFwvoFl8REWmbuLg4rr76at544w3PsbfeeovExEQuv/xyRo8ezU9+8hNGjBjBoEGDeOSRRxgwYADvv/9+u/t+4403qKqq4s9//jMjRozgO9/5Ds888wyvvvoqubm5lJSUUFxczHXXXceAAQMYNmwYs2fP9oSgo0ePkp6eztChQxk0aBA333wzo0ePbve4zsXrmZGVK1eSkZHBsmXLmDRpEkuXLmXq1Kns2bOHHj16nHX+G2+8wcKFC1mxYgVTpkxh79693H777ZhMJp566imfvAlfSxuQyMaDhaw/kM9t3+pn9HBERKSx0Aj3DIVRfbfSzJkzmTdvHs899xxhYWG8/vrr3HLLLZjNZsrKyvj1r3/NBx98wMmTJ6mtraWyspKjR4+2e4i7du1i9OjRREY2zOCkpaXhdDrZs2cPl156KbfffjtTp07lyiuvJD09nR/84Af07NkTgIyMDObOncurr75Keno6N998MwMGDGj3uM7F65mRp556innz5jFnzhyGDx/OsmXLiIiIYMWKFc2ev379etLS0rj11ltJTU3lqquu4oc//OF5Z1OMVF8afv2BApxOrRsREelQTCb3pRIjtrpLGa0xbdo0XC4XH3zwAdnZ2Xz++efMnDkTgF/84he88847PPbYY3z++eds3bqVkSNHYrfb/fWn1sRLL73Ehg0bmDJlCitXrmTw4MFs3LgRgF//+td88803XHvttXzyyScMHz6cd955x6/j8SqM2O12Nm/eTHp6ekMDZjPp6els2LCh2ddMmTKFzZs3e8LHwYMHWbVqFddcc02L/VRXV1NSUtJkC6RRvWOICguhqKKGnScD27eIiHQNNpuNG264gddff52//OUvDBkyhIsuugiAdevWcfvtt/P973+fkSNHkpyczOHDh33S77Bhw9i2bRvl5eWeY+vWrcNsNjNkyBDPsbFjx7Jo0SLWr1/PiBEjmlxSGjx4MPfddx8fffQRN9xwAy+99JJPxtYSr8JIfn4+DoeDpKSkJseTkpLIyclp9jW33norDz/8MBdffDGhoaEMGDCAyy67jPvvv7/FfpYsWUJMTIxnS0lJ8WaY7RZiMTPpgnhA60ZERKTtZs6cyQcffMCKFSs8syIAgwYN4u2332br1q1s27aNW2+99aw7b9rTp81mY/bs2ezYsYNPP/2Uu+++mx/96EckJSVx6NAhFi1axIYNGzhy5AgfffQR+/btY9iwYVRWVnLXXXexZs0ajhw5wrp169i0aRPDhg3zydha4vdbe9esWcNjjz3Gc889x5YtW3j77bf54IMPeOSRR1p8zaJFiyguLvZs2dnZ/h7mWepv8V2nMCIiIm30ne98h/j4ePbs2cOtt97qOf7UU08RFxfHlClTmDZtGlOnTvXMmrRXREQEH374IYWFhUyYMIGbbrqJK664gmeeecbz8927d3PjjTcyePBg7rzzThYsWMBPfvITLBYLBQUFzJo1i8GDB/ODH/yAq6++mt/85jc+GVtLTC4vimnY7XYiIiJ46623mD59uuf47NmzKSoq4r333jvrNZdccgnf+ta3+P3vf+859tprr3nueTabz5+HSkpKiImJobi4mOjo6NYOt1325pZy1f98hi3UzLaHriIsxBKQfkVEpEFVVRWHDh2if//+2Gw2o4cjzTjX76i1n99ezYxYrVbGjRtHZmam55jT6SQzM5PJkyc3+5qKioqzAofF4v5g78hFxQb16Eb3qDCqapxsOVJk9HBERES6LK8v02RkZLB8+XJeeeUVdu3axfz58ykvL2fOnDkAzJo1i0WLFnnOnzZtGs8//zxvvvkmhw4d4uOPP+bBBx9k2rRpnlDSEZlMJtIGJACw/oAu1YiIiDFef/11unXr1ux24YUXGj08n/C6zsiMGTM4deoUixcvJicnhzFjxrB69WrPotajR482mQn51a9+hclk4le/+hXHjx+ne/fuTJs2jUcffdR378JP0gYm8u7WE6zdn8/Prxpy/heIiIj42Pe+9z0mTZrU7M/8XRk1ULxaM2IUI9aMAJwoqmTK459gMZv4avGVRNu6xi9dRKSz0JqRji/ga0aCTa/YcPonRuJwuvjiYKHRwxERCVqd4N/NQcsXvxuFkfNIG+heN6JbfEVEAq/+MkRFRYXBI5GW1P9u2nPJSE/tPY+0AYm8tvGowoiIiAEsFguxsbHk5eUB7hoZJi9Ksov/uFwuKioqyMvLIzY2tl03pSiMnMfkAQmYTLAvr4y8kip6ROuapYhIICUnJwN4Aol0LLGxsZ7fUVspjJxHbISVEb1i2H68mPUHCpg+trfRQxIRCSomk4mePXvSo0cPampqjB6ONBIaGuqTMh0KI62QNjCR7ceLWbs/X2FERMQgFoulQ9enkrbTAtZWqF/Eun5/vlZ0i4iI+JjCSCuM7xeP1WLmRHEVh/LLz/8CERERaTWFkVYIt1oY1y8OgHUHCgwejYiISNeiMNJKnnoj+3SLr4iIiC8pjLRS2sBEADYcLMDh1LoRERERX1EYaaWRvWOICguhuLKGnSdKjB6OiIhIl6Ew0kohFjPfGuC+VLNW1VhFRER8RmHEC2l1YWT9AYURERERX1EY8UL9upGsQ4VU1TgMHo2IiEjXoDDihYE9utEjKozqWidbjp42ejgiIiJdgsKIF0wmk2d2RE/xFRER8Q2FES81hBEVPxMREfEFhREv1Rc/+/pYESVVenqkiIhIeymMeKlnTDgXdI/E6YKNKg0vIiLSbgojbZA2wH2pZr3CiIiISLspjLRB/aUaFT8TERFpP4WRNph8QSImE+zPKyO3pMro4YiIiHRqCiNtEBMRysjeMYBu8RUREWkvhZE20i2+IiIivqEw0kYNi1jzcblcBo9GRESk81IYaaPxqXFYQ8ycLK7iYH650cMRERHptBRG2sgWamF8vzgA1mvdiIiISJspjLRD/boR3eIrIiLSdgoj7VAfRjYcKMDh1LoRERGRtlAYaYeRvWOIsoVQUlXLjuPFRg9HRESkU1IYaQeL2cTkC9zVWNcd0KUaERGRtlAYaaf6SzXrVW9ERESkTRRG2qk+jGw6XEhVjcPg0YiIiHQ+CiPtNKB7JEnRYVTXOtly5LTRwxEREel0FEbayWQyeaqx6hZfERER7ymM+IDnOTUHtG5ERETEWwojPlAfRrYfK6K4ssbg0YiIiHQubQojzz77LKmpqdhsNiZNmkRWVlaL51522WWYTKaztmuvvbbNg+5okmNsDOgeidMFGw9qdkRERMQbXoeRlStXkpGRwUMPPcSWLVsYPXo0U6dOJS8vr9nz3377bU6ePOnZduzYgcVi4eabb2734DsSz6UarRsRERHxitdh5KmnnmLevHnMmTOH4cOHs2zZMiIiIlixYkWz58fHx5OcnOzZPv74YyIiIhRGREREBPAyjNjtdjZv3kx6enpDA2Yz6enpbNiwoVVtvPjii9xyyy1ERkZ6N9IO7lsXJGA2wYFT5eQUVxk9HBERkU7DqzCSn5+Pw+EgKSmpyfGkpCRycnLO+/qsrCx27NjB3Llzz3ledXU1JSUlTbaOLiY8lJG9YwDNjoiIiHgjoHfTvPjii4wcOZKJEyee87wlS5YQExPj2VJSUgI0wvZpuMVXYURERKS1vAojiYmJWCwWcnNzmxzPzc0lOTn5nK8tLy/nzTff5Mc//vF5+1m0aBHFxcWeLTs725thGqbxuhGXy2XwaERERDoHr8KI1Wpl3LhxZGZmeo45nU4yMzOZPHnyOV/7t7/9jerqam677bbz9hMWFkZ0dHSTrTMY1y+OsBAzuSXVHDhVbvRwREREOgWvL9NkZGSwfPlyXnnlFXbt2sX8+fMpLy9nzpw5AMyaNYtFixad9boXX3yR6dOnk5CQ0P5Rd1C2UAvjU+MArRsRERFprRBvXzBjxgxOnTrF4sWLycnJYcyYMaxevdqzqPXo0aOYzU0zzp49e1i7di0fffSRb0bdgU0ZkMi6/QWs25/P7CmpRg9HRESkwzO5OsHihpKSEmJiYiguLu7wl2y2ZRdx/bPriLKFsHXxVVjMJqOHJCIiYojWfn7r2TQ+NqJ3DNG2EEqratl+vNjo4YiIiHR4CiM+ZjGbmDzAvS5G60ZERETOT2HED1QaXkREpPUURvygPox8eeQ0VTUOg0cjIiLSsSmM+MEFiZEkR9uw1zr58vBpo4cjIiLSoSmM+IHJZGLKwLp1IyoNLyIick4KI35ycd2lmvVaNyIiInJOCiN+Ur9u5OvjxRRX1Bg8GhERkY5LYcRPkqJtDOzRDZcLNhwsMHo4IiIiHZbCiB+lqd6IiIjIeSmM+JGn3ogWsYqIiLRIYcSPJl2QgNkEB0+Vc7K40ujhiIiIdEgKI34UEx7KyD6xAKzbr3UjIiIizVEY8bOL6+qN6BZfERGR5imM+FnaAPe6kbX783G5XAaPRkREpONRGPGzi/rFERZiJq+0mgOnyowejoiISIejMOJntlALE1LjAVi7T5dqREREzqQwEgANt/hqEauIiMiZFEYCIK1uEevGAwXUOpwGj0ZERKRjURgJgAt7xRBtC6G0upbtx4uNHo6IiEiHojASABaziSl1d9Ws16UaERGRJhRGAqT+Uo0WsYqIiDSlMBIg9YtYNx85TaXdYfBoREREOg6FkQDpnxhJzxgbdoeTL48UGj0cERGRDkNhJEBMJlPDLb56To2IiIiHwkgA1a8bWafn1IiIiHgojARQ/R01O04UU1RhN3g0IiIiHYPCSAAlRdsY1KMbLhdsPKhLNSIiIqAwEnD160bW6lKNiIgIoDAScPVhZL0WsYqIiAAKIwE36YJ4zCY4mF/OiaJKo4cjIiJiOIWRAIu2hTI6JRbQXTUiIiKgMGKItAH19UYURkRERBRGDDClvt7IgQJcLpfBoxERETGWwogBLuobhy3UzKnSavbllRk9HBEREUMpjBjAFmphQmo8oEs1IiIiwRtGnE7Y+xH8dRbYKwLevZ5TIyIi4ha8YQQXrPoF7HwPdrwV8N7rF7F+cbCAWocz4P2LiIh0FMEbRswWmDDXvZ/1AgR4IenwXtHERoRSWl3L18eLA9q3iIhIR9KmMPLss8+SmpqKzWZj0qRJZGVlnfP8oqIiFixYQM+ePQkLC2Pw4MGsWrWqTQP2qbG3QYgNcrZD9hcB7dpiNjH5grq7avZp3YiIiAQvr8PIypUrycjI4KGHHmLLli2MHj2aqVOnkpeX1+z5drudK6+8ksOHD/PWW2+xZ88eli9fTu/evds9+HaLiIeRN7v3s14IePdT6teNHFAYERGR4OV1GHnqqaeYN28ec+bMYfjw4SxbtoyIiAhWrFjR7PkrVqygsLCQd999l7S0NFJTU/n2t7/N6NGj2z14n5g4z/1153tQmhPQri+uCyNbjhRRaXcEtG8REZGOwqswYrfb2bx5M+np6Q0NmM2kp6ezYcOGZl/z/vvvM3nyZBYsWEBSUhIjRozgsccew+Fo+cO3urqakpKSJpvf9BwNKd8CZy1sftl//TQjNSGCXjE27A4nmw4XBrRvERGRjsKrMJKfn4/D4SApKanJ8aSkJHJymp9VOHjwIG+99RYOh4NVq1bx4IMP8oc//IHf/va3LfazZMkSYmJiPFtKSoo3w/Re/ezIlyug1u7fvhoxmUwNt/jqUo2IiAQpv99N43Q66dGjBy+88ALjxo1jxowZPPDAAyxbtqzF1yxatIji4mLPlp2d7d9BDvsedEuGslzY/Q//9nWGhnojCiMiIhKcvAojiYmJWCwWcnNzmxzPzc0lOTm52df07NmTwYMHY7FYPMeGDRtGTk4OdnvzsxBhYWFER0c32fwqxArj57j3vwjsQtb659R8c6KE0+WBm5URERHpKLwKI1arlXHjxpGZmek55nQ6yczMZPLkyc2+Ji0tjf379+N0NhT22rt3Lz179sRqtbZx2H4w7nYwh0D2Rji5LWDd9oiyMTipGy4XbDioaqwiIhJ8vL5Mk5GRwfLly3nllVfYtWsX8+fPp7y8nDlz3DMLs2bNYtGiRZ7z58+fT2FhIffccw979+7lgw8+4LHHHmPBggW+exe+EJUMw69372ctD2jXUwboUo2IiAQvr8PIjBkzePLJJ1m8eDFjxoxh69atrF692rOo9ejRo5w8edJzfkpKCh9++CGbNm1i1KhR/OxnP+Oee+5h4cKFvnsXvjLxTvfX7X+DisDd3XKx1o2IiEgQM7lcAa6D3gYlJSXExMRQXFzs3/UjLhf88RJ3RdYrH4G0n/mvr0ZKq2oY8/DHOJwu1i38Dr1jwwPSr4iIiD+19vM7eJ9N0xyTqWF2ZNOfwBmYQmRRtlBG94kBNDsiIiLBR2HkTCNuAlssFB2BfR8HrFvd4isiIsFKYeRM1gi46Efu/QA+r6YhjBTQCa6ciYiI+IzCSHPG/xgwwYFMyN8fkC7H9o3FFmomv6yavbllAelTRESkI1AYaU58fxg81b2/6U8B6TIsxMKE1HhAl2pERCS4KIy0pH4h69bXoTowMxW6xVdERIKRwkhLLrgcEgZCdQl8/WZAuqxfN/LFoUJqHc7znC0iItI1KIy0xGyGCXVP881a7q5B4mfDe0YTGxFKWXUt244V+70/ERGRjkBh5FzG/BBCI+HUbjj8ud+7M5tNTBngfnCeLtWIiEiwUBg5F1sMjL7FvR+g23xVb0RERIKNwsj5TKy7VLP7AyjK9nt3aXUPzdty9DQV9lq/9yciImI0hZHz6TEMUi8BlxM2v+T37volRNA7Npwah4tNh0/7vT8RERGjKYy0Rv1tvptfhpoqv3ZlMplIG6h1IyIiEjwURlpjyDUQ3RsqCmDnu37vTutGREQkmCiMtIYlBMbf4d4PwELWKXXrRnaeLKGw3O73/kRERIykMNJa424HixWOb4Zjm/3aVfeoMIYkReFywYYDBX7tS0RExGgKI60VmQgjbnTvb1ru9+48l2oO6FKNiIh0bQoj3qi/zXfH36HslF+70iJWEREJFgoj3ug9zr057LDlFb92NbF/PBaziSMFFWQXVvi1LxERESMpjHir/jbfL1eAw39FyaJsoYxJiQVgvS7ViIhIF6Yw4q3h0yEiEUqOw55Vfu0qzfOcGi1iFRGRrkthxFuhNhg3273v59t86xexrj+QjysATw0WERExgsJIW4y/A0xm95N883b5rZuxfeMID7WQX2ZnT26p3/oRERExksJIW8T0gaHXuvez/HebrzXEzMT+8YAu1YiISNelMNJW9QtZt70JVcV+60a3+IqISFenMNJWqZdA92FQUw5b/+K3bupLw39xsIAah9Nv/YiIiBhFYaStTKaGImibloPTP0FheM9o4iJCKbc72JZd5Jc+REREjKQw0h6jZkBYNBTsh4Of+qULs9nkmR3RuhEREemKFEbaI6wbjJnp3vfjbb6e59Ro3YiIiHRBCiPtNWGu++veD6HwkF+6qF/E+lX2aSrs/qv6KiIiYgSFkfZKHAgDrgBc8OWLfumib3wEfeLCqXG4yDpU6Jc+REREjKIw4gv1t/lueRXsvn+onclkIm2ALtWIiEjXpDDiC4OuhNh+UFUEO97ySxdTBuo5NSIi0jUpjPiC2dKwdiTrBfDDc2Tq76jZebKEgrJqn7cvIiJiFIURXxl7G4TYIGc7ZH/h8+a7R4UxNDkKgA0HNTsiIiJdh8KIr0TEw8ib3ft+us1Xt/iKiEhXpDDiS/ULWXe+B6U5Pm8+TetGRESkC1IY8aWeo6DvZHDWwuaXfd78xP4JhJhNHC2sILvQ93ftiIiIGKFNYeTZZ58lNTUVm83GpEmTyMrKavHcl19+GZPJ1GSz2WxtHnCHV/+8mi9XQK3dp013CwthTEosoEs1IiLSdXgdRlauXElGRgYPPfQQW7ZsYfTo0UydOpW8vLwWXxMdHc3Jkyc925EjR9o16A5t6DTolgxlubDrfZ83P6V+3cgBXaoREZGuwesw8tRTTzFv3jzmzJnD8OHDWbZsGREREaxYsaLF15hMJpKTkz1bUlJSuwbdoYVYYfwc937Wcp83f3FdGFm/Px+n0/e3EIuIiASaV2HEbrezefNm0tPTGxowm0lPT2fDhg0tvq6srIx+/fqRkpLC9ddfzzfffHPOfqqrqykpKWmydSrjbgdzCGRvhJPbfNr0mJRYwkMtFJTb2ZNb6tO2RUREjOBVGMnPz8fhcJw1s5GUlEROTvN3jwwZMoQVK1bw3nvv8dprr+F0OpkyZQrHjh1rsZ8lS5YQExPj2VJSUrwZpvGikmH49e59H8+OWEPMTLogHtC6ERER6Rr8fjfN5MmTmTVrFmPGjOHb3/42b7/9Nt27d+ePf/xji69ZtGgRxcXFni07O9vfw/S9+tt8t/8NKnz7cDs9p0ZERLoSr8JIYmIiFouF3NzcJsdzc3NJTk5uVRuhoaGMHTuW/fv3t3hOWFgY0dHRTbZOJ2USJI+E2ir46jWfNl1f/OyLQ4XUOJw+bVtERCTQvAojVquVcePGkZmZ6TnmdDrJzMxk8uTJrWrD4XCwfft2evbs6d1IOxuTqWF2ZNOfwOnwWdNDk6OIj7RSYXewNbvIZ+2KiIgYwevLNBkZGSxfvpxXXnmFXbt2MX/+fMrLy5kzx30HyaxZs1i0aJHn/IcffpiPPvqIgwcPsmXLFm677TaOHDnC3LlzffcuOqoRN4EtFoqOwL6Pfdas2Wxi8oD6aqy6VCMiIp2b12FkxowZPPnkkyxevJgxY8awdetWVq9e7VnUevToUU6ePOk5//Tp08ybN49hw4ZxzTXXUFJSwvr16xk+fLjv3kVHZY2Ai2a59338vJqL9ZwaERHpIkwulx+ed+9jJSUlxMTEUFxc3PnWj5w+DP87BnDBXZshcaBPmj1aUMGlv/+UELOJbQ9dRWRYiE/aFRER8ZXWfn7r2TT+FpcKg7/r3t/ku9t8+yZEkBIfTq3TRdYh396tIyIiEkgKI4FQ/7yarW9Ate8KlekWXxER6QoURgLhgsshYSBUl8DXK33WbJqeUyMiIl2AwkggmM0woW52JGs5+GiZzpS6O2p2nSwhv6zaJ22KiIgEmsJIoIz5IYRGwqndcPhznzSZ0C2MoclRAGzQ7IiIiHRSCiOBYouB0be49314m69u8RURkc5OYSSQ6hey7v4AinzzvJ2GdSMKIyIi0jkpjARSj2GQegm4nLD5JZ80ObF/PCFmE9mFlRwtqPBJmyIiIoGkMBJok37i/rr5ZaipandzkWEhjO0bC8DbXx1rd3siIiKBpjASaIOvhug+UFEAO9/1SZO3fasfAM+tOcDBU2U+aVNERCRQFEYCzRICE+5w7/toIev3Rvfi0sHdsdc6WfT2dpzODl/hX0RExENhxAgXzQaLFY5vhmOb292cyWTi0ekjCA+18MWhQv622TeLY0VERAJBYcQIkYkw4kb3vo9mR1LiI8i4cjAAj36wi7zS9q9HERERCQSFEaPU3+b7zdtQdsonTc5JS2VE72hKqmr5zT92+qRNERERf1MYMUrvce7NYYctr/ikyRCLmcdvGIXFbOKDr0+SuSvXJ+2KiIj4k8KIkSbe6f765Qpw1PqkyRG9Y/jxxf0B+NW7Oyir9k27IiIi/qIwYqTh0yEiEUqOw55VPmv2vvTBpMSHc7K4iic/3OOzdkVERPxBYcRIoTYYN9u978Pn1YRbLTz2/ZEAvLLhMF8dPe2ztkVERHxNYcRo4+8Ak8X9JN+8XT5r9pJB3blhbG9cLlj09nZqHE6ftS0iIuJLCiNGi+kDQ69172ct92nTv7puOPGRVnbnlPLCZwd92raIiIivKIx0BPULWbe9CVXFPms2PtLKg9cNA+B/M/epVLyIiHRICiMdQerF0H0Y1JTD1r/4tOnpY3pzyaBE7LVO7n9nOy6XSsWLiEjHojDSEZhMDUXQsl4Ap+/Wd7hLxY/EFmpm48FC/vqlSsWLiEjHojDSUYyaAWHRUHgADn7i06b7JjQtFX+qtNqn7YuIiLSHwkhHEdYNxsx07/t4ISvAHWn9G5WK/8bn7YuIiLSVwkhHMmGu++veD6HwkE+bblwq/p9fn+ST3SoVLyIiHYPCSEeSOBAGXAG44MsXfd58k1Lx76hUvIiIdAwKIx1N/W2+W14Fe4XPm783fRAp8eGcUKl4ERHpIBRGOppBV0JsP6gqgh1v+bz5CGsIj05XqXgREek4FEY6GrOl6W2+fqgLcung7nxfpeJFRKSDUBjpiMbMhJBwyNkO2V/4pYtfXTuMuIhQlYoXERHDKYx0RBHxMOpm974Pn+bbWEK3MB68bjjgLhV/KL/cL/2IiIicj8JIRzWh7lLNzvegNMcvXXx/bKNS8W+rVLyIiBhDYaSj6jkK+k4GZy18+ZJfumhcKn7DwQL+9uUxv/QjIiJyLgojHVn9QtbNL0Gt3S9d9E2I4L70ulLxq1QqXkREAk9hpCMbOg26JUNZLux632/d/Pji/lzYK5riyhqVihcRkYBTGOnIQqwwfo573w/Pq/F0U1cq3mxCpeJFRCTgFEY6unG3gzkEsjfCyW1+62Zkn4ZS8Q+++w3lKhUvIiIB0qYw8uyzz5KamorNZmPSpElkZWW16nVvvvkmJpOJ6dOnt6Xb4BSVDMOvd+/7cXYE4L4rB9MnLpzjRZU8+ZFKxYuISGB4HUZWrlxJRkYGDz30EFu2bGH06NFMnTqVvLy8c77u8OHD/OIXv+CSSy5p82CDVv3zarb/DSoK/dZNhDWEx77vLhX/8vrDbM0u8ltfIiIi9bwOI0899RTz5s1jzpw5DB8+nGXLlhEREcGKFStafI3D4WDmzJn85je/4YILLmjXgINSyiRIHgW1VfDVa37tqnGp+IV//1ql4kVExO+8CiN2u53NmzeTnp7e0IDZTHp6Ohs2bGjxdQ8//DA9evTgxz/+cav6qa6upqSkpMkW1EymhtmRTX8Cp8Ov3alUvIiIBJJXYSQ/Px+Hw0FSUlKT40lJSeTkNF8ldO3atbz44ossX9769Q5LliwhJibGs6WkpHgzzK5p5E0QHgdFR2Dfx37tKqFbGL+6VqXiRUQkMPx6N01paSk/+tGPWL58OYmJia1+3aJFiyguLvZs2dnZfhxlJxEaDmN/5N7P+qPfu7vhooZS8Q+8o1LxIiLiP16FkcTERCwWC7m5TetQ5ObmkpycfNb5Bw4c4PDhw0ybNo2QkBBCQkL485//zPvvv09ISAgHDhxotp+wsDCio6ObbAJM+DFgggOfQP4+v3bVuFT8+gMF/G2zSsWLiIh/eBVGrFYr48aNIzMz03PM6XSSmZnJ5MmTzzp/6NChbN++na1bt3q2733ve1x++eVs3bpVl1+8FZcKg7/r3t/0J79316RU/AcqFS8iIv7h9WWajIwMli9fziuvvMKuXbuYP38+5eXlzJnjrhQ6a9YsFi1aBIDNZmPEiBFNttjYWKKiohgxYgRWq9W37yYY1D+vZusbUF3q9+4al4p/+J87/d6fiIgEH6/DyIwZM3jyySdZvHgxY8aMYevWraxevdqzqPXo0aOcPHnS5wOVOhdcDgkDoboEvl7p9+4al4r/x7YTfLr73PVkREREvGVydYKViSUlJcTExFBcXKz1IwAbl8HqX0L3ofBfG923/vrZb/+5kz+tPUTv2HA+uu9SIsNC/N6niIh0bq39/NazaTqjMT+E0Eg4tRsOfx6QLjOuaigV/4eP9gakTxERCQ4KI52RLQZG3+Lez3ohIF1GWEN41FMq/hDbVCpeRER8RGGks6qvyLr7AygKTB2Wbw/uzvQxvXC64JcqFS8iIj6iMNJZ9RgK/S8FlxM2vxSwbh+8brinVPzyz1UqXkRE2k9hpDOrnx3Z/DLUVAWkyyal4v+9j8MqFS8iIu2kMNKZDb4aovtARQF8807Aur3hot5cPDCR6lon96tUvIiItJPCSGdmCYEJd7j3A7SQFepKxX9/hKdU/FsqFS8iIu2gMNLZXTQbLFY4sQW+eTdg3fZLiOTe+lLxq3aRX6ZS8SIi0jYKI51dZCKMudW9/7fZsHoR1AYmGMy9uD/De0ZTVFHDw/9QqXgREWkbhZGu4OrfwaT57v2Nz8Gf0iF/v9+7DbGYeeJGd6n497ed4NM9KhUvIiLeUxjpCkLC4OrH4YcrITwecr6GP14KX70Ofl5cOrJPDHek9QfgV+/soLy61q/9iYhI16Mw0pUM+S7MXw+pl0BNObz3X/D3uVBV4tduVSpeRETaQ2Gkq4nuCbPegysWg8kCO96CZRfDsS/91mWENYTfTh8BqFS8iIh4T2GkKzJb4JKfwx2rIaYvFB2BFVNh7f+A0z8l3C8b0oPr60rFL3x7u0rFi4hIqymMdGUpE+Gnn8OF3wdnLfz71/Da96E0xy/dPXjdcGIjQtl1soQ/fX7IL32IiEjXozDS1YXHwk0vwfeehtAIOLgGnk+DfR/7vKvERqXil/57r0rFi4hIqyiMBAOTCS6aBXeugaSRUJEPr98Eq+/3eU2SGxuVin/gXZWKFxGR81MYCSbdh8Dcf8Okn7q/3/gsvHilT2uSNC4Vv26/SsWLiMj5KYwEm1AbXP0E/PBNd02Sk9vcNUm2vuGzmiQqFS8iIt5QGAlWQ66G+esaapK8Ox/evtNnNUkal4p/5J8qFS8iIi1TGAlm0b3cNUm+8yt3TZLtf4U/XgLHNre76RCLmcdvHInZBO9tVal4ERFpmcJIsDNb4NL/hjn/ctckOX0YVlwFa5e2uybJqD6xzFGpeBEROQ+FEXHrO8ldk2T49LqaJA/BazdAaW67ms24cjC9Y92l4p/6WKXiRUTkbAoj0iA8Fm5+Gab9H4SEw8FP4fkpsO/fbW4yMiyER7/vLhX/0jqVihcRkbMpjEhTJhOMmw0/+Q8kjairSXIjfPgA1Nrb1KRKxYuIyLkojEjzug+BuZkw8U739xuecdckKTjQpuYal4p/ca1KxYuISAOFEWlZqA2u+T3c8hcIj4OTW2HZJbD1L143ldgtjAeuGQbA/3y8lyMFKhUvIiJuCiNyfkOvgfnrod/FdTVJftqmmiQ3jetD2sAEqmud3P+OSsWLiIibwoi0TnQvmP0+XF5Xk+Trle7KrcdbX5PEZDLx6PSRhIW4S8X/fctxPw5YREQ6C4URaT2zBb793zBnFcSkwOlD8OJVsO7/Wl2TJDWxoVT8bz/YqVLxIiKiMCJt0PdbdTVJrnfXJPn4QfcdN62sSTL3kv4MU6l4ERGpozAibRMeBze/AtP+112T5MAnsCwN9p+/JkmoxcwTKhUvIiJ1FEak7UwmGHc73LkGelwI5afgtRvho1+dtybJmaXiK+wqFS8iEqwURqT9egyFeZkwYZ77+/VPt6omSZNS8R+pVLyISLBSGBHfCA2Ha5+EW95oqEnyx0th28oWXxIZFsJv60rFr1h3iK+PFQVmrCIi0qEojIhvDb0WfrrOXZPEXgbv3Alv/wSqS5s9/fIhPfje6LpS8X9XqXgRkWCkMCK+F9O7ribJA2Ayw9dv1tUk2dLs6YunuUvF71SpeBGRoKQwIv5htsC3/x/cvgqi+0DhQXdNkvVPn1WT5MxS8bpcIyISXNoURp599llSU1Ox2WxMmjSJrKysFs99++23GT9+PLGxsURGRjJmzBheffXVNg9YOpl+k2H+Whj2PXDWuO+0ef0mKGt6O2/jUvHXP7uOn/91GyeKKg0atIiIBJLXYWTlypVkZGTw0EMPsWXLFkaPHs3UqVPJy2u+VkR8fDwPPPAAGzZs4Ouvv2bOnDnMmTOHDz/8sN2Dl04iPA5+8Ge4bimE2OBAJjyfBvszPaeYTCb+95axXDeqJy4X/H3LMS5/cg1PrN5NSVWNcWMXERG/M7m8fFrZpEmTmDBhAs888wwATqeTlJQU7r77bhYuXNiqNi666CKuvfZaHnnkkVadX1JSQkxMDMXFxURHR3szXOlo8nbBW3dAXl3l1Sk/g+88CCFWzylfHT3Nkn/tJutQIQBxEaH87IpBzJzUD2uIriyKiHQWrf389upvdrvdzubNm0lPT29owGwmPT2dDRs2nPf1LpeLzMxM9uzZw6WXXupN19JV9BgG8z6BCXPd36//P1hxVZOaJGP7xrHyzm/xp1njGdijG6cravjNP3aS/tR/+OfXJ/S0XxGRLsarMJKfn4/D4SApKanJ8aSkJHJyclp8XXFxMd26dcNqtXLttdfy9NNPc+WVV7Z4fnV1NSUlJU026UJCw+HaP8CM18AWCye+ct9t8/VfPaeYTCbShyex+p5LeOz7I+keFcbRwgrueuMrpj+3ni8OFhg3fhER8amAzHlHRUWxdetWNm3axKOPPkpGRgZr1qxp8fwlS5YQExPj2VJSUgIxTAm0YdNg/jroO8Vdk+Ttee6aJMe3gMO9TiTEYubWSX1Z84vLuC99MBFWC9uyi5jxwkbmvvIl+/Oar18iIiKdh1drRux2OxEREbz11ltMnz7dc3z27NkUFRXx3nvvtaqduXPnkp2d3eIi1urqaqqrGx4tX1JSQkpKitaMdFVOB3z2e/jPE+Cqu+03JBx6jYWUCdBnIqRMhG49OFVazf9m7uUvWdk4nC7MJpgxoS/3pQ+iR7TN2PchIiJN+GXNiNVqZdy4cWRmNtwF4XQ6yczMZPLkya1ux+l0NgkbZwoLCyM6OrrJJl2Y2QKXLXTXJBk01X3pprYSjq6Hdf8LK2fCk4Ng6Si6f7SA3/bcwJpbY7l6WAJOF/wl6yiXPbmG//l4L+XVeuCeiEhnE+LtCzIyMpg9ezbjx49n4sSJLF26lPLycubMmQPArFmz6N27N0uWLAHcl1zGjx/PgAEDqK6uZtWqVbz66qs8//zzvn0n0vn1m+zenE4o2A/HsiA7C45tct+FU3TEvW3/GynA8yHhlPQbyb9L+/GvohReyyzk9S+Ocm/6IGZMSCHUojtvREQ6A6/DyIwZMzh16hSLFy8mJyeHMWPGsHr1as+i1qNHj2I2N3wIlJeX81//9V8cO3aM8PBwhg4dymuvvcaMGTN89y6kazGboftg9zb2NvexqmI4vhmyN7lDyrFNUFVMdG4WN5DFDXV3Bh+x92DLB4N47tMLmXDJd5k8+VJMllDj3ouIiJyX13VGjKA6I3IWpxMK9tXNnGRB9iZcp3Zjoul/zlWmMGqSxhI1cIp73UmfCRCZaNCgRUSCS2s/vxVGpOuoLILjm6k+tIETOz4joWg70aaKs8+Lv6BuUWzd4tgew8Hi9SShiIich8KIBL2TReW88c+PObVrLWNN+xhn2cdA0/GzTwyNhN4X1c2c1M+eJAR+wCIiXYzCiEid3TklPP6v3azZc4poypgcdpi5qae4yLwPy4ktUN1MUb34AQ2XdVLqZk/MlsAPXkSkE1MYETnDuv35LPnXLnYcd4eP5GgbP79yADeklGM5vqlhcWz+3rNfbO3mnj2pr3nSZwJExAf4HYiIdC4KIyLNcDpd/OPrE/xu9R6OF1UCMCQpioXXDOWywd0xmUxQUVh3507d4thjm8HeTKXXhIFnrD0ZptkTEZFGFEZEzqGqxsGrG47w9Cf7KKlyF0qbMiCB+68ZxojeMU1Pdjrg1G53OKkPKAX7z27UGtVo7ckEiOkDEQnuTbcXi0hH5HKBww72cgiL8vnfVQojIq1QVGHnuTUHeHndYewOdyn66WN68fOrhpASH9HyCysK3bVO6sPJ8S3u5+u0JCzGfVknIsF9a3FEQsP3EYkNoSUiwb14NizGXW9FRIKb0+muSF1T6Q4MNZVQU/fVXgE1jTZ7RSt+fua5FeByuPu6c437MRw+pDAi4oXswgr+8NEe3t16AgCrxcztaaksuGwgMRGt+JeC0wF5Oxsqxp7YCuWnoLKw4Xk73jBZ6sLKGcElsnFwiW8aZKznCE8i4h+O2vMEgvKGD/0zA8GZP2/u3NrKwL2X21dBappPm1QYEWmDHceLeWzVLtYfKAAgJjyUuy4fyI8m98MW2ob1IE4nVBVBRYF7K89v2G9uKy9ofn1Ka4SE14WV+EaB5RxhJjxe9VWk83PUQm0V1FbXfW28X/fVYW/+eLPHzvW1+uzjzprAvdcQG4RGuDdrBISGu0sThIbXfV//s7pjTc6t38Jb/rkfLicrjIi0kcvlYs3eUzy+ajd7ct3BoHdsOP89dQjfG90Ls9nk3wHUVrsvA1UUQEV9eClsOciU57f9L0Rb7NmXiJoEmXj3X1qWMLBY3X9ZhYS5v1qsdcfrj1m1gLcrcrnAWQuOGveHev2+s6buWP2+3R0MzjpeU/cae6NjteBo5oO9yX5LAeKMr/WXGAxnOncIaG0gaClshEZ0yku3CiMi7eRwuvj7lmM89dFeckqqABjRO5r7rx7GlIEdqKS8y+Ver1Ke3yjENA4ydTMujQNM5WnAD//rm8wtBJfWhJkzjlmsZ7z+zGPNhKFznYvJfcmsyeZy/zmcdfyMc875fUvH6rYm7bemr/Oc43TUhYKaRh/+9kYf+ucLDTVnhILm2mq07+xET8I2h7pnD0LCvPga1sxxb9qom60ICQOTn/+h0gkpjIj4SKXdwYp1h3h+zQHKqt1/MV82pDsLrx7K0ORO+t+jo/Ycl48KmwaZ+qnp+g85R91+bXVgp6il4zBZ3CHPHFoX9prbD6mbLWtm3xzaQgjwMhRYzmhDM3MdjsKIiI8VlFXz9Cf7eW3jEWqdLswmuGlcHzKuHEJyjM3o4RnD5aoLKY0CSv2/0h2N9j3H7c0ca3Rurf2M81o41mybLZzbWibzOTaT+yum85/T6u/P2DCd/xyTyf2Be64PeYv1jP1QMIc0zBA1t9/s60KaDxvm0E55uUCMoTAi4ieH88v5/Yd7+GD7SQBsoWZ+fHF/fvLtAUTbVE+kQ/GEpbpQ0mKA0PS6iD8ojIj42Zajp1myahebDp8GID7Sys++M5BbJ/XDGqJ/OYqIKIyIBIDL5eLjnbk8vno3B0+VA5CaEMH/++5Qpl6YjMXfd96IiHRgCiMiAVTrcLLyy2z+5+N95JdVAxAbEUragETSBiZy8cBE+iaoKJmIBBeFEREDlFXXsvyzg6xYd4jSqqa3RPaNj/AEkykDEoiLtBo0ShGRwFAYETFQrcPJtmPFrNufz9r9+Ww5cppaZ8P/aiYTjOgVQ9rARC4ZlMi4fnFtq/AqItKBKYyIdCDl1bVkHSpk7f581u7L91R2rRcWYmZCajwXD3LPnAzvGe3/Sq8iIn6mMCLSgeWVVLH+QAGf78tn7f5T5JZUN/l5XEQoU+ou6Vw8MPHcTxAWEemgFEZEOgmXy8WBU2Ws3ZfP2v0FbDxY4Kn0Wq9fQtP1JrERWm8iIh2fwohIJ1XjcPL1sSLW7itg7f5TfHW06Kz1JiN71603GZjIRVpvIiIdlMKISBdRVl1L1iH3JZ11+/PZm1vW5OdhIWYm9o/n4oHu24i13kREOgqFEZEuKq+kyr0Qdr87nJy53iQ+0sqUAQmecKL1JiJiFIURkSDgcrnYn1fmCSYbDhRQbnc0OadfQoRnIexkrTcRkQBSGBEJQjUOJ9uyizy3EH+VXYTjjPUmo+rWm1w8MJFxqXGEhWi9iYj4h8KIiFBaVUPWoULPepN9eU3Xm9hC6+qbDEzk4kGJDEvWehMR8R2FERE5S25JFWvrgsna/fnklTa/3uSSQe71Jn3itN5ERNpOYUREzsnlcrEvr8wTTjYePHu9SWpCBKP6xDIkOYpBPboxOCmKlPgIPY1YRFpFYUREvFLjcLI1u6iu+Fo+W89Yb1LPFmpmYI9uDO4RxeDkKAYnuUNK79hwTCaFFBFpoDAiIu1SWlXDl4dPsyunhL05pezNLWP/qTLstc5mz4+0WhiYFMWQunAyKCmKIUlRJEWHKaSIBCmFERHxOYfTxZGCcvbmlrEvt5Q9uaXsyy3jYH4ZNY7m/yqJsoUwOCmqbqsPKt3o3k0hRaSrUxgRkYCpcTg5nO8OKXtzSz3b4YKKZi/1gPthgPWzJ4OTujGoLrDER6oOikhXoTAiIoarrnVw8FQ5e+tmUNwzKaUcKaygpb95EruFeWZQBjcKKjHhoYEdvIi0m8KIiHRYlXYHB07Vz6I0zKYcO13Z4muSo20MSupWN5PivtQzKCmKbmEhARy5iHhDYUREOp3y6lr25ZXVzaSUsqdubcrJ4qoWX9M7Ntw9k5Ic5b7DJymKgT26EW5VZVkRoymMiEiXUVxZw/680jPWpJRx6oyibfVMJugbH8GgHlEMSXZf8umXEEmfuHASIq1aOCsSIAojItLlnS63u4NJXt3dPTml7Msro7Dc3uJrbKFmesWG0zs2nD5xEfSJc+/3jgunT1w4PaJsKuom4iN+DSPPPvssv//978nJyWH06NE8/fTTTJw4sdlzly9fzp///Gd27NgBwLhx43jsscdaPL85CiMi4o38suq62igNQSW7sJLc0qoWF87WCzGb6Blr84QVT1Cp+z45xoY1xByYNyLSybX289vrlV8rV64kIyODZcuWMWnSJJYuXcrUqVPZs2cPPXr0OOv8NWvW8MMf/pApU6Zgs9l44oknuOqqq/jmm2/o3bu3t92LiJxXYrcwEgeGMWVgYpPj9lonJ4srOX66kmNFlRw77d4/XlTB8aJKThZVUet0kV1YSXZhJVB4VtsmEyRF2TwzKQ2zKnXBJTZc61VEvOT1zMikSZOYMGECzzzzDABOp5OUlBTuvvtuFi5ceN7XOxwO4uLieOaZZ5g1a1ar+tTMiIgEgsPpIrekiuNFdYHltDukHDtd6TlW3UIF2sYSIq3uoFIfVupnWeqORdt0m7IEB7/MjNjtdjZv3syiRYs8x8xmM+np6WzYsKFVbVRUVFBTU0N8fHyL51RXV1Nd3bAwraSkxJthioi0icVsoldsOL1iw5mQevbPXS4X+WX2s8LK8bqwcux0JWXVtRSU2ykot7PtWHGz/UTZQjwzKfWzK43DS7wW2UqQ8SqM5Ofn43A4SEpKanI8KSmJ3bt3t6qNX/7yl/Tq1Yv09PQWz1myZAm/+c1vvBmaiIjfmUwmukeF0T0qjDEpsWf93OVyUVJZy7GiirqwUnlGWKngdEUNpVW17DpZwq6Tzf9DKzzU0jCr0iis9IkLJzkmnMRuVsJCdClIuo6AVgt6/PHHefPNN1mzZg02m63F8xYtWkRGRobn+5KSElJSUgIxRBGRNjOZTMREhBITEcOFvWKaPae8upYTRWeuWank+OkKjp2uJK+0msoaB/vzytifV9ZiX9G2EE8w6h5lo3u3MBKjrHTvFtboeBjxEVZCLFpwKx2bV2EkMTERi8VCbm5uk+O5ubkkJyef87VPPvkkjz/+OP/+978ZNWrUOc8NCwsjLCzMm6GJiHQKkWEhDKp7qnFzqmsdnCyq8syk1C+2rZ9pOVVajd3hpKSqlpKqWg6cKj9nfyaTew1LYuOQ0sx+YrcwYiNCdXlIDOFVGLFarYwbN47MzEymT58OuBewZmZmctddd7X4ut/97nc8+uijfPjhh4wfP75dAxYR6crCQiykJkaSmhjZ7M/rLwWdKqsir7SaU6XV5JfZOVW3f6qs/lg1BWXVOF2QX2Ynv8zO7pzSc/YdajE1hJZuYU0DTFRDaOkeFUak1aLgIj7j9WWajIwMZs+ezfjx45k4cSJLly6lvLycOXPmADBr1ix69+7NkiVLAHjiiSdYvHgxb7zxBqmpqeTk5ADQrVs3unXr5sO3IiLS9TVcCgplYI/mZ1fqOZwuCsvtZ4UUT3CpO55fVk1RRQ01Dhcni6vOWX6/XniopVFAsdYFGNtZxxK7hWEL1foWOTevw8iMGTM4deoUixcvJicnhzFjxrB69WrPotajR49iNjdcn3z++eex2+3cdNNNTdp56KGH+PWvf92+0YuISIss5oYFt+dTXeug4IwZlvxGIabxsXK7g8oaB0cLKzhaWHHetuvXtzSeaam/LBQfYSU2wkp8pJW4iFBiI6wqKheEVA5eRES8Ul5d23SGpbngUvd9jcP7j5iosBBiI5sGFU9wibQSH+EOLnGRVuIi3D/T7EvH5LcKrCIiEtwiw0KIDAuhX0Lz61rqNbe+pT6kFJbZOV1Rw+kKu3srt1NUWYPLBaXVtZRW19ZVwW2dCKuFuAgrcZGh7q+e2Zamx+r34yOtCjAdiMKIiIj4hTfrW8C9xqWksnFAqaGwwk5RhZ3C8pq6r3aKKhqOn66oweF0UWF3UGF33ybdWrZQ89mzL5F13zeaeakPMfGRVsJDtXDXHxRGRESkQ7CYTe4AEGlt9WucThelVbWcrrA3G1xOV9RwutzeEHDqvq91uqiqcXKiuIoTrViwW88aUh9gQj0BJtoWSnR4KNG2kLqvoUSHhzQ67v5eQaZlCiMiItJpmc0Nsy+pnPuyUT2Xy0VZdS2ny2taDDFFFTV1YaZhlsbucGKvdZJTUkVOSesDTL0Qs+k8oSV4w4zCiIiIBBWTyUSULZQoWyh9EyJa9RqXy30pqD6Y1IeUoooaSqtq3EXoKmsoqaqhpLK27mvD8Vqni9q6W60Ly+1tGnd9mImyhTQNLGeGl2aCTLQtlIgOXBtGYUREROQ8TCaTZ+FunzjvXutyuaiscZwRUpoPLf4MMxazqfnZl7r9277V77yLkv1FYURERMSPTCYTEdYQIqwhJMe0/Fy2lngbZko9++6vxXVhxuF01d3BVNNsP1eP7KkwIiIiImfzRZipqnGeN8j0jg33w+hbR2FERESkCzOZTIRbLYRbLSRFex9mAkE1d0VERMRQCiMiIiJiKIURERERMZTCiIiIiBhKYUREREQMpTAiIiIihlIYEREREUMpjIiIiIihFEZERETEUAojIiIiYiiFERERETGUwoiIiIgYSmFEREREDNUpntrrcrkAKCkpMXgkIiIi0lr1n9v1n+Mt6RRhpLS0FICUlBSDRyIiIiLeKi0tJSYmpsWfm1zniysdgNPp5MSJE0RFRWEymXzWbklJCSkpKWRnZxMdHe2zdqVt9PvoePQ76Vj0++hY9Ps4P5fLRWlpKb169cJsbnllSKeYGTGbzfTp08dv7UdHR+s/pA5Ev4+OR7+TjkW/j45Fv49zO9eMSD0tYBURERFDKYyIiIiIoYI6jISFhfHQQw8RFhZm9FAE/T46Iv1OOhb9PjoW/T58p1MsYBUREZGuK6hnRkRERMR4CiMiIiJiKIURERERMZTCiIiIiBgqqMPIs88+S2pqKjabjUmTJpGVlWX0kILSkiVLmDBhAlFRUfTo0YPp06ezZ88eo4cldR5//HFMJhP33nuv0UMJWsePH+e2224jISGB8PBwRo4cyZdffmn0sIKWw+HgwQcfpH///oSHhzNgwAAeeeSR8z5/RVoWtGFk5cqVZGRk8NBDD7FlyxZGjx7N1KlTycvLM3poQec///kPCxYsYOPGjXz88cfU1NRw1VVXUV5ebvTQgt6mTZv44x//yKhRo4weStA6ffo0aWlphIaG8q9//YudO3fyhz/8gbi4OKOHFrSeeOIJnn/+eZ555hl27drFE088we9+9zuefvppo4fWaQXtrb2TJk1iwoQJPPPMM4D7+TcpKSncfffdLFy40ODRBbdTp07Ro0cP/vOf/3DppZcaPZygVVZWxkUXXcRzzz3Hb3/7W8aMGcPSpUuNHlbQWbhwIevWrePzzz83eihS57rrriMpKYkXX3zRc+zGG28kPDyc1157zcCRdV5BOTNit9vZvHkz6enpnmNms5n09HQ2bNhg4MgEoLi4GID4+HiDRxLcFixYwLXXXtvk/xMJvPfff5/x48dz880306NHD8aOHcvy5cuNHlZQmzJlCpmZmezduxeAbdu2sXbtWq6++mqDR9Z5dYoH5flafn4+DoeDpKSkJseTkpLYvXu3QaMScM9Q3XvvvaSlpTFixAijhxO03nzzTbZs2cKmTZuMHkrQO3jwIM8//zwZGRncf//9bNq0iZ/97GdYrVZmz55t9PCC0sKFCykpKWHo0KFYLBYcDgePPvooM2fONHponVZQhhHpuBYsWMCOHTtYu3at0UMJWtnZ2dxzzz18/PHH2Gw2o4cT9JxOJ+PHj+exxx4DYOzYsezYsYNly5YpjBjkr3/9K6+//jpvvPEGF154IVu3buXee++lV69e+p20UVCGkcTERCwWC7m5uU2O5+bmkpycbNCo5K677uKf//wnn332GX369DF6OEFr8+bN5OXlcdFFF3mOORwOPvvsM5555hmqq6uxWCwGjjC49OzZk+HDhzc5NmzYMP7+978bNCL57//+bxYuXMgtt9wCwMiRIzly5AhLlixRGGmjoFwzYrVaGTduHJmZmZ5jTqeTzMxMJk+ebODIgpPL5eKuu+7inXfe4ZNPPqF///5GDymoXXHFFWzfvp2tW7d6tvHjxzNz5ky2bt2qIBJgaWlpZ93qvnfvXvr162fQiKSiogKzuenHp8Viwel0GjSizi8oZ0YAMjIymD17NuPHj2fixIksXbqU8vJy5syZY/TQgs6CBQt44403eO+994iKiiInJweAmJgYwsPDDR5d8ImKijprvU5kZCQJCQlax2OA++67jylTpvDYY4/xgx/8gKysLF544QVeeOEFo4cWtKZNm8ajjz5K3759ufDCC/nqq6946qmnuOOOO4weWuflCmJPP/20q2/fvi6r1eqaOHGia+PGjUYPKSgBzW4vvfSS0UOTOt/+9rdd99xzj9HDCFr/+Mc/XCNGjHCFhYW5hg4d6nrhhReMHlJQKykpcd1zzz2uvn37umw2m+uCCy5wPfDAA67q6mqjh9ZpBW2dEREREekYgnLNiIiIiHQcCiMiIiJiKIURERERMZTCiIiIiBhKYUREREQMpTAiIiIihlIYEREREUMpjIiIiIihFEZERETEUAojIiIiYiiFERERETGUwoiIiIgY6v8DgUb4zfpSHUcAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGgCAYAAACJ7TzXAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUthJREFUeJzt3Xl8VNXB//HPzCQzk4RsEMhGIOzIDoGkKC5VKmqlbkXBDXGrFvuoeayCIuijkGorxSqWn9al7uBSa5Xikqp1QYNEVGRfE5aEJJCdZJKZ+/tjkoFAgAyZyUyS7/v1uq+5uXPvOWcIOl/OPfcck2EYBiIiIiJBzBzoBoiIiIiciAKLiIiIBD0FFhEREQl6CiwiIiIS9BRYREREJOgpsIiIiEjQU2ARERGRoKfAIiIiIkFPgUVERESCngKLiIiIBL2TCiyLFy8mNTUVu91ORkYGOTk5xzy3rq6O//u//6Nfv37Y7XZGjhzJihUrmpzzwAMPYDKZmmyDBw8+maaJiIhIBxTi7QVLly4lMzOTJUuWkJGRwaJFi5g0aRIbN26kR48eR50/Z84cXn75ZZ555hkGDx7MBx98wCWXXMJXX33F6NGjPecNHTqUjz/++FDDQlreNJfLxZ49e4iMjMRkMnn7kURERCQADMOgoqKCpKQkzOYT9KEYXkpPTzdmzpzp+dnpdBpJSUlGVlZWs+cnJiYaTz75ZJNjl156qXHVVVd5fp43b54xcuRIb5vikZ+fbwDatGnTpk2btna45efnn/C73qseFofDwerVq5k9e7bnmNlsZuLEiaxcubLZa2pra7Hb7U2OhYWF8cUXXzQ5tnnzZpKSkrDb7YwfP56srCx69ep1zDJra2s9PxsNC07n5+cTFRXlzUcSERGRACkvLyclJYXIyMgTnutVYCkuLsbpdBIfH9/keHx8PBs2bGj2mkmTJrFw4ULOOOMM+vXrR3Z2Nm+//TZOp9NzTkZGBi+88AKDBg1i7969PPjgg5x++umsXbu22Q+RlZXFgw8+eNTxqKgoBRYREZF2piXDOfz+lNDjjz/OgAEDGDx4MFarldtuu40ZM2Y0uVd1/vnnM2XKFEaMGMGkSZNYvnw5paWlLFu2rNkyZ8+eTVlZmWfLz8/398cQERGRAPIqsMTFxWGxWCgsLGxyvLCwkISEhGav6d69O++88w5VVVXs3LmTDRs20KVLF/r27XvMemJiYhg4cCBbtmxp9n2bzebpTVGvioiISMfnVWCxWq2kpaWRnZ3tOeZyucjOzmb8+PHHvdZut5OcnEx9fT1vvfUWF1100THPraysZOvWrSQmJnrTPBEREemgvH6sOTMzk+nTpzN27FjS09NZtGgRVVVVzJgxA4Brr72W5ORksrKyAPjmm2/YvXs3o0aNYvfu3TzwwAO4XC7uvvtuT5l33XUXkydPpnfv3uzZs4d58+ZhsViYNm2ajz6me2BufX19k7EzIkeyWCyEhITo8XgRkSDjdWC54oorKCoqYu7cuRQUFDBq1ChWrFjhGYibl5fXZHxKTU0Nc+bMYdu2bXTp0oULLriAl156iZiYGM85u3btYtq0aZSUlNC9e3cmTJjA119/Tffu3Vv/CXE/3bR3716qq6t9Up50bOHh4SQmJmK1WgPdFBERaWAyGp8JbsfKy8uJjo6mrKzsqPEsLpeLzZs3Y7FY6N69O1arVf96lmYZhoHD4aCoqAin08mAAQNOPJGRiIictON9fx/J6x6W9sbhcOByuUhJSSE8PDzQzZEgFxYWRmhoKDt37sThcBw1h5CIiARGp/nno/6lLC2lvysiIsFH/2cWERGRoKfAIiIiIkFPgUVERESCngKLeKWuri7QTRARkU5IgSXIrVixggkTJhATE0O3bt248MIL2bp1q+f9xjlsunbtSkREBGPHjuWbb77xvP+vf/2LcePGYbfbiYuL45JLLvG8ZzKZeOedd5rUFxMTwwsvvADAjh07MJlMLF26lDPPPBO73c4rr7xCSUkJ06ZNIzk5mfDwcIYPH85rr73WpByXy8Wjjz5K//79sdls9OrVi/nz5wNw9tlnc9tttzU5v6ioCKvV2mQWZRER8T/DMKisrWdP6UE2FJSzasd+stcX8o/vdvHiyh08+Z/NLFi+noffWxfQdnb4x5qbYxgGB+sCM+NtWKjFq3lgqqqqyMzMZMSIEVRWVjJ37lwuueQS1qxZQ3V1NWeeeSbJycm8++67JCQkkJubi8vlAuD999/nkksu4b777uPFF1/E4XCwfPlyr9s8a9YsHnvsMUaPHo3dbqempoa0tDTuueceoqKieP/997nmmmvo168f6enpgHuBymeeeYY///nPTJgwgb1793pW9L7xxhu57bbbeOyxx7DZbAC8/PLLJCcnc/bZZ3vdPhGRzqze6aKipp7ymjr368E6yht+Lj9Y53mv/GA9FTV1h/ZrDx1ztWBGNmuImTkXDvH/BzqGThlYDtY5GTL3g4DUve7/JhFubfkf+2WXXdbk5+eee47u3buzbt06vvrqK4qKili1ahVdu3YFoH///p5z58+fz9SpU3nwwQc9x0aOHOl1m++44w4uvfTSJsfuuusuz/7vfvc7PvjgA5YtW0Z6ejoVFRU8/vjjPPnkk0yfPh2Afv36MWHCBAAuvfRSbrvtNv75z39y+eWXA/DCCy9w3XXXaVI/EelUDMOgtt7lCRFNQ8ex9huCR8P51Q7f/AM81GIiyh5KVFgoUfYQIu2hRIWFEGUPJdLufnW5DMzmwPx/ulMGlvZk8+bNzJ07l2+++Ybi4mJP70leXh5r1qxh9OjRnrBypDVr1nDTTTe1ug1jx45t8rPT6WTBggUsW7aM3bt343A4qK2t9UzMt379empraznnnHOaLc9ut3PNNdfw3HPPcfnll5Obm8vatWt59913W91WEZG2ZBgGNXUuT29GeU0dZQcPhQlPb8dxQofD6fJJW8KtlkPhotnQcUQACQt1B5SGfVuIOaj/0dgpA0tYqIV1/zcpYHV7o3FRyGeeeYakpCRcLhfDhg3D4XAQFhZ2/LpO8L7JZOLIlRmaG1QbERHR5Oc//vGPPP744yxatIjhw4cTERHBHXfcgcPhaFG94L4tNGrUKHbt2sXzzz/P2WefTe/evU94nYiIrznqXUeFi7KDdU16PdwhxP1+2cE6Kg573xeBw2SiSU9GVFhD2Giyf+i9IwNIF3sIoZaOPSy1UwYWk8nk1W2ZQCkpKWHjxo0888wznH766QB88cUXnvdHjBjB3/72N/bv399sL8uIESPIzs72rKR9pO7du7N3717Pz5s3b27RApFffvklF110EVdffTXgHmC7adMmhgxx39scMGAAYWFhZGdnc+ONNzZbxvDhwxk7dizPPPMMr776Kk8++eQJ6xURaY7TZVDZECSO19NRdoxA4osxjRazydNT0RgqosNCibSFEh1+4t6OCGtIwG61tBfB/63dicXGxtKtWzeefvppEhMTycvLY9asWZ73p02bxoIFC7j44ovJysoiMTGR7777jqSkJMaPH8+8efM455xz6NevH1OnTqW+vp7ly5dzzz33AO6ndZ588knGjx+P0+nknnvuITQ09ITtGjBgAG+++SZfffUVsbGxLFy4kMLCQk9gsdvt3HPPPdx9991YrVZOO+00ioqK+Omnn7jhhhs85TQOvo2IiGjy9JKIdD6GYVB+sJ791Q72Vzk4UOWg7Ihg0TSQNNxaOVhHRW29T9oQaWsIHGGHbpNEHxFADh/j4Q4i7p8jrN49UCHeU2AJYmazmddff53/+Z//YdiwYQwaNIi//OUvnHXWWQBYrVY+/PBD/vd//5cLLriA+vp6hgwZwuLFiwE466yzeOONN3jooYf4wx/+QFRUFGeccYan/Mcee4wZM2Zw+umnk5SUxOOPP87q1atP2K45c+awbds2Jk2aRHh4ODfffDMXX3wxZWVlnnPuv/9+QkJCmDt3Lnv27CExMZFbbrmlSTnTpk3jjjvuYNq0aVpkUKSDqalzcqAhfDRuBxr3qw8/VkdJlYPSagf1LXlU5TjCQi3NBwtPCDk6eDTud7GHYFEPR1AzGUcOYmiHjrc8dU1NDdu3b6dPnz76UgwyO3bsoF+/fqxatYoxY8YEujke+jsj0pTLZVB2sO6IoOGg5IgQcvixqpN8ciXCaqFrFyux4VZiwq3N9nRE2UMPCyGHbsNYQzr2GI6O6Hjf30dSD4u0ubq6OkpKSpgzZw4/+9nPgiqsiHQGBx1Od/ioPDpoeELIYbdmDlQ7WjRPx5FCzCZiI6x0DbfSNcK9xUaE0jXCRtfwUGIjrHSLsBEbEUq3CBsx4aHYvXwwQToPBRZpc19++SU///nPGThwIG+++WagmyPS7rlcBiVVDvaUHmRvWQ0lVbUNPR917K+qZX+1+/VAVR37qxwnPcg00h7iDh3hVrpFWBsCh7VJKDn8WJQ9ROM6xGcUWKTNnXXWWUc9Ti0ix1ZeU8fe0hr2lB10h5LSGvaUHmRPmTug7C2t8frR2lCL6VD46NI0hDT2hnQNt9K1i/s1JtyqWy4SUAosIiIBVFvvpKCsht0NQWRv2UF2N7w2hpOWPAVjMkGPSBuJ0WHEdbHRtfHWy2Gv7lDivgXTxabeD2lfFFhERPzE6TIorqz1hBFPr4int6SG4sraFpUVHRZKUkwYSdF2kmLCSIyxkxwTRmJ0GInRdhKi7R1+4jDp3BRYREROgmG4n5zZ0xBE9pYdZE9ZjadXZHfpQQrLa1r0qK491ExStDuEuF/DSI6xkxgd5g4n0XYibPrftXRu+i9ARKQZNXVOd4/IkWNHGvfLalq06JzFbCI+0tbQKxJGUmMoaegpSYoJIzY8VLdnRE5AgUVEOqV6p4tdBw6yvaSK7UVV7Cyp8owd2VtWw/4qR4vK6RZhJbGhNyQ55vAg4j7WI9JGiG7ViLSaAouIdFgul8He8hq2F1WxvaSKHcVVbC92v+btrz7h7Zpwq8XTC5IU3XiL5lDPSGK0XfOGiLQRBRYRadcMw6CootYdREqq2FZ8KJjsLKmmtv7Yj/vaQsz0iYsgtVsEqXERJMceGtSaFB1GVJiepBEJFgosHVhqaip33HEHd9xxR6CbItJqB6ocnts3O0rcgaSxt+R408CHWkykdA2n72HBpG+c+zUhyq4VckXaCQUWEQkaFTV17CiubnL7pnErO1h3zOvMJugZG05qXAR9uoW7e03iIugTF0FyTJjGkIh0AAosEpScTicmkwmzWV80HU1NnZMdDYGk8fbNjuJqthVXnXBOksRoO6ndIujTPYI+3SI8wSSlaxi2EI0lEenIOue3gWGAoyowWwunpH/66adJSkrC5Wp6//2iiy7i+uuvZ+vWrVx00UXEx8fTpUsXxo0bx8cff3zSfyQLFy5k+PDhREREkJKSwm9/+1sqKyubnPPll19y1llnER4eTmxsLJMmTeLAgQMAuFwuHn30Ufr374/NZqNXr17Mnz8fgE8//RSTyURpaamnrDVr1mAymdixYwcAL7zwAjExMbz77rsMGTIEm81GXl4eq1at4he/+AVxcXFER0dz5plnkpub26RdpaWl/OY3vyE+Ph673c6wYcN47733qKqqIioq6qj1it555x0iIiKoqKg46T8vOT5HvYutRZV8vK6Qv32+jfv+8SNXPvM1p2ZlM/j+FZy36HNueTmXR1dsZNm3u8jZsd8TVuK62BiXGsuUtJ7cfd4g/nrVGP59++ms/7/zWDn7HF67+WcsuGQ4N53Rl4lD4unfo4vCikgn0Dl7WOqqYUFSYOq+dw9YI0542pQpU/jd737HJ598wjnnnAPA/v37WbFiBcuXL6eyspILLriA+fPnY7PZePHFF5k8eTIbN26kV69eXjfLbDbzl7/8hT59+rBt2zZ++9vfcvfdd/PUU08B7oBxzjnncP311/P4448TEhLCJ598gtPpHjswe/ZsnnnmGf785z8zYcIE9u7dy4YNG7xqQ3V1NY888gh/+9vf6NatGz169GDbtm1Mnz6dJ554AsMweOyxx7jgggvYvHkzkZGRuFwuzj//fCoqKnj55Zfp168f69atw2KxEBERwdSpU3n++ef59a9/7amn8efIyEiv/5ykqf1VDtbuLmty62ZHSRW7DhzEeZwncKLsIfTp3uWwcSXh9I3rQmpcOJH20Db8BCLSXnTOwNIOxMbGcv755/Pqq696Asubb75JXFwcP//5zzGbzYwcOdJz/kMPPcQ//vEP3n33XW677Tav6zt8YG5qaioPP/wwt9xyiyewPProo4wdO9bzM8DQoUMBqKio4PHHH+fJJ59k+vTpAPTr148JEyZ41Ya6ujqeeuqpJp/r7LPPbnLO008/TUxMDJ999hkXXnghH3/8MTk5Oaxfv56BAwcC0LdvX8/5N954I6eeeip79+4lMTGRffv2sXz58lb1RnVWTpfB5n0VrN55gNydpeTmHWB7cdUxzw+3Wg6NJTns9k2fuAhNlCYiXuucgSU03N3TEai6W+iqq67ipptu4qmnnsJms/HKK68wdepUzGYzlZWVPPDAA7z//vvs3buX+vp6Dh48SF5e3kk16+OPPyYrK4sNGzZQXl5OfX09NTU1VFdXEx4ezpo1a5gyZUqz165fv57a2lpPsDpZVquVESNGNDlWWFjInDlz+PTTT9m3bx9Op5Pq6mrP51yzZg09e/b0hJUjpaenM3ToUP7+978za9YsXn75ZXr37s0ZZ5zRqrZ2BmUH6/gu7wC5eaXk7jzAmvxSKptZhK9v9wj6d+/SZFxJn7gIukfaFEpExGc6Z2AxmVp0WybQJk+ejGEYvP/++4wbN47PP/+cP//5zwDcddddfPTRR/zpT3+if//+hIWF8etf/xqHo2Wzcx5ux44dXHjhhdx6663Mnz+frl278sUXX3DDDTfgcDgIDw8nLCzsmNcf7z3AM3DWOGz8Tl3d0U98hIWFHfUFN336dEpKSnj88cfp3bs3NpuN8ePHez7nieoGdy/L4sWLmTVrFs8//zwzZszQF+kRXC6DbcWV5O4sdfeg5B1g877Ko86LsFoY1SuGtF6xjO4dy5iUWKLDdQtHRPyvcwaWdsJut3PppZfyyiuvsGXLFgYNGsSYMWMA9wDY6667jksuuQSAyspKzwBWb61evRqXy8Vjjz3mCRfLli1rcs6IESPIzs7mwQcfPOr6AQMGEBYWRnZ2NjfeeONR73fv3h2AvXv3EhsbC7h7Rlriyy+/5KmnnuKCCy4AID8/n+Li4ibt2rVrF5s2bTpmL8vVV1/N3XffzV/+8hfWrVvnuW3VmVXW1vN9/qFw8l1eabOPDad2C2dM71jG9IolrXcsA+MjsWjeEhEJAAWWIHfVVVdx4YUX8tNPP3H11Vd7jg8YMIC3336byZMnYzKZuP/++496oqil+vfvT11dHU888QSTJ0/myy+/ZMmSJU3OmT17NsOHD+e3v/0tt9xyC1arlU8++YQpU6YQFxfHPffcw913343VauW0006jqKiIn376iRtuuIH+/fuTkpLCAw88wPz589m0aROPPfZYi9o2YMAAXnrpJcaOHUt5eTm///3vm/SqnHnmmZxxxhlcdtllLFy4kP79+7NhwwZMJhPnnXce4B4PdOmll/L73/+ec889l549e57Un1N7ZRgGO0qqyW0IJ6t3HmBTYQVHjom1h5oZ2TOGMb1j3T0ovWLo1sUWmEaLiBxBgSXInX322XTt2pWNGzdy5ZVXeo4vXLiQ66+/nlNPPdUTGMrLy0+qjpEjR7Jw4UIeeeQRZs+ezRlnnEFWVhbXXnut55yBAwfy4Ycfcu+995Kenk5YWBgZGRlMmzYNgPvvv5+QkBDmzp3Lnj17SExM5JZbbgEgNDSU1157jVtvvZURI0Ywbtw4Hn744WOOiTncs88+y80338yYMWNISUlhwYIF3HXXXU3Oeeutt7jrrruYNm0aVVVV9O/fnz/84Q9Nzrnhhht49dVXuf7660/qz6g9Oehw8v0ud+9J4xiU5hby6xkb5uk5GdMrlsGJkYRqgjURCVImw2jhxCBBrLy8nOjoaMrKyoiKimryXk1NDdu3b6dPnz7Y7fYAtVAC7aWXXuLOO+9kz549WK3W457bnv7OGIbBrgMHyc070NCDUsq6veVHPVJsDTEzPDm6IZzEMKZXLD2igvuziUjHd7zv7yOph0U6tOrqavbu3csf/vAHfvOb35wwrAS7mjona3eXNQSUUlbnHaCo4ujZYROi7KT1dt/WGdM7lqFJUZpcTUTaNQWWTuCVV17hN7/5TbPv9e7dm59++qmNW9R2Hn30UebPn88ZZ5zB7NmzA90cr+0tO+iZ82T1zgP8tKeMOmfT3pMQs4mhydGenpO03rEkxZz46SkRkfZEt4Q6gYqKCgoLC5t9LzQ0lN69e7dxi4JboP7OOOpdrNtbfujJnZ0H2FNWc9R5cV1s7nDS2x1OhidHYw9V74mItD+6JSRNREZGahr6ILSvoobcnaUNA2MP8MOuMmrrmz7pZTGbGJwQ2WRwbErXo+erERHp6DpNYOkAHUnSRvz5d6Wqtp73ftjDazn5rMkvPer9mPBQTzgZ3SuGkT1jiLB1mv9MRUSOqcP/nzA01D0LZ3V1dYtmRRWprq4GDv3d8YUfd5Xx2qo83l2zxzO9vckEA3tENkzMFkNa71j6xEWo90REpBknFVgWL17MH//4RwoKChg5ciRPPPEE6enpzZ5bV1dHVlYWf//739m9ezeDBg3ikUce8UzqdTJlesNisRATE8O+ffsACA8P1xeCNMswDKqrq9m3bx8xMTFYLK0bF1JeU8c/1+zh9Zw8ftpzaI6c1G7hXDGuF5elJdMjsnOOqxIR8ZbXgWXp0qVkZmayZMkSMjIyWLRoEZMmTWLjxo306NHjqPPnzJnDyy+/zDPPPMPgwYP54IMPuOSSS/jqq68YPXr0SZXprYSEBABPaBE5npiYGM/fGW8ZhkFuXimv5eTx/g97OVjnBMBqMXPesASmpqfwsz7dMGt6exERr3j9lFBGRgbjxo3jySefBMDlcpGSksLvfvc7Zs2addT5SUlJ3HfffcycOdNz7LLLLiMsLIyXX375pMo8UktHGTudzmYX3RNpFBoaelI9K6XVDt7O3c3rq/LYVHho0cD+PbowdVwKl47pSdeI9j0HjIiIr/ntKSGHw8Hq1aubzGdhNpuZOHEiK1eubPaa2traox4NDQsL44svvmhVmbW1hybLaumU9BaLpdXd/CKNDMPgm+37eT0nj+VrC3A0POFjDzXzy+FJTEtPIa13rG5Bioj4gFeBpbi4GKfTSXx8fJPj8fHxbNiwodlrJk2axMKFCznjjDPo168f2dnZvP322zidzpMuMysrq9lVg0XaQnFlLW+t3sXSVflsK67yHD8lMYpp6SlcNCqZ6DDfDdgVEZE2eEro8ccf56abbmLw4MGYTCb69evHjBkzeO655066zNmzZ5OZmen5uby8nJSUFF80V6RZLpfBF1uKeX1VHh+tK/TMNhthtfCrUUlMHdeLET2j1ZsSaIYBzjpwOsBV17Bfd+x9z3n17teOwDAAAwxXw3b4/rG2w85xOY//fkvKOKn3mznHbAFzyGGvISf5c3NbS645xjmW0GNfo/8H+I1XgSUuLg6LxXLUrKmFhYXHHKTYvXt33nnnHWpqaigpKSEpKYlZs2bRt2/fky7TZrNhs2nZe/G/wvIa3vg2n6Xf5pO//6Dn+MiUGKaNS+HCkUl06UzzpBgG1FVDbQXUlENtuXvfEwQch778nY4TB4Zmr6lvGiSa3T9G+DCcgf4Tks7OZG4m5IRCiM0ddCyNr9bDjlkPbU2OHX6utZljzZx7zOsPr98K5va3MrtX/6e1Wq2kpaWRnZ3NxRdfDLgHyGZnZ3Pbbbcd91q73U5ycjJ1dXW89dZbXH755a0uU8QfnC6DTzfu47WcfD7ZuM+z8nGkPYRLRiczdVwvhiQdf3BYUHK5wHFY0KhpCBu15VBT1syxxkBS3jScuOoD/Um8Yw5p+B90KFgO32/YGvc70r+OTebDNtMRPx+5Nfe+pZXXe3tOc++bGnp86t29Pq76I7Yjj7XiZ2ed99cfKxwbrobg7Wjb37m3TBbvA0+IHX79bMCa7PU/DTMzM5k+fTpjx44lPT2dRYsWUVVVxYwZMwC49tprSU5OJisrC4BvvvmG3bt3M2rUKHbv3s0DDzyAy+Xi7rvvbnGZIm1h14Fqln27ize+zWfvYWv4jEuNZeq4XlwwPJEwa4AGbTvrGkJDWdPejeZCxeHh4vBjjgrftcdkBlsk2KLB1qXhf24N/2Nr7DI/4b61aWA4cv+41x/jmuau7yghRIKLYbQg5BwWiBpDjNMB9Y6mPx91vPbQNc0eq22mzGaOHX79kbc8Dae7t9SbO6EhgZ181evAcsUVV1BUVMTcuXMpKChg1KhRrFixwjNoNi8vD/NhXU01NTXMmTOHbdu20aVLFy644AJeeuklYmJiWlymiL/UOV1kry/ktZx8/ru5iMaH/GPDQ7l0TE+mpafQv4eP12E6WAr71sH+be6ejROGjwqoP3jCYlvMYgVblDtw2KPc+/boZo41vB6+3/hqjVAQkM7NZGrosWsnt4RdrkO3XZsLTE0CT3OByQEEdombDr9as0hzdpZU8fqqfN74dhfFlYcekT+1Xzempvdi0tB4bCGt7E1x1sP+rVC4Fgp/OrSV5Z98maHhR4SJkwgdoZpdV0SCg1ZrFmlGbb2TD34q5PWcPL7aWuI5HtfFxpSxPblibAqpcREnV3hV8RHBZC3s2+D+l0pzolMgbiCExTYEicgWhI5I960OEZFOSIFFOrwt+yp4LSeft3N3caDafcPWZIIzBnRnWnoK55wST6ilhSPm6x1QvOlQKGkMKJUFzZ8fGgHxQyB+KMQPc7/2GAJhMb75cCIinYQCi3RIBx1Olv+4l9dX5bFqxwHP8cRoO1PGpnD52J70jA0/dgGGARUFRweT4o3Hfkomtg8kDDsUTOKHQkxqu3x8UEQk2CiwSIeybk85r6/K4x/f7aaixh0sLGYTPx/UgyszUjhzYA8sRy48WHcQija4A0nB2kMB5eD+5iuxRR8KJI09Jz1OcT8tIyIifqHAIu1eVW09//p+D6+tyuf7/FLP8Z6xYUwdl8KUsSnER9ndvSZl+Uf3mpRscc+dcCSTGboNaBpM4odCdE89ISMi0sYUWKRdMgyDH3aV8fqqPN5ds4cqh3sSp1CLiXOHJHDV6Fh+FrEPc9Hn8PlhT+jUHmOhzPBuDYHksNs53QdBaGDnHRARETcFFmlXqmrreTt3F6/l5LNubzkmXPQy7eOymH38KmE/w0N3YSteB8t2NF+AOdQdRI68pdMlXr0mIiJBTIFF2g1HvYs7//o2CUVfcLUpjyG2fE4x78Jm1EANsOOICyITj76d022Ae00OERFpVxRYJPgZBuStZMc7WSw58Dnm0MPmOjRwr2/R45QjHh0eChHdAtZkERHxLQUWCV7OOlj3T1j5JOz5joEAJijuMZ64QacdCijd+rlXRBURkQ5LgUWCz8FSyH0Rvvl/UL4LgFqsvFl/OrsGX8c9V/8qsO0TEZE2p8AiwePADvh6CXz3Ejgq3cciuvNB+K+YlT+OiNh4/v3r0wPaRBERCQwFFgm8/Bz3bZ/1/zo0H0qPITB+Jh+aT+c3r63FZIL/d/koIu1aS0dEpDNSYJHAcNbDhvfcQWXXqkPH+50D42dCv7PZV1nLrEWfA/CbM/qR3qdrgBorIiKBpsAibau2AnJfgm/+CqV57mMWK4y4HH42071QIO6J4e558wf2Vzk4JTGKO38xIICNFhGRQFNgkbZRmg85/w9W//3QbLPh3WDcje6tS48mp7+ak8cnG4uwhphZdMUobCF6CkhEpDNTYBH/2p0LKxfDT/8Awz19Pt0GuG/7jJza7NT324oqefi99QDcPWkQgxIi27LFIiIShBRYxPdcTtj4b3dQyfvq0PE+Z8D426D/L8BsbvbSeqeLO5d9z8E6J6f268b1p/Vpo0aLiEgwU2AR33FUwZpX4eunYP829zFzKAz/Nfzst5A44oRFLP5kK9/nlxJpD+FPU0ZiNmt9HxERUWARXyjfCzlPw7fPQU2p+5g9BsZeD+k3QVRSi4r5Pr+Uv/xnMwAPXzyMpBitlCwiIm4KLHLy9v7gvu2z9i1w1bmPde3r7k0ZdSVYI1pcVLWjnjuXrsHpMrhwRCK/GtmykCMiIp2DAot4x+WCLR+550/Z/t9Dx3udCqfeBgPPO6l1fbKWb2BbcRUJUXYevngYJpNuBYmIyCEKLNIydQfh+9dg5VNQ4r5tg8kCQy+B8b+F5LSTLvqTjft46eudAPxxyghiwq2+aLGIiHQgCixyfJX7IOcZ+PZZqC5xH7NFQdp0SP8NxKS0qvj9VQ7ufvMHAK47NZXTB3RvbYtFRKQDUmCR5hWug68Xww/LwOlwH4vp5R6fMvpqsLV+bhTDMLj37R8pqqilf48uzDp/cKvLFBGRjkmBRQ4xDNj6H/f4lK3/OXS85zj3/CmDLwSL7/7KvJ27mxU/FRBiNrHoilHYQzWbrYiINE+BRaCuBn58w/3ET5F7hllMZjhlsjuopKT7vMr8/dXMe/cnAO78xUCGJUf7vA4REek4FFg6s6pi99wpOU9DVZH7mLULjL4GfnYLxKb6pVqny+B/3/ieytp60nrH8psz+vqlHhER6TgUWDqjok3u8Snfvw71Ne5jUcmQcQuMuRbCYvxa/d8+30bO9v1EWC38+fJRhFian6ZfRESkkQJLZ2EY7nlTVi6GzR8cOp44Ck79HQy5CCyhfm/Guj3l/OnDjQDMnTyEXt3C/V6niIi0fwosncVbN8LaNxt+MMGgC9wTvfUaD200SVtNnZM7l66hzmkw8ZR4Lh/bukeiRUSk81Bg6QwKfnSHFZPFvb7Pz26Fbv3avBmPfbiRjYUVxHWx8ofLhms2WxERaTEFls5g9d/dr6dcCL/8U0Ca8NXWYv72xXYA/nDpCOK62ALSDhERaZ802rGjc1S7J38DSLsuIE0or6njrmXfYxgwLT2FiUPiA9IOERFpvxRYOrp170BtGcT0hj5nBaQJ8/75E3vKaujdLZw5vxwSkDaIiEj7psDS0TXeDhpzDZjb/tf93g97+Md3uzGbYOHlo4iw6S6kiIh4T4GlI9u3AfK/dg+2HXV1m1dfUFbDff9YC8DMn/cnrXdsm7dBREQ6BgWWjiy3oXdl4HkQldimVRuGwe/f/J6yg3UMT47mf84Z0Kb1i4hIx6LA0lHV1cD3r7n306a3efUvrtzJ55uLsYWY+fMVowjVbLYiItIK+hbpqDa8BwcPuKfc7z+xTavesq+SBcvdiyjee8Ep9O/RpU3rFxGRjkeBpaNa/YL7dfQ1YLa0WbV1Thd3Ll1Dbb2L0wfEcc3PerdZ3SIi0nEpsHREJVthx+eACUa37WDbv2Rv5sfdZUSHhfLHX4/EbNZstiIi0noKLB1R42DbAb+AmLZbr2f1zgMs/mQLAAsuGU5CtL3N6hYRkY7tpALL4sWLSU1NxW63k5GRQU5OznHPX7RoEYMGDSIsLIyUlBTuvPNOampqPO8/8MADmEymJtvgwYNPpmlS74DvXnHvj2m7wbZVtfVkLluDy4BLRifzyxFt+1SSiIh0bF7P4rV06VIyMzNZsmQJGRkZLFq0iEmTJrFx40Z69Ohx1Pmvvvoqs2bN4rnnnuPUU09l06ZNXHfddZhMJhYuXOg5b+jQoXz88ceHGhaiCcZOysblUF0MXeJh4KQ2q/bh99ezs6SapGg7D/xqaJvVKyIinYPXPSwLFy7kpptuYsaMGQwZMoQlS5YQHh7Oc8891+z5X331FaeddhpXXnklqampnHvuuUybNu2oXpmQkBASEhI8W1xc3Ml9os6u8XbQ6KvBEtomVX68rpDXcvIwmeCxy0cRHdY29YqISOfhVWBxOBysXr2aiRMPPSZrNpuZOHEiK1eubPaaU089ldWrV3sCyrZt21i+fDkXXHBBk/M2b95MUlISffv25aqrriIvL++Y7aitraW8vLzJJsCBHbD1P+790de0SZXFlbXMevsHAG6c0Ifx/bq1Sb0iItK5eHXfpbi4GKfTSXx809V24+Pj2bBhQ7PXXHnllRQXFzNhwgQMw6C+vp5bbrmFe++913NORkYGL7zwAoMGDWLv3r08+OCDnH766axdu5bIyMijyszKyuLBBx/0pumdQ+5L7te+Z0HXPn6vzjAMZr/9I8WVDgYnRPK/5w7ye50iItI5+f0poU8//ZQFCxbw1FNPkZuby9tvv83777/PQw895Dnn/PPPZ8qUKYwYMYJJkyaxfPlySktLWbZsWbNlzp49m7KyMs+Wn5/v748R/Jz18N3L7v2069qkymXf5vPRukKsFvdstvbQtpvvRUREOhevelji4uKwWCwUFhY2OV5YWEhCQkKz19x///1cc8013HjjjQAMHz6cqqoqbr75Zu677z7MzawgHBMTw8CBA9myZUuzZdpsNmw2mzdN7/g2fwCVBRAeB4N+6ffqdpZU8eC/1gHwv+cO5JTEKL/XKSIinZdXPSxWq5W0tDSys7M9x1wuF9nZ2YwfP77Za6qrq48KJRaL+1/ihmE0e01lZSVbt24lMVGPxrbY6obBtqOmQYjVr1U5XQaZy76n2uEkvU9Xbjy9r1/rExER8frZ4czMTKZPn87YsWNJT09n0aJFVFVVMWPGDACuvfZakpOTycrKAmDy5MksXLiQ0aNHk5GRwZYtW7j//vuZPHmyJ7jcddddTJ48md69e7Nnzx7mzZuHxWJh2rRpPvyoHVjZLtjykXt/zHV+r27JZ1tZvfMAXWwhPDZlJBbNZisiIn7mdWC54oorKCoqYu7cuRQUFDBq1ChWrFjhGYibl5fXpEdlzpw5mEwm5syZw+7du+nevTuTJ09m/vz5nnN27drFtGnTKCkpoXv37kyYMIGvv/6a7t27++AjdgLfvQyGC3pPgLj+fq1q7e4y/vzRJgAe/NVQUrqG+7U+ERERAJNxrPsy7Uh5eTnR0dGUlZURFdXJxlK4nLBoBJTvgkufgRGX+62qmjonFz7xBVv2VXL+sASeumoMJpN6V0RE5OR48/2ttYTau63/cYcVewyc8iu/VvXIig1s2VdJ90gb8y8ZrrAiIiJtRoGlvVv9gvt15DQI9d9ig59vLuL5L3cA8Mdfj6BrhH8H9oqIiBxOgaU9qyiAjf9276f5b6HD0moHd73xPQDX/Kw3Zw06es0oERERf1Jgac/WvAKGE1IyoMcpfqvm/n/+RGF5LX3jIrj3Av/VIyIiciwKLO2Vy3Vo7pUx/utd+eea3fzr+z1YzCb+fMUowqyazVZERNqeAkt7tf0zKN0JtigYerFfqthTepA576wF4H/OHsDIlBi/1CMiInIiCiztVW5D78qIy8Ea4fPiXS6Du974noqaekamxDDz5/18XoeIiEhLKbC0R1XFsP49976fbgc9/9UOvtpaQliohUVXjCLEor8qIiISOPoWao/WvAquOkgaDYkjfF78psIKHlmxAYA5F55Cnzjf9+CIiIh4Q4GlvTEMyH3RvZ92nc+Ld9S7uOP1NTjqXfx8UHeuTO/l8zpERES8pcDS3uz8Cko2Q2gEDLvM58X/+eNNrNtbTtcIK4/8eoRmsxURkaCgwNLeNM5sO/wysEX6tOhVO/az5LOtACy4ZDg9Iv03c66IiIg3FFjak+r9sO6f7n0f3w6qqKnjzqVrMAyYktaT84Yl+LR8ERGR1lBgaU9+WAbOWogfDkljfFr0//1rHbsOHKRnbBhzJw/xadkiIiKtpcDSXhjGodtBadPBh2NLVqwt4I3VuzCZ4M9XjCLSHuqzskVERHxBgaW92LUKitZDSBgMn+KzYvdV1HDvP34E4JYz+zEutavPyhYREfEVBZb2onHdoKGXQFiMT4o0DIN73vyB/VUOTkmM4s6JA31SroiIiK8psLQHNWWw9i33fprvZrZ9NSePTzYWYQ0x8/jUUVhD9NdBRESCk76h2oMf34D6g9B9MKRk+KTI7cVVPPzeegDuOW8wA+N9+4i0iIiILymwBLvDB9uO8c1g23qnizuXruFgnZNT+3VjxqmprS5TRETEnxRYgt2e76DgR7BYYeRUnxS5+JOtrMkvJcoewp+mjMRs1my2IiIS3BRYgl1uw2DbIRdBeOuf4Pk+v5S//GczAA9dPIykmLBWlykiIuJvCizBrLYSfnzTvT+m9YNtDzqc3Ll0DU6XweSRSVw0KrnVZYqIiLQFBZZgtvYtcFRC136QOqHVxS1Yvp5txVUkRNl56KKhPmigiIhI21BgCWaNt4N8MLPtJxv38dLXOwH405SRxIRbW9s6ERGRNqPAEqwKfoTdq8EcCiOvbFVRhmEw758/ATDjtFQmDIjzRQtFRETajAJLsGqc2XbwBdCle6uKyt9/kLz91YRaTNx17iAfNE5ERKRtKbAEI0e1e2Vm8Mlg22+2lwAwPDmaCFtIq8sTERFpawoswWjdP6G2DGJ6Qd+ft7q4VTv2AzCujxY2FBGR9kmBJRh5Zra9Fsyt/xWt2nEAgAwFFhERaacUWILNvg2Q/zWYLDDq6tYXV1HD9uIqTCZI663AIiIi7ZMCS7DJfdH9OvA8iEpsdXHfNvSuDIqPJDostNXliYiIBIICSzCpq4HvX3Xvp7V+sC1Aznb3+JV03Q4SEZF2TIElmGx4Dw4egKhk6D/RJ0V6BtymKrCIiEj7pcASTBoH246+BsyWVhdXXlPHur3lgHpYRESkfVNgCRYlW2HH54AJRrd+sC3A6p0HMAzo3S2c+Ci7T8oUEREJBAWWYNG4blD/iRCT4pMiV23X7SAREekYFFiCQb0D1jQOtr3OZ8U2jl9JV2AREZF2ToElGGxcDlVF0CUeBk7ySZE1dU6+zy8DNMOtiIi0fwoswaDxdtCoq8Dim7lSfthVhsPpIq6LjdRu4T4pU0REJFAUWALtwA7Y+ol7f8y1Pis2p2HBw/Q+sZhMJp+VKyIiEggKLIGW+xJgQN+zoGsfnxWb0zDDrcaviIhIR6DAEkjOeljzint/jG9mtgVwugxyd7oDi8aviIhIR3BSgWXx4sWkpqZit9vJyMggJyfnuOcvWrSIQYMGERYWRkpKCnfeeSc1NTWtKrND2PwhVOyF8DgYfKHPil2/t5zK2noibSEMTojyWbkiIiKB4nVgWbp0KZmZmcybN4/c3FxGjhzJpEmT2LdvX7Pnv/rqq8yaNYt58+axfv16nn32WZYuXcq999570mV2GJ7BttMgxOqzYhvXD0pLjcVi1vgVERFp/7wOLAsXLuSmm25ixowZDBkyhCVLlhAeHs5zzz3X7PlfffUVp512GldeeSWpqamce+65TJs2rUkPirdldghlu909LODT20Gg9YNERKTj8SqwOBwOVq9ezcSJhxbmM5vNTJw4kZUrVzZ7zamnnsrq1as9AWXbtm0sX76cCy644KTLrK2tpby8vMnW7nz3Mhgu6D0B4gb4rFjDMA5NGKfxKyIi0kGEeHNycXExTqeT+Pj4Jsfj4+PZsGFDs9dceeWVFBcXM2HCBAzDoL6+nltuucVzS+hkyszKyuLBBx/0punBxeWE715y76f5tndlW3EVxZUOrCFmRvSM9mnZIiIigeL3p4Q+/fRTFixYwFNPPUVubi5vv/0277//Pg899NBJlzl79mzKyso8W35+vg9b3Aa2/gfK8sEeA6f8yqdFN64fNColBltI61d8FhERCQZe9bDExcVhsVgoLCxscrywsJCEhIRmr7n//vu55ppruPHGGwEYPnw4VVVV3Hzzzdx3330nVabNZsNms3nT9OCy+gX368hpEOrbVZRztH6QiIh0QF71sFitVtLS0sjOzvYcc7lcZGdnM378+Gavqa6uxmxuWo3F4v6Xv2EYJ1Vmu1ZRAJtWuPd9fDsIDhtwq/ErIiLSgXjVwwKQmZnJ9OnTGTt2LOnp6SxatIiqqipmzJgBwLXXXktycjJZWVkATJ48mYULFzJ69GgyMjLYsmUL999/P5MnT/YElxOV2aGseQVc9dAzHXqc4tOiC8pqyN9/ELMJxvSK8WnZIiIigeR1YLniiisoKipi7ty5FBQUMGrUKFasWOEZNJuXl9ekR2XOnDmYTCbmzJnD7t276d69O5MnT2b+/PktLrPDcLkg90X3ftp1Pi++8XbQkKQoIu2+WURRREQkGJgMwzAC3YjWKi8vJzo6mrKyMqKignhm122fwosXgS0K/ncDWCN8Wvycd37k5a/zmHFaKvMmD/Vp2SIiIr7mzfe31hJqS42DbYdP8XlYAVi13b1+UIbGr4iISAejwNJWqoph/XvufT/cDiqtdrCxsAKAsXpCSEREOhgFlrby/WvgqoOk0ZA4wufFf7vD3bvSt3sEcV3a8SPfIiIizVBgaQuGAasbFjr08bpBjVZp/hUREenAFFjaws6voGQzhEbA8F/7pYocLXgoIiIdmAJLW8ht6F0ZfhnYIn1efLWjnh93lQFa8FBERDomBRZ/q94PP73j3h9znV+qWJNXSr3LICHKTs/YML/UISIiEkgKLP72wzJw1kL8cEge45cqPOsH9emKyWTySx0iIiKBpMDiT4Zx6HZQ2nTwU5jQ+kEiItLRKbD4065VsG8dhIS5J4vzgzqni9ydpYCeEBIRkY5LgcWfGh9lHnoJhMX4pYqf9pRzsM5JdFgoA3p08UsdIiIigabA4i81ZfDT2+79NP/MvQKwanvj48yxmM0avyIiIh2TAou//PgG1FVD3CBIyfBbNd9s1/wrIiLS8Smw+Evj7aC06/w22NblMvh256EnhERERDoqBRZ/2PMdFPwAFiuMnOq3arYUVVJaXUdYqIVhydF+q0dERCTQFFj8YfUL7tdTfgXh/uv5yGm4HTS6VwyhFv0qRUSk49K3nK/VVsKPb7r3067za1WrtH6QiIh0EgosvvbT2+CohK79IHWC36oxDMPTw6LxKyIi0tEpsPha4+2gMdf6bbAtwK4DB9lbVkOI2cToXjF+q0dERCQYKLD4UsFa2L0azKEw6iq/VtV4O2hocjTh1hC/1iUiIhJoCiy+1Lhu0OALoEt3v1bVGFgydDtIREQ6AQUWX3FUw/dL3ftj/DezbaMcTRgnIiKdiAKLr6z7J9SWQUwv6Ptzv1ZVUlnL1qIqAMb2jvVrXSIiIsFAgcVXGm8HjbkWzP79Y1214wAAA+O7EBth9WtdIiIiwUCBxRf2bYC8lWCywKir/V6d5l8REZHORoHFF3JfdL8OPA+iEv1eneZfERGRzkaBpbXqa+H719z7af4fbFtZW89Pe8oA9bCIiEjnocDSWuv/BQf3Q1Qy9J/o9+pydx7AZUDP2DCSYsL8Xp+IiEgwUGBprcaZbUdfDWaL36trHL+Srt4VERHpRBRYWqNkK+z4HDDB6GvapErP/CsavyIiIp2IAktrNA627T8RYlL8Xl1tvZM1+aWAxq+IiEjnosBysuodsOYV934bDLYF+HFXGbX1LrpFWOnXPaJN6hQREQkGCiwna9O/oaoIusS7H2duAzkN41fGpsZi8uNK0CIiIsFGgeVkrW6Y2XbUVWAJbZMqV3nmX+nWJvWJiIgECwWWk3FgJ2z9j3t/TNsMtnW6DL7d6Z6SX08IiYhIZ6PAcjK+ewkwoO9Z0LVvm1S5saCCipp6IqwWTkmMbJM6RUREgoUCi7ec9fDdy+79MW0z2BYOzb8ypncsIRb92kREpHPRN5+3Nn8IFXshvBsM/mWbVetZP0i3g0REpBNSYPFWbuNg2yshxNYmVRqG4XlCSBPGiYhIZ6TA4o2y3e4eFmjT20E7S6opqqjFajEzKiWmzeoVEREJFgos3vjuZTBc0Ps0iBvQZtU29q6M6BmNPdT/6xWJiIgEGwWWlnI5G54OAtKua9OqV2n9IBER6eQUWFpq6ydQlg/2GDjlV21atVZoFhGRzu6kAsvixYtJTU3FbreTkZFBTk7OMc8966yzMJlMR22//OWhJ2yuu+66o94/77y2me6+xVY/734dORVC7W1W7b7yGnaUVGMyuR9pFhER6YxCvL1g6dKlZGZmsmTJEjIyMli0aBGTJk1i48aN9OjR46jz3377bRwOh+fnkpISRo4cyZQpU5qcd9555/H88897frbZ2uYJnBapKIRNK9z7bTjYFg6NXxmcEEV0WNssASAiIhJsvO5hWbhwITfddBMzZsxgyJAhLFmyhPDwcJ577rlmz+/atSsJCQme7aOPPiI8PPyowGKz2ZqcFxsbRL0Ja14BVz30TIf4IW1adeP4lQyNXxERkU7Mq8DicDhYvXo1EydOPFSA2czEiRNZuXJli8p49tlnmTp1KhEREU2Of/rpp/To0YNBgwZx6623UlJScswyamtrKS8vb7L5jct1aO6VtLbtXQHI2eFeP2icxq+IiEgn5lVgKS4uxul0Eh8f3+R4fHw8BQUFJ7w+JyeHtWvXcuONNzY5ft555/Hiiy+SnZ3NI488wmeffcb555+P0+lstpysrCyio6M9W0pKijcfwzs7/gsHdoAtCoZe4r96mlF2sI4NBe4wNq5PEPU4iYiItDGvx7C0xrPPPsvw4cNJT09vcnzq1Kme/eHDhzNixAj69evHp59+yjnnnHNUObNnzyYzM9Pzc3l5uf9Cy+qG3pXhU8AacfxzfSx35wEMA1K7hdMjsu0G+oqIiAQbr3pY4uLisFgsFBYWNjleWFhIQkLCca+tqqri9ddf54YbbjhhPX379iUuLo4tW7Y0+77NZiMqKqrJ5hdVxbD+X+79gNwOaph/RbeDRESkk/MqsFitVtLS0sjOzvYcc7lcZGdnM378+ONe+8Ybb1BbW8vVV199wnp27dpFSUkJiYmJ3jTP9wwXZPwG+p0DiSPbvPocTRgnIiICnMQtoczMTKZPn87YsWNJT09n0aJFVFVVMWPGDACuvfZakpOTycrKanLds88+y8UXX0y3bt2aHK+srOTBBx/ksssuIyEhga1bt3L33XfTv39/Jk2a1IqP5gNdesCk+QGpuqbOyQ+7SgFNGCciIuJ1YLniiisoKipi7ty5FBQUMGrUKFasWOEZiJuXl4fZ3LTjZuPGjXzxxRd8+OGHR5VnsVj44Ycf+Pvf/05paSlJSUmce+65PPTQQ8E1F0sbW5NfSp3ToEekjd7dwgPdHBERkYAyGYZhBLoRrVVeXk50dDRlZWX+G8/Sxp7I3sxjH23ilyMSWXzlmEA3R0RExOe8+f7WWkJBKkfrB4mIiHgosASheqeL3J2aME5ERKSRAksQWre3nCqHk0h7CIMSIgPdHBERkYBTYAlCjY8zj+0di8VsCnBrREREAk+BJQitahy/0qfbCc4UERHpHBRYgoxhGHzbsOBhutYPEhERARRYgs7WoipKqhzYQswMT44JdHNERESCggJLkGm8HTQqJQZriH49IiIioMASdFZtbxy/oseZRUREGimwBJlvtmuFZhERkSMpsASRPaUH2V16ELMJxvTWgFsREZFGCixBpHH8yrDkaLrYvF6XUkREpMNSYAkiObodJCIi0iwFliDS2MOiwCIiItKUAkuQOFDlYFNhJQDjUjV+RURE5HAKLEGisXelX/cIunWxBbg1IiIiwUWBJUgcWj9It4NERESOpMASJHI86wcpsIiIiBxJgSUIVDvq+Wl3GaABtyIiIs1RYAkC3+WVUu8ySIq20zM2PNDNERERCToKLEHAM/+KbgeJiIg0S4ElCGj+FRERkeNTYAkwR72L3DwNuBURETkeBZYAW7unjJo6FzHhofTv3iXQzREREQlKCiwBtuqw9YPMZlOAWyMiIhKcFFgCzDNhnMaviIiIHJMCSwC5XAarGiaM0xNCIiIix6bAEkCb91VSdrCOsFALQ5OiAt0cERGRoKXAEkA520sAGNM7hlCLfhUiIiLHom/JAGpcP0jzr4iIiByfAkuAGIbheUJI86+IiIgcnwJLgOw6cJCC8hpCLSZGp8QGujkiIiJBTYElQBrXDxqWHE2Y1RLg1oiIiAQ3BZYA0fwrIiIiLafAEiA527XgoYiISEspsARAUUUt24qrABibqvErIiIiJ6LAEgDfNtwOGhQfSUy4NcCtERERCX4KLAGQs0OPM4uIiHhDgSUAGgfcav0gERGRllFgaWMVNXWs21MO6AkhERGRllJgaWO5eaW4DEjpGkZCtD3QzREREWkXFFjaWOOCh3qcWUREpOUUWNrYqu3uBQ91O0hERKTlTiqwLF68mNTUVOx2OxkZGeTk5Bzz3LPOOguTyXTU9stf/tJzjmEYzJ07l8TERMLCwpg4cSKbN28+maYFtdp6J2t2lQJ6QkhERMQbXgeWpUuXkpmZybx588jNzWXkyJFMmjSJffv2NXv+22+/zd69ez3b2rVrsVgsTJkyxXPOo48+yl/+8heWLFnCN998Q0REBJMmTaKmpubkP1kQ+mFXGY56F3FdrPSJiwh0c0RERNoNrwPLwoULuemmm5gxYwZDhgxhyZIlhIeH89xzzzV7fteuXUlISPBsH330EeHh4Z7AYhgGixYtYs6cOVx00UWMGDGCF198kT179vDOO++06sMFm8On4zeZTAFujYiISPvhVWBxOBysXr2aiRMnHirAbGbixImsXLmyRWU8++yzTJ06lYgIdw/D9u3bKSgoaFJmdHQ0GRkZxyyztraW8vLyJlt74Jl/ReNXREREvOJVYCkuLsbpdBIfH9/keHx8PAUFBSe8Picnh7Vr13LjjTd6jjVe502ZWVlZREdHe7aUlBRvPkZAOF0Gq3c0DLjV+BURERGvtOlTQs8++yzDhw8nPT29VeXMnj2bsrIyz5afn++jFvrP+r3lVNTW08UWwimJUYFujoiISLviVWCJi4vDYrFQWFjY5HhhYSEJCQnHvbaqqorXX3+dG264ocnxxuu8KdNmsxEVFdVkC3aNt4PG9I7FYtb4FREREW94FVisVitpaWlkZ2d7jrlcLrKzsxk/fvxxr33jjTeora3l6quvbnK8T58+JCQkNCmzvLycb7755oRltieNgSVDt4NERES8FuLtBZmZmUyfPp2xY8eSnp7OokWLqKqqYsaMGQBce+21JCcnk5WV1eS6Z599losvvphu3bo1OW4ymbjjjjt4+OGHGTBgAH369OH+++8nKSmJiy+++OQ/WRAxDIOchgnjNOBWRETEe14HliuuuIKioiLmzp1LQUEBo0aNYsWKFZ5Bs3l5eZjNTTtuNm7cyBdffMGHH37YbJl33303VVVV3HzzzZSWljJhwgRWrFiB3d4x1trZUVJNcWUtVouZET2jA90cERGRdsdkGIYR6Ea0Vnl5OdHR0ZSVlQXleJZlq/K5+60fGJcayxu3nBro5oiIiAQFb76/tZZQG/hmu+ZfERERaQ0FljbgmTBOA25FREROigKLnxWW15C3vxqzCdJ6xwa6OSIiIu2SAoufNa4fdEpiFFH20AC3RkREpH1SYPEzrR8kIiLSegosftbYw6L1g0RERE6eAosflVXXsbGwAlAPi4iISGsosPjRtzv3YxjQJy6C7pG2QDdHRESk3VJg8aOchvEr6epdERERaRUFFj9atV3zr4iIiPiCAouf1NQ5+XF3GaAeFhERkdZSYPGT7/JKqXMaxEfZSOkaFujmiIiItGsKLH6Sc9j6QSaTKcCtERERad8UWPykccI4zb8iIiLSegosflDvdJGbdwDQ/CsiIiK+oMDiBz/tKafa4STKHsKg+MhAN0dERKTdU2Dxg8PXDzKbNX5FRESktRRY/CBH86+IiIj4lAKLjxmGoRWaRUREfEyBxce27KvkQHUd9lAzw5OjA90cERGRDkGBxcca1w8alRKDNUR/vCIiIr6gb1Qfa1w/KL1PtwC3REREpONQYPGxVTvc869o/SARERHfUWDxod2lB9ldehCL2cToXjGBbo6IiEiHocDiQ423g4YlRRFhCwlwa0RERDoOBRYf+ma7HmcWERHxBwUWH/LMv6IJ40RERHxKgcVH9lc52LKvElAPi4iIiK8psPhIY+/KgB5d6BphDXBrREREOhYFFh9ZpfWDRERE/EaBxUcae1g0/4qIiIjvKbD4QFVtPWv3lAPqYREREfEHBRYfyM07gNNlkBwTRnJMWKCbIyIi0uEosPiAZ/xKamyAWyIiItIxKbD4QOMKzVrwUERExD8UWFrJUe/iu7xSANL7qIdFRETEHxRYWunH3WXU1rvoGmGlX/cugW6OiIhIh6TA0kqNjzOP7R2LyWQKcGtEREQ6JgWWVsrZ3jh+RY8zi4iI+IsCSyu4XAbf7tAKzSIiIv6mwNIKGwsrKK+pJ9xqYWhSVKCbIyIi0mEpsLRC4/iVtN6xhFj0RykiIuIv+pZthZztuh0kIiLSFk4qsCxevJjU1FTsdjsZGRnk5OQc9/zS0lJmzpxJYmIiNpuNgQMHsnz5cs/7DzzwACaTqck2ePDgk2lamzEMw9PDosAiIiLiXyHeXrB06VIyMzNZsmQJGRkZLFq0iEmTJrFx40Z69Ohx1PkOh4Nf/OIX9OjRgzfffJPk5GR27txJTExMk/OGDh3Kxx9/fKhhIV43rU3l7a+msLyWUIuJ0b1iAt0cERGRDs3rVLBw4UJuuukmZsyYAcCSJUt4//33ee6555g1a9ZR5z/33HPs37+fr776itDQUABSU1OPbkhICAkJCd42J2AabwcNT47GHmoJcGtEREQ6Nq9uCTkcDlavXs3EiRMPFWA2M3HiRFauXNnsNe+++y7jx49n5syZxMfHM2zYMBYsWIDT6Wxy3ubNm0lKSqJv375cddVV5OXlHbMdtbW1lJeXN9namud2kOZfERER8TuvAktxcTFOp5P4+Pgmx+Pj4ykoKGj2mm3btvHmm2/idDpZvnw5999/P4899hgPP/yw55yMjAxeeOEFVqxYwV//+le2b9/O6aefTkVFRbNlZmVlER0d7dlSUlK8+Rg+sWrHAQAyFFhERET8zu8DRVwuFz169ODpp5/GYrGQlpbG7t27+eMf/8i8efMAOP/88z3njxgxgoyMDHr37s2yZcu44YYbjipz9uzZZGZmen4uLy9v09Cyr6KG7cVVmEyQ1luBRURExN+8CixxcXFYLBYKCwubHC8sLDzm+JPExERCQ0OxWA6N8zjllFMoKCjA4XBgtVqPuiYmJoaBAweyZcuWZsu02WzYbDZvmu5T3zb0rgyKjyQ6LDRg7RAREeksvLolZLVaSUtLIzs723PM5XKRnZ3N+PHjm73mtNNOY8uWLbhcLs+xTZs2kZiY2GxYAaisrGTr1q0kJiZ607w2o/WDRERE2pbX87BkZmbyzDPP8Pe//53169dz6623UlVV5Xlq6Nprr2X27Nme82+99Vb279/P7bffzqZNm3j//fdZsGABM2fO9Jxz11138dlnn7Fjxw6++uorLrnkEiwWC9OmTfPBR/Q9TRgnIiLStrwew3LFFVdQVFTE3LlzKSgoYNSoUaxYscIzEDcvLw+z+VAOSklJ4YMPPuDOO+9kxIgRJCcnc/vtt3PPPfd4ztm1axfTpk2jpKSE7t27M2HCBL7++mu6d+/ug4/oW+U1dawvcD+VpB4WERGRtmEyDMMIdCNaq7y8nOjoaMrKyoiK8u8ihJ9s3MeM51fRq2s4/737536tS0REpCPz5vtbawl5aZXGr4iIiLQ5BRYvNU4Yl67xKyIiIm1GgcULNXVOvs8vAzTDrYiISFtSYPHC9/mlOJwu4rrYSO0WHujmiIiIdBoKLF7w3A7qE4vJZApwa0RERDoPBRYv5DTMcKv5V0RERNqWAksLOV0GuTvdgUVPCImIiLQtBZYWWr+3nMraeiJtIQxO8O9cLyIiItKUAksLNU7Hn5Yai8Ws8SsiIiJtSYGlhRoH3Gr8ioiISNtTYGkBwzC0QrOIiEgAKbC0wLbiKkqqHFhDzIzoGR3o5oiIiHQ6Ciwt0Lh+0KiUGGwhlgC3RkREpPNRYGmBHK0fJCIiElAKLC3gGXCr8SsiIiIBocByAnvLDpK//yBmE4zpFRPo5oiIiHRKCiwn0Ph00JCkKCLtoQFujYiISOekwHICmn9FREQk8BRYTmDV9ob1gxRYREREAkaB5ThKqx1sLKwANOBWREQkkEIC3YBgZjKZeGDyEHaUVBPXxRbo5oiIiHRaCizHER0WynWn9Ql0M0RERDo93RISERGRoKfAIiIiIkFPgUVERESCngKLiIiIBD0FFhEREQl6CiwiIiIS9BRYREREJOgpsIiIiEjQU2ARERGRoKfAIiIiIkFPgUVERESCngKLiIiIBD0FFhEREQl6HWK1ZsMwACgvLw9wS0RERKSlGr+3G7/Hj6dDBJaKigoAUlJSAtwSERER8VZFRQXR0dHHPcdktCTWBDmXy8WePXuIjIzEZDL5tOzy8nJSUlLIz88nKirKp2WL9/T7CC76fQQf/U6Ci34fx2cYBhUVFSQlJWE2H3+USofoYTGbzfTs2dOvdURFRekvWxDR7yO46PcRfPQ7CS76fRzbiXpWGmnQrYiIiAQ9BRYREREJegosJ2Cz2Zg3bx42my3QTRH0+wg2+n0EH/1Ogot+H77TIQbdioiISMemHhYREREJegosIiIiEvQUWERERCToKbCIiIhI0FNgOYHFixeTmpqK3W4nIyODnJycQDepU8rKymLcuHFERkbSo0cPLr74YjZu3BjoZkmDP/zhD5hMJu64445AN6XT2r17N1dffTXdunUjLCyM4cOH8+233wa6WZ2S0+nk/vvvp0+fPoSFhdGvXz8eeuihFq2XI8emwHIcS5cuJTMzk3nz5pGbm8vIkSOZNGkS+/btC3TTOp3PPvuMmTNn8vXXX/PRRx9RV1fHueeeS1VVVaCb1umtWrWK//f//h8jRowIdFM6rQMHDnDaaacRGhrKv//9b9atW8djjz1GbGxsoJvWKT3yyCP89a9/5cknn2T9+vU88sgjPProozzxxBOBblq7pseajyMjI4Nx48bx5JNPAu41i1JSUvjd737HrFmzAty6zq2oqIgePXrw2WefccYZZwS6OZ1WZWUlY8aM4amnnuLhhx9m1KhRLFq0KNDN6nRmzZrFl19+yeeffx7opghw4YUXEh8fz7PPPus5dtlllxEWFsbLL78cwJa1b+phOQaHw8Hq1auZOHGi55jZbGbixImsXLkygC0TgLKyMgC6du0a4JZ0bjNnzuSXv/xlk/9OpO29++67jB07lilTptCjRw9Gjx7NM888E+hmdVqnnnoq2dnZbNq0CYDvv/+eL774gvPPPz/ALWvfOsTih/5QXFyM0+kkPj6+yfH4+Hg2bNgQoFYJuHu67rjjDk477TSGDRsW6OZ0Wq+//jq5ubmsWrUq0E3p9LZt28Zf//pXMjMzuffee1m1ahX/8z//g9VqZfr06YFuXqcza9YsysvLGTx4MBaLBafTyfz587nqqqsC3bR2TYFF2p2ZM2eydu1avvjii0A3pdPKz8/n9ttv56OPPsJutwe6OZ2ey+Vi7NixLFiwAIDRo0ezdu1alixZosASAMuWLeOVV17h1VdfZejQoaxZs4Y77riDpKQk/T5aQYHlGOLi4rBYLBQWFjY5XlhYSEJCQoBaJbfddhvvvfce//3vf+nZs2egm9NprV69mn379jFmzBjPMafTyX//+1+efPJJamtrsVgsAWxh55KYmMiQIUOaHDvllFN46623AtSizu33v/89s2bNYurUqQAMHz6cnTt3kpWVpcDSChrDcgxWq5W0tDSys7M9x1wuF9nZ2YwfPz6ALeucDMPgtttu4x//+Af/+c9/6NOnT6Cb1Kmdc845/Pjjj6xZs8azjR07lquuuoo1a9YorLSx00477ajH/Ddt2kTv3r0D1KLOrbq6GrO56derxWLB5XIFqEUdg3pYjiMzM5Pp06czduxY0tPTWbRoEVVVVcyYMSPQTet0Zs6cyauvvso///lPIiMjKSgoACA6OpqwsLAAt67ziYyMPGr8UEREBN26ddO4ogC48847OfXUU1mwYAGXX345OTk5PP300zz99NOBblqnNHnyZObPn0+vXr0YOnQo3333HQsXLuT6668PdNPaN0OO64knnjB69eplWK1WIz093fj6668D3aROCWh2e/755wPdNGlw5plnGrfffnugm9Fp/etf/zKGDRtm2Gw2Y/DgwcbTTz8d6CZ1WuXl5cbtt99u9OrVy7Db7Ubfvn2N++67z6itrQ1009o1zcMiIiIiQU9jWERERCToKbCIiIhI0FNgERERkaCnwCIiIiJBT4FFREREgp4Ci4iIiAQ9BRYREREJegosIiIiEvQUWERERCToKbCIiIhI0FNgERERkaCnwCIiIiJB7/8DP3Q7GyVvN5cAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "history = nnlm_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+    "CLASSES = ['github', 'nytimes', 'techcrunch']\n",
+    "NUM_CLASSES = len(CLASSES)\n",
+    "\n",
+    "# Create a StringLookup layer to map string labels to integer indices\n",
+    "label_lookup = tf.keras.layers.StringLookup(vocabulary=CLASSES, num_oov_indices=0)\n",
+    "\n",
+    "def prepare_dataset(dataset):\n",
+    "    def map_fn(features, label):\n",
+    "        # Extract the title string tensor from the dictionary\n",
+    "        title = features['title']\n",
+    "        # Map string label to integer index, then one-hot encode\n",
+    "        label_idx = label_lookup(label)\n",
+    "        label_one_hot = tf.one_hot(label_idx, depth=NUM_CLASSES)\n",
+    "        return title, label_one_hot\n",
+    "\n",
+    "    # Apply mapping and prefetch for training performance\n",
+    "    return dataset.map(map_fn, num_parallel_calls=tf.data.AUTOTUNE).prefetch(tf.data.AUTOTUNE)\n",
+    "\n",
+    "train_ds_prepared = prepare_dataset(train_ds)\n",
+    "eval_ds_prepared = prepare_dataset(eval_ds)\n",
+    "\n",
+    "# Verify prepared dataset structure\n",
+    "for title_batch, label_batch in train_ds_prepared.take(1):\n",
+    "    print(\"Title batch shape:\", title_batch.shape)\n",
+    "    print(\"Label batch shape:\", label_batch.shape)\n",
+    "    print(\"First label vector:\", label_batch[0].numpy())"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "d0kN6g9vN00f"
+   },
    "source": [
-    "## Training Swivel"
+    "## TF-Hub Pre-trained Embedding Modules\n",
+    "\n",
+    "To represent raw text sentences as numerical vectors, we use a pre-trained embedding model from **TensorFlow Hub** via `tensorflow_hub`. Specifically, we will use a **Universal Sentence Encoder (USE)** or a similar text embedding model (`nnlm-en-dim128`).\n",
+    "\n",
+    "Let's test loading a simple TF-Hub text embedding model and passing a sample sentence to see the generated dense vector."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "e_zMItgXN00f"
    },
    "outputs": [],
    "source": [
-    "swivel_model = build_model(swivel_module, name='swivel')"
+    "import tensorflow_hub as hub\n",
+    "\n",
+    "# Using TF-Hub Universal Sentence Encoder / NNLM as our text embedding module\n",
+    "HUB_HANDLE = \"https://tfhub.dev/google/nnlm-en-dim128/2\"\n",
+    "\n",
+    "print(\"Loading embedding module...\")\n",
+    "hub_layer = hub.KerasLayer(HUB_HANDLE, input_shape=[], dtype=tf.string, trainable=False)\n",
+    "print(\"Embedding module loaded.\")\n",
+    "\n",
+    "sample_sentences = [\"TensorFlow is an open-source machine learning library.\"]\n",
+    "embeddings = hub_layer(sample_sentences)\n",
+    "\n",
+    "print(\"Embedding shape:\", embeddings.shape)\n",
+    "print(\"First 5 embedding values:\", embeddings[0, :5].numpy())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "3Z8P1n_zN00f"
+   },
+   "source": [
+    "## Model Architecture with Keras Functional API\n",
+    "\n",
+    "Now we build a Deep Neural Network (DNN) classifier using the `tf.keras.Functional` API.\n",
+    "\n",
+    "Our model consists of:\n",
+    "1. **Input Layer**: Takes 1D raw text strings of shape `()`.\n",
+    "2. **Embedding Layer**: The pre-trained TF-Hub layer `hub_layer` transforms strings into dense feature vectors.\n",
+    "3. **Dense Hidden Layer**: A fully-connected layer with `64` units and `relu` activation.\n",
+    "4. **Dropout Layer**: Drops out `0.2` (20%) of units for regularization to prevent overfitting.\n",
+    "5. **Output Layer**: A `Dense` layer with `NUM_CLASSES` (3) units and `softmax` activation to output class probabilities."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "9Btt0W0KN00g"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch 1/10\n",
-      "63/63 [==============================] - 2s 23ms/step - loss: 1.2382 - accuracy: 0.3374 - val_loss: 0.9483 - val_accuracy: 0.5588\n",
-      "Epoch 2/10\n",
-      "63/63 [==============================] - 1s 21ms/step - loss: 0.8401 - accuracy: 0.6325 - val_loss: 0.7546 - val_accuracy: 0.6802\n",
-      "Epoch 3/10\n",
-      "63/63 [==============================] - 1s 21ms/step - loss: 0.6815 - accuracy: 0.7146 - val_loss: 0.6200 - val_accuracy: 0.7458\n",
-      "Epoch 4/10\n",
-      "63/63 [==============================] - 2s 25ms/step - loss: 0.5628 - accuracy: 0.7696 - val_loss: 0.5232 - val_accuracy: 0.7862\n",
-      "Epoch 5/10\n",
-      "63/63 [==============================] - 2s 35ms/step - loss: 0.4836 - accuracy: 0.8041 - val_loss: 0.4642 - val_accuracy: 0.8081\n",
-      "Epoch 6/10\n",
-      "63/63 [==============================] - 2s 31ms/step - loss: 0.4351 - accuracy: 0.8243 - val_loss: 0.4285 - val_accuracy: 0.8258\n",
-      "Epoch 7/10\n",
-      "63/63 [==============================] - 1s 20ms/step - loss: 0.4035 - accuracy: 0.8380 - val_loss: 0.4047 - val_accuracy: 0.8375\n",
-      "Epoch 8/10\n",
-      "63/63 [==============================] - 1s 20ms/step - loss: 0.3808 - accuracy: 0.8480 - val_loss: 0.3875 - val_accuracy: 0.8434\n",
-      "Epoch 9/10\n",
-      "63/63 [==============================] - 2s 33ms/step - loss: 0.3635 - accuracy: 0.8557 - val_loss: 0.3746 - val_accuracy: 0.8500\n",
-      "Epoch 10/10\n",
-      "63/63 [==============================] - 3s 45ms/step - loss: 0.3499 - accuracy: 0.8620 - val_loss: 0.3652 - val_accuracy: 0.8537\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "swivel_history = train_and_evaluate(data, val_data, swivel_model)"
+    "def build_model(embed_layer):\n",
+    "    # Input for string tensors\n",
+    "    text_input = tf.keras.Input(shape=(), dtype=tf.string, name='title_input')\n",
+    "    \n",
+    "    # Pass strings through the pre-trained embedding layer\n",
+    "    x = embed_layer(text_input)\n",
+    "    \n",
+    "    # Dense hidden layer with ReLU and regularizing Dropout\n",
+    "    x = tf.keras.layers.Dense(64, activation='relu', name='hidden_dense')(x)\n",
+    "    x = tf.keras.layers.Dropout(0.2, name='dropout')(x)\n",
+    "    \n",
+    "    # Output softmax predictions across our 3 source classes\n",
+    "    output = tf.keras.layers.Dense(NUM_CLASSES, activation='softmax', name='predictions')(x)\n",
+    "    \n",
+    "    model = tf.keras.Model(inputs=text_input, outputs=output, name='text_classifier_hub')\n",
+    "    return model\n",
+    "\n",
+    "model = build_model(hub_layer)\n",
+    "model.summary()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "e_bT7nB0N00g"
+   },
+   "source": [
+    "## Compile and Train the Model\n",
+    "\n",
+    "We compile our model using the `Adam` optimizer, `CategoricalCrossentropy` loss function (since our labels are one-hot encoded), and track `CategoricalAccuracy`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {
-    "tags": []
+    "id": "y-cI7vE0N00g"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Axes: >"
-      ]
-     },
-     "execution_count": 46,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAATIFJREFUeJzt3Xd4VFX+x/H3zKT3BEhIg9B7CVVAXVEUAREEOwoWLPywweou2MsK67oqroAI9oLiIkUFCyBIEZcaeu8tjZJeZ+b3x4RANEDKnUyS+byeZx4md+6cc4ZZyWfv95xzTXa73Y6IiIiIi5hdPQARERFxbwojIiIi4lIKIyIiIuJSCiMiIiLiUgojIiIi4lIKIyIiIuJSCiMiIiLiUgojIiIi4lIerh5AWdhsNo4fP05gYCAmk8nVwxEREZEysNvtZGRkEBUVhdl84esfNSKMHD9+nNjYWFcPQ0RERCrgyJEjxMTEXPD1GhFGAgMDAceHCQoKcvFoREREpCzS09OJjY0t/j1+ITUijJwtzQQFBSmMiIiI1DCXmmKhCawiIiLiUgojIiIi4lIKIyIiIuJSNWLOiIiIuDe73U5hYSFWq9XVQ5HzWCwWPDw8Kr3thsKIiIhUa/n5+Zw4cYLs7GxXD0VK4efnR2RkJF5eXhVuQ2FERESqLZvNxoEDB7BYLERFReHl5aXNL6sJu91Ofn4+KSkpHDhwgGbNml10Y7OLURgREZFqKz8/H5vNRmxsLH5+fq4ejvyBr68vnp6eHDp0iPz8fHx8fCrUjiawiohItVfR/8ctzmfEd6NvV0RERFxKYURERERcSmFERETECa666iqeeOIJVw+jRlAYEREREZdy2zBis9mZvf4oIz9ZR1p2gauHIyIi4rbcNoyYzSamL9/H4h1JLNqR5OrhiIhIGdntdrLzC13ysNvtFRrz6dOnGT58OKGhofj5+dGvXz/27NlT/PqhQ4cYOHAgoaGh+Pv706ZNGxYuXFj83mHDhlGvXj18fX1p1qwZH330kSF/l9WFW+8zMqBdFLuTdrNwywlu7hzj6uGIiEgZ5BRYaf38Ty7pe/vLffHzKv+vznvuuYc9e/bw7bffEhQUxN///nf69+/P9u3b8fT0ZPTo0eTn57N8+XL8/f3Zvn07AQEBADz33HNs376dH374gbp167J3715ycnKM/mgu5d5hpH193lq8mxV7UkjLKSDY19PVQxIRkVrmbAhZtWoVPXv2BOCLL74gNjaWefPmccstt3D48GGGDh1Ku3btAGjcuHHx+w8fPkx8fDxdunQBIC4urso/g7O5dRhpGh5I84gAdidlsmh7kq6OiIjUAL6eFra/3NdlfZfXjh078PDwoHv37sXH6tSpQ4sWLdixYwcAjz32GKNGjeLnn3+mT58+DB06lPbt2wMwatQohg4dyoYNG7juuusYPHhwcaipLdx2zshZ/dtFArBwywkXj0RERMrCZDLh5+Xhkoez7oszcuRI9u/fz913382WLVvo0qUL77zzDgD9+vXj0KFDjBkzhuPHj3PNNdfw5JNPOmUcruL2YWRAURg5W6oRERExUqtWrSgsLOR///tf8bGTJ0+ya9cuWrduXXwsNjaWhx9+mDlz5vDXv/6VGTNmFL9Wr149RowYweeff86kSZOYPn16lX4GZ3P7MNIsIpBm4QEUWO0s3q5VNSIiYqxmzZoxaNAgHnjgAVauXMmmTZu46667iI6OZtCgQQA88cQT/PTTTxw4cIANGzawdOlSWrVqBcDzzz/P/Pnz2bt3L9u2beP7778vfq22cPswAjCgvUo1IiLiPB999BGdO3fmhhtuoEePHtjtdhYuXIinp2PhhNVqZfTo0bRq1Yrrr7+e5s2bM3XqVAC8vLwYP3487du358orr8RisfDVV1+58uMYzmSv6KLpKpSenk5wcDBpaWkEBQUZ3v6epAyufWs5nhYT6569VqtqRESqidzcXA4cOECjRo0qfHt6ca6LfUdl/f2tKyOoVCMiIuJKCiNFtKpGRETENcodRpYvX87AgQOJiorCZDIxb968i54/Z84crr32WurVq0dQUBA9evTgp59cs3PexZydN7JiTyrpuVpVIyIiUlXKHUaysrLo0KEDU6ZMKdP5y5cv59prr2XhwoWsX7+e3r17M3DgQDZu3FjuwTpT86JSTb7VplKNiIhIFSr3Dqz9+vWjX79+ZT5/0qRJJX6eMGEC8+fP57vvviM+Pr683TtV/3aRvL1kDwu3nGBIJ+3GKiIiUhWqfM6IzWYjIyODsLCwC56Tl5dHenp6iUdVOFuqWb5bpRoREZGqUuVh5N///jeZmZnceuutFzxn4sSJBAcHFz9iY2OrZGzNIwJpqlKNiIhIlarSMDJz5kxeeuklvv76a8LDwy943vjx40lLSyt+HDlypMrGqFU1IiIiVavKwshXX33FyJEj+frrr+nTp89Fz/X29iYoKKjEo6qcvVeNSjUiIiJVo0rCyJdffsm9997Ll19+yYABA6qiywprHhFQXKpZskOlGhERcY24uLg/LQK5kLJstVGdlTuMZGZmkpCQQEJCAgAHDhwgISGBw4cPA44Sy/Dhw4vPnzlzJsOHD+eNN96ge/fuJCYmkpiYSFpamjGfwGAmk6m4VLNgs0o1IiIizlbuMLJu3Tri4+OLl+WOHTuW+Ph4nn/+eQBOnDhRHEwApk+fTmFhIaNHjyYyMrL48fjjjxv0EYynUo2IiEjVKXcYueqqq7Db7X96fPzxxwB8/PHHLFu2rPj8ZcuWXfT86qh5RABN6vmrVCMiUh3Z7ZCf5ZpHGe8tO336dKKiorDZbCWODxo0iPvuu499+/YxaNAgIiIiCAgIoGvXrixevNiwv6ItW7Zw9dVX4+vrS506dXjwwQfJzMwsfn3ZsmV069YNf39/QkJC6NWrF4cOHQJg06ZN9O7dm8DAQIKCgujcuTPr1q0zbGylKfemZ+7AZDIxoF0k//llLws2J3JTvDZAExGpNgqyYUKUa/p++jh4+V/ytFtuuYVHH32UpUuXcs011wBw6tQpfvzxRxYuXEhmZib9+/fn1Vdfxdvbm08//ZSBAweya9cuGjRoUKkhZmVl0bdvX3r06MHatWtJTk5m5MiRPPLII3z88ccUFhYyePBgHnjgAb788kvy8/NZs2YNJpMJgGHDhhEfH8+7776LxWIhISEBT0/n3s1eYeQCBrSP4j+/7GX57hQycgsI9HHuFyEiIrVHaGgo/fr1Y+bMmcVhZPbs2dStW5fevXtjNpvp0KFD8fmvvPIKc+fO5dtvv+WRRx6pVN8zZ84kNzeXTz/9FH9/R3CaPHkyAwcO5LXXXsPT05O0tDRuuOEGmjRpAkCrVq2K33/48GGeeuopWrZsCUCzZs0qNZ6yUBi5gLOlmn0pWSzekaSrIyIi1YWnn+MKhav6LqNhw4bxwAMPMHXqVLy9vfniiy+4/fbbMZvNZGZm8uKLL7JgwQJOnDhBYWEhOTk5JeZcVtSOHTvo0KFDcRAB6NWrFzabjV27dnHllVdyzz330LdvX6699lr69OnDrbfeSmSkY77k2LFjGTlyJJ999hl9+vThlltuKQ4tzlLlO7DWFGdLNQALNie6eDQiIlLMZHKUSlzxKCpllMXAgQOx2+0sWLCAI0eOsGLFCoYNGwbAk08+ydy5c5kwYQIrVqwgISGBdu3akZ+f76y/tRI++ugjVq9eTc+ePZk1axbNmzfn999/B+DFF19k27ZtDBgwgF9++YXWrVszd+5cp45HYeQi+p+9V80eR6lGRESkrHx8fBgyZAhffPEFX375JS1atKBTp04ArFq1invuuYebbrqJdu3aUb9+fQ4ePGhIv61atWLTpk1kZWUVH1u1ahVms5kWLVoUH4uPj2f8+PH89ttvtG3blpkzZxa/1rx5c8aMGcPPP//MkCFD+OijjwwZ24UojFxEi4hAGtfzJ7/QxpIdya4ejoiI1DDDhg1jwYIFfPjhh8VXRcAxD2POnDkkJCSwadMm7rzzzj+tvKlMnz4+PowYMYKtW7eydOlSHn30Ue6++24iIiI4cOAA48ePZ/Xq1Rw6dIiff/6ZPXv20KpVK3JycnjkkUdYtmwZhw4dYtWqVaxdu7bEnBJnUBi5iBKlGt2rRkREyunqq68mLCyMXbt2ceeddxYff/PNNwkNDaVnz54MHDiQvn37Fl81qSw/Pz9++uknTp06RdeuXbn55pu55pprmDx5cvHrO3fuZOjQoTRv3pwHH3yQ0aNH89BDD2GxWDh58iTDhw+nefPm3HrrrfTr14+XXnrJkLFdiMluL+OiaRdKT08nODiYtLS0Kr1PDcDOxHSun7QCLw8z65/to1U1IiJVKDc3lwMHDtCoUSN8fHxcPRwpxcW+o7L+/taVkUtQqUZERMS5FEYuQaUaERFxpS+++IKAgIBSH23atHH18AyhfUbKoH+7SN75ZS+/agM0ERGpYjfeeCPdu3cv9TVn74xaVRRGyqBl/UAa1/Vnf2oWv+xMZlDHaFcPSURE3ERgYCCBgYGuHoZTqUxTBiaTiQHtz26AplKNiEhVqwFrLdyWEd+NwkgZ9S+aN7JstzZAExGpKmfLENnZ2S4eiVzI2e+mMiUjlWnKSKUaEZGqZ7FYCAkJITnZsZrRz8+v+O6y4lp2u53s7GySk5MJCQnBYrFUuC2FkTIymUz0bxfJ5KV7WbD5hMKIiEgVqV+/PkBxIJHqJSQkpPg7qiiFkXI4G0aW7U4hM6+QAG/99YmIOJvJZCIyMpLw8HAKClQmr048PT0rdUXkLP02LYdWkYE0quvPgdQsluxI0tUREZEqZLFYDPnFJ9WPJrCWw/kboC3UBmgiIiKGUBgpp7OrapbucpRqREREpHIURsrpbKnGca+aJFcPR0REpMZTGCknx6oax6xhlWpEREQqT2GkAoo3QNuVQpZKNSIiIpWiMFIBrSODaFTXn7xCG0t2at27iIhIZSiMVMD5pZoFm4+7eDQiIiI1m8JIBalUIyIiYgyFkQpqHRlEXB0/lWpEREQqSWGkgs7eqwZg4WatqhEREakohZFKGND+7AZoySrViIiIVJDCSCWoVCMiIlJ5CiOVoFKNiIhI5SmMVNK5e9WoVCMiIlIRCiOV1CYqiIZFpZpfVKoREREpN4WRSipRqtG9akRERMpNYcQAA1SqERERqTCFEQOcLdXkFqhUIyIiUl4KIwZQqUZERKTiFEYMcn6pJjtfpRoREZGyUhgxSJuoIBqEqVQjIiJSXgojBjGZTMXbw6tUIyIiUnYKIwY6W6r5ZadKNSIiImWlMGIglWpERETKT2HEQFpVIyIiUn4KIwZTqUZERKR8FEYM1jY6iNgwX3ILbCzdmeLq4YiIiFR7CiMGM5lMDGgXBahUIyIiUhYKI05wtlSzZGeSSjUiIiKXoDDiBCrViIiIlJ3CiBNoVY2IiEjZKYw4yfmranLyrS4ejYiISPWlMOIk7aKDiQ3zJafAytJd2gBNRETkQhRGnOT8Us2CzSrViIiIXIjCiBOpVCMiInJpCiNO1C46mJhQlWpEREQuRmHEiRwboBWVarSqRkREpFQKI052dt7ILztUqhERESmNwoiTtY9RqUZERORiFEacTKUaERGRi1MYqQIq1YiIiFyYwkgVOL9Us0ylGhERkRIURqpAiQ3QVKoREREpQWGkimgDNBERkdIpjFSRs6Wa7HyVakRERM6nMFJFVKoREREpXbnDyPLlyxk4cCBRUVGYTCbmzZt3yfcsW7aMTp064e3tTdOmTfn4448rMNSar/95pZrcApVqREREoAJhJCsriw4dOjBlypQynX/gwAEGDBhA7969SUhI4IknnmDkyJH89NNP5R5sTdchJpjoEJVqREREzudR3jf069ePfv36lfn8adOm0ahRI9544w0AWrVqxcqVK3nrrbfo27dvebuv0RylmvrMWHGABVsSub5tpKuHJCIi4nJOnzOyevVq+vTpU+JY3759Wb16tbO7rpYGtI8CYMmOJJVqREREqIIwkpiYSERERIljERERpKenk5OTU+p78vLySE9PL/GoLVSqERERKalarqaZOHEiwcHBxY/Y2FhXD8kwZ0s1AAu2JLp4NCIiIq7n9DBSv359kpKSShxLSkoiKCgIX1/fUt8zfvx40tLSih9Hjhxx9jCr1NlVNSrViIiIVEEY6dGjB0uWLClxbNGiRfTo0eOC7/H29iYoKKjEozbpGBtyXqkmxdXDERERcalyh5HMzEwSEhJISEgAHEt3ExISOHz4MOC4qjF8+PDi8x9++GH279/P3/72N3bu3MnUqVP5+uuvGTNmjDGfoAYqWarRBmgiIuLeyh1G1q1bR3x8PPHx8QCMHTuW+Ph4nn/+eQBOnDhRHEwAGjVqxIIFC1i0aBEdOnTgjTfe4P3333e7Zb1/pFKNiIiIg8lut9tdPYhLSU9PJzg4mLS0tFpTsrHb7Vz+2lKOnclh2l2dub5tfVcPSURExFBl/f1dLVfTuAOTyUS/ogCyUKUaERFxYwojLtS/vUo1IiIiCiMuFF+0qiYr38qvu7WqRkRE3JPCiAudX6pZsFmlGhERcU8KIy6mUo2IiLg7hREXi48NISrYR6UaERFxWwojLmYymehXtOeIVtWIiIg7UhipBs5ugLZ4u0o1IiLifhRGqgGVakRExJ0pjFQDZrNKNSIi4r4URqqJc/eqSVapRkRE3IrCyJkjrh4B4CjVRAb7kJlXyHKVakRExI24bxgpyIV5/weTu0LqXlePxlGqaatSjYiIuB/3DSMWL0g7CoU5MO9hsBa6ekQMKNoAbbFKNSIi4kbcN4yYzTB4KngHwdG18Nvbrh6RSjUiIuKW3DeMAATHQL/XHM+XToTELS4djko1IiLijtw7jAB0uANaDABbAcx9GArzXDqcAe0dN85TqUZERNyFwojJBAPfBr86kLQVlv3TpcOJjw2lfpCjVLNiT6pLxyIiIlIVFEYAAurBDZMcz1dNgiNrXDYUxwZojqsjKtWIiIg7UBg5q/WN0P42sNsc5Zr8LJcN5YaiVTWLdK8aERFxAwoj5+v3LwiMglP7YPGLLhuGSjUiIuJOFEbO5xsCg6c4nq+ZDvuXuWQYKtWIiIg7URj5oyZXQ9eRjufzRkNumkuGMaDoXjWLtyeRV6hSjYiI1F4KI6W59mUIawzpR+GHcS4ZQqcGjlJNRl4hK3arVCMiIrWXwkhpvPxh8DQwmWHTTNi5oMqHcH6pZoFKNSIiUospjFxIg+7Q8zHH8+8eh6yqvzqhUo2IiLgDhZGL6f00hLeBrBT4/gmw26u0e5VqRETEHSiMXIyHN9w0DcyesOM72Px1lXZvNpu4vq1W1YiISO2mMHIpke3hqr87ni98CtKOVmn3A87bAE2lGhERqY0URsqi1xiI7gJ5aTD/kSot13RuEEpEkDcZeYWs1AZoIiJSCymMlIXFw1Gu8fCF/Uth7ftV1rXZbKJfW8fVkQWbVaoREZHaR2GkrOo2gz4vOp4veh5O7quyrlWqERGR2kxhpDy6PQhxV0BBNswbBbaqCQYq1YiISG2mMFIeZjMMngpegXDkf/Dbf6qo2/NKNVpVIyIitYzCSHmFNIB+/3Q8XzoBkrZVSbf926lUIyIitZPCSEV0HAbN+4E1H+Y8BIX5Tu+yS8NQwgO9ychVqUZERGoXhZGKMJlg4NvgGwZJW+DX15zepdlsKr46olKNiIjUJgojFRUYATe85Xi+8k04us7pXapUIyIitZHCSGW0GQztbgG7DeY+BPnZTu3u/FLNqr0q1YiISO2gMFJZ/V+HwEg4uReWvOTUrhyrahz3qlmwOdGpfYmIiFQVhZHK8g2FGyc7nv9vGuz/1andnS3V/Lw9kfxCm1P7EhERqQoKI0Zo1gc63+t4Pn805KY5rasucWHnVtXsTXFaPyIiIlVFYcQo1/0DQuMg7Qj8+LTTurGoVCMiIrWMwohRvANg8LuACRI+h10/OK2rc6tqVKoREZGaT2HESA17Qs9HHM+/fQyyTjqlmy5xYdQL9CZdq2pERKQWUBgxWu9noV4ryEqGBWPAbje8ixKlGm2AJiIiNZzCiNE8feCmaWD2gO3zYctsp3Qz4Oyqmm0q1YiISM2mMOIMUR3hyr85ni/8K6QfN7wLlWpERKS2UBhxlivGQlQnxzLfbx81vFyjUo2IiNQWCiPOYvGEm94DDx/YuxjWf2R4F/1VqhERkVpAYcSZ6jWHa15wPP/pWTi139Dmu8aFUTegqFSzT6UaERGpmRRGnK37wxB3BRRkwbz/A5txd9u1mE30b3d2AzSVakREpGZSGHE2sxkGTQGvQDi8GlZPMbR5lWpERKSmUxipCqEN4foJjue/vALJOwxr+vxSzY/btD28iIjUPAojVSX+bmjWF6z5MOdBKMw3pFmL2cStXWIAeHrOFnYnZRjSroiISFVRGKkqJhPc+B/wDYXEzbD8dcOafqJPc7o3CiMzr5D7P1nLqSxjgo6IiEhVUBipSoH1YcCbjucr3oBj6w1p1svDzLS7OtOwjh9HTuXw8GfrNX9ERERqDIWRqtZ2CLQdCnYrzH0YCnIMaTbU34sPRnQh0NuDNQdP8czcLdidcF8cERERoymMuEL/f0NAfUjdDUteNqzZpuGBvHNnPGYT/Hf9Ud5fccCwtkVERJxFYcQV/MLgxnccz3+fCgdWGNb0VS3Cee6G1gBM+GEHS3YkGda2iIiIMyiMuErz66DTCMfzef8HuemGNX1Pzzju7N4Aux0e+3IjuxK1wkZERKovhRFX6vsqhDSEtMPw09OGNWsymXjpxjb0bFKHrHwr93+yltTMPMPaFxERMZLCiCt5B8LgdwETbPwMdv9kWNOeFjNTh3Uiro4fR087VtjkFRq3Fb2IiIhRFEZcLa4X9BjteP7to5B9yrCmQ/y8+OCergT6eLDu0GnGz9EKGxERqX4URqqDq5+Dui0gMwkWjDW06Sb1Apg6rBMWs4k5G47x3nJj7xwsIiJSWRUKI1OmTCEuLg4fHx+6d+/OmjVrLnr+pEmTaNGiBb6+vsTGxjJmzBhyc3MrNOBaydMHbpoGJgtsmwtbZhva/BXN6vHCQMcKm9d+3Mmi7VphIyIi1Ue5w8isWbMYO3YsL7zwAhs2bKBDhw707duX5OTkUs+fOXMm48aN44UXXmDHjh188MEHzJo1i6efNm7CZq0Q3QmufMrxfMFfIf2Eoc0P7xHH3Zc1xG6Hx7/ayI4Txq3eERERqYxyh5E333yTBx54gHvvvZfWrVszbdo0/Pz8+PDDD0s9/7fffqNXr17ceeedxMXFcd1113HHHXdc8mqKW7rySYjsCLlnHPNHDJ7f8fzA1lzetC7Z+VZGfrKOlAytsBEREdcrVxjJz89n/fr19OnT51wDZjN9+vRh9erVpb6nZ8+erF+/vjh87N+/n4ULF9K/f/8L9pOXl0d6enqJh1uweMJN74HFG/Yugg2fGNq8p8XMlDs70biuP8fO5PDQZ+vILdAKGxERca1yhZHU1FSsVisREREljkdERJCYmFjqe+68805efvllLr/8cjw9PWnSpAlXXXXVRcs0EydOJDg4uPgRGxtbnmHWbOEt4ZrnHM9/egZOHzS0+WA/T94f0YUgHw82HD6jFTYiIuJyTl9Ns2zZMiZMmMDUqVPZsGEDc+bMYcGCBbzyyisXfM/48eNJS0srfhw5csTZw6xeLvs/aNAT8jMdu7PajL0Db+N6Abx7V2csZhNzNx5j6rJ9hrYvIiJSHuUKI3Xr1sVisZCUVHI1RlJSEvXr1y/1Pc899xx33303I0eOpF27dtx0001MmDCBiRMnYrvAL1lvb2+CgoJKPNyK2QKDp4KnPxxa5bh/jcF6Na3LSze2AeD1n3bx49bSr2yJiIg4W7nCiJeXF507d2bJkiXFx2w2G0uWLKFHjx6lvic7OxuzuWQ3FosFQOWBiwlr5NguHhx39k3eaXgXd13WkHt6xgEwZlYCW4+lGd6HiIjIpZS7TDN27FhmzJjBJ598wo4dOxg1ahRZWVnce++9AAwfPpzx48cXnz9w4EDeffddvvrqKw4cOMCiRYt47rnnGDhwYHEokQvofA80vRaseTD3IbAWGN7FswNacUWzuuQUWHng03UkZ2j/FxERqVoe5X3DbbfdRkpKCs8//zyJiYl07NiRH3/8sXhS6+HDh0tcCXn22WcxmUw8++yzHDt2jHr16jFw4EBeffVV4z5FbWUywY3vwNTL4EQCrHgDrhpnaBceFjOT7+zEkKmr2JeSxYOfruerBy/Dx1NBUUREqobJXgNqJenp6QQHB5OWluZ+80fAsSPrN/eD2QNGLoaoeMO7OJiaxeCpqziTXcCNHaJ4+/aOmEwmw/sRERH3Udbf37o3TU3Q7mZocxPYCmHuw1BgfCklrq4/U4d1wsNs4ttNx5n8y17D+xARESmNwkhNMeBNCIiAlJ3wy4WXRVdGzyZ1eWVwWwDeWLSbH7YYuyW9iIhIaRRGagq/MMf8EYDVU+DgKqd0c0e3BtzXqxEAY77WChsREXE+hZGapHlfiL8bsMO8UZCX4ZRunu7fkqta1CO3wMbIT9aRlK4VNiIi4jwKIzVN3wkQ3ADOHIKfn3VKFx4WM/+5I55m4QEkpufywKfryMnXPWxERMQ5FEZqGp8gx+6sAOs/hj2LnNJNkI8nH4zoSqifJ5uPpvHk7E3apE5ERJxCYaQmanSF4/41APMfgexTTummQR0/pt3VGU+LiQWbT/D2kj1O6UdERNybwkhNdc3zULc5ZCbCwied1k33xnX4R9EKm0mL9/D95uNO60tERNyTwkhN5ekLN00DkwW2fgNb5zitq9u6NuCBKxwrbP769SY2HTnjtL5ERMT9KIzUZNGd4Yq/Op4vGAvpzrtqMa5fK65uGU5eoY0HPl1HYppW2IiIiDEURmq6K5+C+u0h5zR8OggykpzSjcVs4u3bO9I8IoDkjDxGfrpWK2xERMQQCiM1nYcX3PY5BMVA6m749EbITHFKV4FFK2zC/L3Yeiydv/43AZtNK2xERKRyFEZqg9CGcM93EBjl2C7+0xsh66RTuooN8+O9ux0rbBZuSWTS4t1O6UdERNyHwkhtEdYY7vkeAupD8nZHycZJS367xoUx4aZ2APznl73MTzjmlH5ERMQ9KIzUJnWaOAKJfzgkbXEEkpzTTunqli6xPPSXxgA8NXszGw87px8REan9FEZqm7rNYMR34F8PEjfDZzdBzhmndPW3vi3p0yqC/EIbD362nuNncpzSj4iI1G4KI7VReEsY/i341YHjG+HzIZBr/N13LWYTk27vSMv6gaRk5DHyk3Vk5xca3o+IiNRuCiO1VURrRyDxDYVj6+Hzm51yl98Abw/eH9GFugFebD+RzphZWmEjIiLlozBSm9VvC8Png08IHF0DX9wCeZmGdxMT6lhh42Ux89O2JN5cpBU2IiJSdgojtV1kBxg+D7yD4fBqmHkr5GcZ3k3nhmH8c6hjhc3kpXuZt1ErbEREpGwURtxBVDzcPRe8g+DQKph5G+RnG97NkE4x/N9VTQD42zebWX9IK2xEROTSFEbcRUxnuGsOeAXCwRXw1R1QYPzqlyeva8F1rR0rbB76bB1HTxsfekREpHZRGHEnsV3hrtng6Q/7l8Gsu6DA2Bvemc0m3rqtI60ig0jNzGfkJ+vIytMKGxERuTCFEXfT4DIY9l/w9IO9i+Hr4VCYZ2gX/sUrbLzZmZjBE1phIyIiF6Ew4o7iesGdX4OHL+z5Cf57DxTmG9pFdIgv04d3xsvDzKLtSbz+8y5D2xcRkdpDYcRdNboC7vwKPHxg10KYfS9YCwztolODUF6/uT0A7y7bxzfrjxravoiI1A4KI+6s8VVw+0yweMPO7+Gb+8Fq7PyOQR2jefTqpgCMn7OFdQedc/M+ERGpuRRG3F3Ta+C2z8HiBdvnw9wHDQ8kY/o0p1/b+uRbbTz02XqOnNIKGxEROUdhRKD5dXDrp2D2hK3fwLxRYLMa1rzZbOKNWzvQJiqIk1mOFTaZWmEjIiJFFEbEoUU/uOVjMHvAlq9h/mhDA4mfl2OFTb1Ab3YlZfD4lxuxaoWNiIigMCLna3UD3PwhmCyw6Uv47jGw2QxrPjLYlxnDu+DtYWbJzmT+9eNOw9oWEZGaS2FESmo9CIa+DyYzbPwcvn/C0EDSMTaEf9/SAYD3lu/n63VHDGtbRERqJoUR+bO2Q+Cm6Y5AsuETWPgk2I0rqQzsEMXj1zQD4Jm5W1hzQCtsRETcmcKIlK79LTD4XcAE6z6AH/5uaCB5/JpmDGgXSYHVzkOfrePwSa2wERFxVwojcmEdbodBUwATrHkPfnrasEBiNpv49y0daBcdzOnsAu7/ZC0ZucZuuiYiIjWDwohcXPwwGPi24/nvU2HRc4YFEl8vCzOGdyEiyJs9yZk8phU2IiJuSWFELq3zCLjhLcfz396BJS8ZFkjqB/swY3gXfDzNLN2VwsSFOwxpV0REag6FESmbLvdB/387nq98C5ZOMKzp9jEhvHFLRwDeX3mA937dZ1jbIiJS/SmMSNl1ewCu/6fj+fJ/wbLXDGt6QPtInryuOQATf9jJK99vx6aSjYiIW1AYkfK5bBRc96rj+bIJsPx1w5oe3bspT/dvCcAHKw/w+KwE8gqN2wVWRESqJ4URKb+ej0CflxzPf/mHo2xjAJPJxINXNmHSbR3xMJv4btNx7v1Iq2xERGo7hRGpmMufgKufczxf/KJjYqtBBsdH89G9XfH3svDbvpPc+t7vJKfnGta+iIhULwojUnFXPglXPe14/vOz8Pu7hjV9RbN6zHqoB3UDvNhxIp2bpv7GvpRMw9oXEZHqQ2FEKueqv8OVf3M8/3EcrJlhWNNto4OZM6oXcXX8OHYmh5vf/Y0Nh08b1r6IiFQPCiNSeb2fhsvHOp4vfBLWfmBY0w3q+DF7VE86xDh2ar1zxu8s2ZFkWPsiIuJ6CiNSeSYTXPM89HzM8fOCsbD+E8OarxvgzcwHLuOqFvXILbDx4GfrmbX2sGHti4iIaymMiDFMJrj2ZbhstOPn7x6HjZ8b1ry/twczhnfh5s4xWG12/v7NFv6zZA92A2/eJyIirqEwIsYxmaDvq9DtIcAO8x+BTV8Z1rynxczrN7dndO8mALy5aDfPztuq+9mIiNRwCiNiLJMJ+r0GXe4H7DBvFGz+r4HNm3iqb0teHtQGkwm++N9hRn2+ntwCbY4mIlJTKYyI8Uwmx31sOt8DdhvMfRC2fmNoF8N7xDH1zk54eZj5eXsSd73/P85k5xvah4iIVA2FEXEOsxkGvAXxdzkCyTcPwPb5hnbRr10kn93XjUAfD9YdOs3N01Zz7EyOoX2IiIjzKYyI85jNMPAd6HAn2K0w+z7Y8b2hXXRvXIfZD/ekfpAPe5MzGTr1N3Ymphvah4iIOJfCiDiX2QyDJkO7W8FWCP+9B3b9YGgXLeoHMuf/etIsPIDE9Fxumbaa3/efNLQPERFxHoURcT6zBQa/C22Hgq0Avh4Ou382tIuoEF/++3APusaFkpFbyPAP1rBwywlD+xAREedQGJGqYfGAm6ZD68FgzYdZd8HexYZ2EeLnxWf3d6dvmwjyrTZGz9zAJ78dNLQPERExnsKIVB2LBwx9H1oNBGsefDUM9i01tAsfTwtTh3XmrssaYLfDC99u418/7tTmaCIi1ZjCiFQtiycM/RBaDIDCXPjyDjiw3NguzCZeGdSWJ69rDsDUZft48r+bKbDaDO1HRESMoTAiVc/DC275GJpfD4U5MPM2OLjK0C5MJhOPXN2Mfw1tj8Vs4psNRxn5yTqy8goN7UdERCpPYURcw8MLbv0Uml4LBdnwxS1w+HfDu7m1aywzhnfGx9PMr7tTuGPG76Rm5hnej4iIVJzCiLiOhzfc9jk07g0FWfD5UDiyxvBurm4ZwZcPXEaonyebj6Zx87u/cehkluH9iIhIxSiMiGt5+sAdX0KjKyE/0xFI9i8zvJv4BqHMHtWTmFBfDp7MZui7v7HlaJrh/YiISPkpjIjrefrCHbMg7grIS4dPB8OSl8Fq7PyOJvUCmDOqJ60jg0jNzOf26atZvjvF0D5ERKT8FEakevDygzu/hk4jADuseAM+7g9nDhvaTXiQD7MeuoxeTeuQlW/lvo/XMnfjUUP7EBGR8lEYkerDyw9u/A/c/BF4B8GR/8G0yw2/wV6gjycf3dONGztEUWizM2bWJt77dZ/2IhERcRGFEal+2g6Bh1dAdBfITXNsH//dE1Bg3B15vTzMTLqtIyMvbwTAxB928vL327HZFEhERKpahcLIlClTiIuLw8fHh+7du7NmzcVXQJw5c4bRo0cTGRmJt7c3zZs3Z+HChRUasLiJ0Di470e4fAxggvUfwYyrIXmHYV2YzSaevaE1z/RvBcBHqw7y6FcbySu0GtaHiIhcWrnDyKxZsxg7diwvvPACGzZsoEOHDvTt25fk5ORSz8/Pz+faa6/l4MGDzJ49m127djFjxgyio6MrPXip5Sye0OdFuHsO+IdD8naY3hvWfQQGllQeuLIxb9/eEU+LiQWbT3DPh2tJzy0wrH0REbk4k72chfLu3bvTtWtXJk+eDIDNZiM2NpZHH32UcePG/en8adOm8frrr7Nz5048PT0rNMj09HSCg4NJS0sjKCioQm1IDZeZDHMfhn1LHD+3HgwD3wbfEMO6WLknlYc+W0dWvpWW9QP55L5uRAT5GNa+iIi7Kevv73JdGcnPz2f9+vX06dPnXANmM3369GH16tWlvufbb7+lR48ejB49moiICNq2bcuECROwWi98KTwvL4/09PQSD3FzAeEwbDZc+wqYPWD7PJh2haGbpF3erC6zHupB3QBvdiZmMGTqb+xNzjSsfRERKV25wkhqaipWq5WIiIgSxyMiIkhMTCz1Pfv372f27NlYrVYWLlzIc889xxtvvME//vGPC/YzceJEgoODix+xsbHlGabUVmYz9HoM7vvZMack7TB8eL1jGbDNmJvgtY0OZu7/9aRRXX+Oncnh5mm/sf7QaUPaFhGR0jl9NY3NZiM8PJzp06fTuXNnbrvtNp555hmmTZt2wfeMHz+etLS04seRI0ecPUypSWI6w0MroO3NYLc6Nkj7bDBklB6Iyys2zI/ZD/egQ2wIZ7ILGPb+7yzenmRI2yIi8mflCiN169bFYrGQlFTyH+akpCTq169f6nsiIyNp3rw5Foul+FirVq1ITEwkPz+/1Pd4e3sTFBRU4iFSgk8QDH0fBk0BTz848Cu82wv2LDak+ToB3nz5QHd6t6hHboGNBz9bx1drjN2ATUREHMoVRry8vOjcuTNLliwpPmaz2ViyZAk9evQo9T29evVi79692M67jL57924iIyPx8vKq4LBFAJMJ4u+CB3+FiLaQnQpfDIWfnoHC0oNuefh5eTB9eBdu6RyDzQ7j5mzh7cV7tDmaiIjByl2mGTt2LDNmzOCTTz5hx44djBo1iqysLO69914Ahg8fzvjx44vPHzVqFKdOneLxxx9n9+7dLFiwgAkTJjB69GjjPoW4t3rNYeQS6Pag4+fVk+HD6+Dkvko37Wkx86+b2/NI76YAvLV4N0/P3Uqh1Zg5KiIiAh7lfcNtt91GSkoKzz//PImJiXTs2JEff/yxeFLr4cOHMZvPZZzY2Fh++uknxowZQ/v27YmOjubxxx/n73//u3GfQsTTB/q/Do2vgvmj4fhGeO8vcMNb0P6WSjVtMpl4sm8LIoJ9eH7+Vr5cc5iUjDzeuSMeXy/LpRsQEZGLKvc+I66gfUakXNKOwjcPwOHfHD93HAb9/gXeAZVu+setJ3jsqwTyC210bhjKByO6EOKncqOISGmcss+ISI0QHAMjvoO/jAOTGRK+gOlXwYnNlW76+raRfH5/d4J8PFh/6DRD3/2No6ezKz9mERE3pjAitZPFA3qPd4SSwCg4uQfevwb+916lt5Lv1iiM2aN6Ehnsw76ULIa++xs7E7Uxn4hIRSmMSO0Wdzk8vBKa9wNrPvzwN/jqTsg+Valmm0cE8s2onjSPCCApPY9b3l3N6n0nDRq0iIh7URiR2s+/DtzxJVz/Gli8YNdCx54kB1dWqtmoEF/++1BPusWFkZFXyIgP17Bg8wmDBi0i4j4URsQ9mExw2cMwcjHUaQoZx+GTgbB0IlgLK9xssJ8nn97fjevb1CffauORLzfw8aoDBg5cRKT2UxgR9xLZwbFJWsdhYLfBr/90hJK0oxVu0sfTwpRhnbj7sobY7fDid9v55w87tTmaiEgZKYyI+/EOgMFTYcgM8ApwLAGedjnsXFDhJi1mEy8PasNTfVsAMO3Xfdz9wRrd9VdEpAwURsR9tb8VHloOkR0h57RjYuvCp6Agt0LNmUwmRvduyus3t8fLw8zKvan0e3s5//xhJ1l5FS8FiYjUdtr0TKQwH5a85NhGHiCiHdz8oWOb+Qo6dDKLl7/bzpKdyQBEBvvwzIBWDGgXiclkMmLUIiLVXll/fyuMiJy1ZxHMfdhxwz1PP8f28h2HOSa/VtDi7Um89P02jpzKAaBX0zq8dGMbmoYHGjVqEZFqS2FEpCIyEmHOg3DgV8fPbW923N/Gp+L/u8stsDLt1328u2wfeYU2PMwm7r+8EY9e04wA73LfHkpEpMZQGBGpKJsVVk2CX14FuxVC4xxlm+jOlWr28MlsXv5+G4t3OEo3EUHePDOgNQPbq3QjIrWTwohIZR3+H3wzEtIOg9kDrnkBejwC5srN+/5lZxIvfrudw6cc97Tp0bgOLw1qQ/MIlW5EpHZRGBExQs4Z+O4x2D7f8XOTa+CmaRAQXqlmcwusTF++nylL9xaXbu7tFcfjfZqrdCMitYbCiIhR7HZY/zH8OA4Kc8E/HIa8B02urnTTR05l88r32/l5exIA4YHePDOgFTd2iFLpRkRqPIUREaMlbYfZ90HKDsAElz8BvZ8Bi2elm162K5kXv93GwZOO0k33RmG8PKgtLeqrdCMiNZfCiIgz5GfDT+MdV0oAYrrC0Pcdk1wrKa/Qyozl+5m8dC+5BTYsZhP39IzjiT7NCPSpfOAREalqCiMizrRtLnz7OOSlgXcQDHwb2g4xpOmjp7P5x/c7+HFbIgD1Ar15un9LBneMVulGRGoUhRERZzt9yLHa5ugax8+dRsD1/wQvP0Oa/3V3Ci9+u40DqVkAdIsL46VBbWgVqf8GRKRmUBgRqQrWAlg6AVa+BdihXkvHniQRbQxpPq/QyvsrDjD5l73kFFixmE0M79GQMdc2J0ilGxGp5hRGRKrS/mWOnVszk8DDB/q+Cl3ur9RW8uc7diaHVxdsZ+EWR+mmboA34/u1ZEgnlW5EpPpSGBGpapkpMG8U7F3k+Dkq3rFJWutBhqy4AVixJ4UXvt3G/hRH6aZLw1BeHtSW1lH670JEqh+FERFXsNng9ynwyz8ce5IABEVD94ccc0p8QyrdRX6hjQ9XHeA/S/aQnW/FbILhPeIYc21zgn1VuhGR6kNhRMSVMlNg3YewdgZkpTiOefpDp7uh+8MQ1qjSXZxIy+EfC3awYPMJAOoGePH361sytFMMZrNKNyLiegojItVBQS5snQ2rp0Dy9qKDJmh1A1w2GhpcVul5Jav2pvLCt9vYm5wJQKcGIbw8qC1to4MrOXgRkcpRGBGpTux22L/UEUr2Lj53PKoT9Bhd6Xkl+YU2Plp1gLfPK90M696QJ69rQbCfSjci4hoKIyLVVfIO+H0qbJoF1jzHsaCYonklwys1ryQxLZdXF+7gu03HAQjz92Lc9S25ubNKNyJS9RRGRKq70uaVeAVA/F2Vnlfy275UXpi/jT1FpZuOsSG8Mqgt7WJUuhGRqqMwIlJTFOTClv86SjgpOxzHTGZoOcCxNDi2e4XmlRRYbXzy20EmLd5DZl4hJhPc2a0BT/VtQYifl8EfQkTkzxRGRGoaux32/eIIJfuWnDse3dkxr6TVILB4lLvZ5PRcJizcwbwER+km1M+Tv1/fklu7xKp0IyJOpTAiUpOVNq8kOPbcvBKf8pdbft9/khfmb2NXUgYAHWJDeGVQG9rHhBg4cBGRcxRGRGqDzBRY9wGsmQHZqY5jXgEQfzdc9jCExpWruQKrjU9XH2LSot1kFJVubu/agL/1bUGov0o3ImIshRGR2qQgF7Z8XTSvZKfjmMkMLW8omlfSrVzzSpIzcvnnwp3M2XgMgBA/T57q24LbuzbAotKNiBhEYUSkNrrgvJIuRfNKbizXvJI1B07x/Pyt7Ex0lG7axwTz8qC2dIwNMXjgIuKOFEZEaruk7Y55JZu/rtS8kkKrjc9+P8SbP58r3dzWJZa/Xd+SMJVuRKQSFEZE3EVmMqz9ANa+X3JeSafhjmBSxnklKRl5/POHnXyz4SgAwb6ePNm3BXd2U+lGRCpGYUTE3VxoXkmrgefmlZTBuoOneH7+NrafSAegfpAPg+OjGdIpmuYRgc4avYjUQgojIu7KbnfMJ1k9xTG/5KxyzCsptNr44n+HeWvxbs5kFxQfbxsdxE3xMdzYIYp6gd7O+gQiUksojIhI0bySKUXzSvIdx4JjHdvNd7r7kvNK8gqtLN2ZzDcbjrFsVzIFVsc/FxaziSub1WVIpxiubR2Bj6fF2Z9ERGoghREROad4XskMyD7pOOYVeN68koaXbOJUVj7fbz7OnA3HSDhypvh4oLcH/dtFMqRTNF3jwrSrq4gUUxgRkT8ryHFcJVk9BVJ3OY5VYF7JvpRM5m44xtyNxzh2Jqf4eHSIL0M6RXNTfDSN6wU44xOISA2iMCIiF2a3w94ljhLO+fNKYro65pW0HFim/UpsNjtrDp5izoajLNySSGZeYfFrHWNDGNopmhvaR2l3VxE3pTAiImWTtO28/UrOzitp4NhuPv5u8Cnbf3M5+VYW7Uhi7oajLN+TitXm+KfF02Kid4twhnSKpnfLcLw9NL9ExF0ojIhI+WQmO/YqWft+yXklLfpBk6uh8VUQFFmmppIzcvk24ThzNx5j2/H04uPBvp4M7BDJTfExdGoQgqkcW9iLSM2jMCIiFVOQA5tnweqp5+aVnFWvFTTpDY17Q1wv8PK/ZHM7E9OZu+EY8xKOkZSeV3w8ro4fQzrFcFN8NLFhfkZ/ChGpBhRGRKRybDY4/Jtjbsn+pXA8ATjvnwuzJ8R2d4STJr0hsiOYL1yCsdrs/LYvlbkbjvHD1kRyCqzFr3WLC+OmTtH0bxdJsK+n0z6SiFQthRERMVb2Kdi/zBFM9i2DtMMlX/cJgcZ/cVw1adL7otvQZ+UV8tO2ROZsOMaqfamc/VfIy8PMta0iGNIpmiub18PTYnbShxGRqqAwIiLOY7fDqf2OlTj7l8GB5ZCXXvKc0EbnSjqNrgTfkFKbOpGWw/yE48zZcJTdSZnFx+v4ezGwQxRDO8XQNjpI80tEaiCFERGpOtZCOL7BEU72LYWja8F+rgyDyQzRnc9dNYnpCpaS5Ri73c624+nM2XCMbzcdIzUzv/i1puEBDOkUzeCO0USF+FbVpxKRSlIYERHXyU2HgyuLSjpL4eSekq97BUDc5efCSd3mcN6VjwKrjZV7Uvlmw1F+3p5EfqENcJzSo3EdhnSK4fq29QnwvvReKCLiOgojIlJ9nDlybr7J/mXnlg6fFRR9Lpg0vgr86xa/lJ5bwA9bTvDNhmOsOXCq+LiPp5nr29Tnpk4xXN60LhZtQy9S7SiMiEj1ZLNB4uZzV00O/w7WvJLn1G93Lpw06AGejtLMkVPZzNt4jDkbj3EgNav49PBAbwbHO7ahbxWpfyNEqguFERGpGfKz4fDqc6t0kraUfN3DxxFIzk6GjWiL3WQi4cgZ5mw4xnebj3Mmu6D49FaRQQyJj2ZQxyjCg3yq9rOISAkKIyJSM2UmO0o5+5Y6AkrGiZKv+9V1lHKKwkm+fyRLdyUzZ8NRftmZTIHV8U+a2QSXN6vH0E7RXNe6Pr5e2oZepKopjIhIzWe3Q8qucyWdgyuhIKvkOXWbF21X35vT4d34flcGczYcZePhM8Wn+HtZuKJZPbo2CqNbXBitIgPx0B4mIk6nMCIitU9hPhxdc+6qyfGNYLede93sATHdoElvjte5jFnH6vBNQhJHT+eUaCbA24NODUPpFhdK17gwOsSG4OOpKyciRlMYEZHaL+e0Y8O1s+Hk9MGSr3sHY290BYdDL2N1flMWpQSx5lAmGXmFJU7zsphpHxNcfOWkc1woQT7all6kshRGRMT9nNp/LpgcWA65aSVfN3tgr9uctKDm7KUhv2fXZ0FSHXZk+QPnlgabTNCyfpDjyklRQNFkWJHyUxgREfdmszrKOPuWwoFf4cRmyEsr9VSrdygn/Zuyiwb8llmfVRn12W2PIRfv4nPi6vjRNS6sOJw0rOOnLepFLkFhRETkfHY7pB2F5O2QtBWStjkeqXtKbl1/9nRMnPSOYYetAWtzItlha8AOewOO2etix0y9QG+6xYXRtejqScv6Qdp4TeQPFEZERMqiIBdSd50LJ0lbIXErZKeWenq2yZcd1lh22GLZaW/ADlsDdtljMfkE0blhKN2Krpy0iwnG20OTYsW9KYyIiFRGZnLJKyhJWx3LjK35pZ5+xFbPEU7ssey0NWCfOY6QmBZ0beRYUty5YajupSNuR2FERMRo1gI4ufdcODkbVNKPlXp6rt2TXUXhZBex5IS1IrRRR9o1bUzXRmHUDfAu9X0itYXCiIhIVck+VTQXxRFS7EnbsCdtx1yYU+rpifZQdtoacMK3Cabw1tRp0omWbTsTUzdYk2KlVnFqGJkyZQqvv/46iYmJdOjQgXfeeYdu3bpd8n1fffUVd9xxB4MGDWLevHll7k9hRERqHJvVse9J0dWT3GObKTyxhYCsI6WeXmC3cMgcw+mAZpgj2xLetBPRLbpiDop0rDUWqYGcFkZmzZrF8OHDmTZtGt27d2fSpEn897//ZdeuXYSHh1/wfQcPHuTyyy+ncePGhIWFKYyIiHvKy4DknWQf2cTJ/RuwJ22jTuYe/O1ZpZ6eYQ4iPag5HlHtqNO4Ex7hLSC0IQREKKRItee0MNK9e3e6du3K5MmTAbDZbMTGxvLoo48ybty4Ut9jtVq58sorue+++1ixYgVnzpxRGBEROctuJzf1MAe2/4/T+zdiSt5Gvey9NOI4FlPp/0QXmr3JD4jBo04cXnUbQWgchDR0BJWQhuAbUqUfQaQ0Zf39Xa6p3fn5+axfv57x48cXHzObzfTp04fVq1df8H0vv/wy4eHh3H///axYsaI8XYqI1H4mEz71GtLqLw3hL7cCUGC1sfVwMvu2ryft4EY8U7YTZz1InDmJSE7iYcvDI30fpO+DA39u0u4djCm0oSOknA0oZwNLSAPw1I6yUn2UK4ykpqZitVqJiIgocTwiIoKdO3eW+p6VK1fywQcfkJCQUOZ+8vLyyMvLK/45PT29PMMUEanxPC1mOjSqT4dGA4AB2Gx29qdmsuFEBnuPnybl+D7yUvbjnXGEGFMysaYUYk0pxJiSqWdKx5SXBombHY/SBEaWvJJyfmAJigKz9kiRquPURe8ZGRncfffdzJgxg7p165b5fRMnTuSll15y4shERGoWs9lE0/BAmoYHQocooA0A2fmF7E3OZFdiBguTMtiVlMnRxGQ8Mo4Se15IcTx3/BxgyoWME47Hkd9L6cwTgmNKCSqNHM/96mi+ihiqXHNG8vPz8fPzY/bs2QwePLj4+IgRIzhz5gzz588vcX5CQgLx8fFYLOcSts3muN232Wxm165dNGnS5E/9lHZlJDY2VnNGRETKKC2ngD1JGexKymB3ouPPXYkZnM7OJ5SMEiGlgSmZBuYUGnmkEmFLwYPCizfu6V8yqPxxvop3QJV8Rqn+nDJnxMvLi86dO7NkyZLiMGKz2ViyZAmPPPLIn85v2bIlW7ZsKXHs2WefJSMjg7fffpvY2NhS+/H29sbbW5sBiYhUVLCvJ13iwugSF1Z8zG63k5qZz+6iYLInOYM1iRl8npRJZl4h5IMZGxGcdoQUczKNLKm08jlNnCWVcFsi/nkpmAqyHPuqJG8vvXO/OudKPn+8uhIcCx5eVfOXIDVGucs0Y8eOZcSIEXTp0oVu3boxadIksrKyuPfeewEYPnw40dHRTJw4ER8fH9q2bVvi/SEhIQB/Oi4iIs5lMpmoF+hNvUBvejU9Vzq32+0cT8stvoJy9s9vkzPJz7fBeTvge5NPtCmV5t6n6BSYRkuf0zQwp1C34AR+2Ucx556B7JOOx/ENpQzCDIFRjjJQYAQE1C/lz/rgGwZms/P/UqRaKHcYue2220hJSeH5558nMTGRjh078uOPPxZPaj18+DBm/Q9IRKTGMJlMRIf4Eh3iS++W5/aLstrsHDqZxe6kDHYnZRYHlf2p3uzPjeLH3D+31dC/kF51MukQkEYzr5PEmFIIyz+GR9oROHMYCnMg/ajjcTFmTwgId+ynElj/wn/6h4NF9/yp6bQdvIiIlEteoZUDqVnsSswoKvlksjspgyOns7nQb5ToEF+ah/sTX6eA9v5niPNKox6n8ctLxZSZBJmJkFH0Z/bJcozGBP51L3CF5Q9/ajlzldO9aUREpEqdv7Jnd9HKnt2JGSSml3IJpUiAtwcxob7EhvnRIMyP2FBfGoZ4EOeTTaQlDZ/cFMhIhMykP/+ZmQx2a9kH6BN84bLQ+VdcvAO1WsggCiMiIlItpGUXsDs547wrKRkcPJlFUnreJd9bL9C7OKTEhvk5HqF+NKjjR/0ATyy5p/4QUs67wnL+n9ZL91XM0+/S5aGA+uAXptByCQojIiJSreUWWDl2JofDp7I5eiqbw6eyOXIqp+jPbDLyLr7E2NPimOsSG+ZHTGjRlZUw36Lw4keIn6fjLsh2O+SeKT2k/PHP/IyyfwCzJ/jXc4QS31DHFvy+oY7Jt76h5x5+f/jZ07dSf281icKIiIjUWHa7nbScgnPh5LQjoBw+lc3R0zkcPZ1NgfXiv74CvT2ICfOjQZgvsaF+50pBYb7EhPrh41nKLrP5WRcuC53/Z86pin84D58/BJaQPweW0gJNDQwxCiMiIlJrWW12ktJzi6+iHDmVzZHTOcWBJTnj0mWZ8LMloD+UgRqE+RER5IPFfJESTGG+I5hkp0LOaccj+xTknDn3c86p854XPWyX2FDuYjx8/hBYQi9+BeZsoPH0dVk5SWFERETcVm6BlaOnS5Z9Dp8XWDLLUQI6N7n23JWVYN+iElB52O2Ql3HhsJL9h+By/uuVCTEW71ICS8ifr8DEXe5YmWQghREREZFS2O12zmQXcOR0yXkqR4t+PnY6h0LbJUpAPh7EhvoRHepL/SAfIoK8CQ/yKXru+LlCgaX0AUN+5nlXX/4YWM784erMea+VJ8Tc+yM07FH58Z7HKdvBi4iI1HQmk4lQfy9C/b1oHxPyp9etNjsn0nI4ciqnqPxT8spKSkYeGbmFbD+RzvYTF76rvLeHuTiYRBSFlPpBPoQX/Xw2uPh6XeIOySaTY7mxdyCENCj7Bz0/xJQaVk4XBZmiY4ERZW/bYLoyIiIiUg45+dbiqyjH03JJTs8lMS2XpIw8ktJyScrI5Ux2QZnbC/TxKA4m4UHeJa6unA0x9QK98bTUvN3NdWVERETECXy9LDSLCKRZROAFz8ktsJKcnkdSRi5JRWElOSOvxPPEtFxyCqxk5BaSkZvJnuTMC7ZnMkEdf28iisJKeFFY+WOICfXzwnyxibfVlMKIiIiIwXw8LTSo49ic7ULsdjsZeYVFV1YcQSUpI9dxdeVskCkKLoU2O6mZeaRm5rHt+IVLQ54WE+GBJa+q/PEqS0SQNwHeHsbMZzGIwoiIiIgLmEwmgnw8CfLxpGn4ha+y2Gx2TmXnF11RcQSV0p6nZuZTYLVz7EwOx87kXLRvPy/Ln+av3NGtAXF1/Y3+mGWiMCIiIlKNmc0m6gZ4UzfAGwi+4Hn5hTZSMouusKTlFl1pOTePJSnd8Twjr5DsfCv7U7PYn5pV/P6+besTh8KIiIiIVJCXh5noEF+iQy6+U2tWXmHxnJXk4jkteTQIu3BJydkURkRERNyIv7cHjbw9aOSikkxpat46IREREalVFEZERETEpRRGRERExKUURkRERMSlFEZERETEpRRGRERExKUURkRERMSlFEZERETEpRRGRERExKUURkRERMSlFEZERETEpRRGRERExKUURkRERMSlasRde+12OwDp6ekuHomIiIiU1dnf22d/j19IjQgjGRkZAMTGxrp4JCIiIlJeGRkZBAcHX/B1k/1ScaUasNlsHD9+nMDAQEwmk2HtpqenExsby5EjRwgKCjKsXakYfR/Vj76T6kXfR/Wi7+PS7HY7GRkZREVFYTZfeGZIjbgyYjabiYmJcVr7QUFB+h9SNaLvo/rRd1K96PuoXvR9XNzFroicpQmsIiIi4lIKIyIiIuJSbh1GvL29eeGFF/D29nb1UAR9H9WRvpPqRd9H9aLvwzg1YgKriIiI1F5ufWVEREREXE9hRERERFxKYURERERcSmFEREREXMqtw8iUKVOIi4vDx8eH7t27s2bNGlcPyS1NnDiRrl27EhgYSHh4OIMHD2bXrl2uHpYU+ec//4nJZOKJJ55w9VDc1rFjx7jrrruoU6cOvr6+tGvXjnXr1rl6WG7LarXy3HPP0ahRI3x9fWnSpAmvvPLKJe+/IhfmtmFk1qxZjB07lhdeeIENGzbQoUMH+vbtS3JysquH5nZ+/fVXRo8eze+//86iRYsoKCjguuuuIysry9VDc3tr167lvffeo3379q4eits6ffo0vXr1wtPTkx9++IHt27fzxhtvEBoa6uqhua3XXnuNd999l8mTJ7Njxw5ee+01/vWvf/HOO++4emg1ltsu7e3evTtdu3Zl8uTJgOP+N7GxsTz66KOMGzfOxaNzbykpKYSHh/Prr79y5ZVXuno4biszM5NOnToxdepU/vGPf9CxY0cmTZrk6mG5nXHjxrFq1SpWrFjh6qFIkRtuuIGIiAg++OCD4mNDhw7F19eXzz//3IUjq7nc8spIfn4+69evp0+fPsXHzGYzffr0YfXq1S4cmQCkpaUBEBYW5uKRuLfRo0czYMCAEv+dSNX79ttv6dKlC7fccgvh4eHEx8czY8YMVw/LrfXs2ZMlS5awe/duADZt2sTKlSvp16+fi0dWc9WIG+UZLTU1FavVSkRERInjERER7Ny500WjEnBcoXriiSfo1asXbdu2dfVw3NZXX33Fhg0bWLt2rauH4vb279/Pu+++y9ixY3n66adZu3Ytjz32GF5eXowYMcLVw3NL48aNIz09nZYtW2KxWLBarbz66qsMGzbM1UOrsdwyjEj1NXr0aLZu3crKlStdPRS3deTIER5//HEWLVqEj4+Pq4fj9mw2G126dGHChAkAxMfHs3XrVqZNm6Yw4iJff/01X3zxBTNnzqRNmzYkJCTwxBNPEBUVpe+kgtwyjNStWxeLxUJSUlKJ40lJSdSvX99Fo5JHHnmE77//nuXLlxMTE+Pq4bit9evXk5ycTKdOnYqPWa1Wli9fzuTJk8nLy8NisbhwhO4lMjKS1q1blzjWqlUrvvnmGxeNSJ566inGjRvH7bffDkC7du04dOgQEydOVBipILecM+Ll5UXnzp1ZsmRJ8TGbzcaSJUvo0aOHC0fmnux2O4888ghz587ll19+oVGjRq4eklu75ppr2LJlCwkJCcWPLl26MGzYMBISEhREqlivXr3+tNR99+7dNGzY0EUjkuzsbMzmkr8+LRYLNpvNRSOq+dzyygjA2LFjGTFiBF26dKFbt25MmjSJrKws7r33XlcPze2MHj2amTNnMn/+fAIDA0lMTAQgODgYX19fF4/O/QQGBv5pvo6/vz916tTRPB4XGDNmDD179mTChAnceuutrFmzhunTpzN9+nRXD81tDRw4kFdffZUGDRrQpk0bNm7cyJtvvsl9993n6qHVXHY39s4779gbNGhg9/Lysnfr1s3++++/u3pIbgko9fHRRx+5emhS5C9/+Yv98ccfd/Uw3NZ3331nb9u2rd3b29vesmVL+/Tp0109JLeWnp5uf/zxx+0NGjSw+/j42Bs3bmx/5pln7Hl5ea4eWo3ltvuMiIiISPXglnNGREREpPpQGBERERGXUhgRERERl1IYEREREZdSGBERERGXUhgRERERl1IYEREREZdSGBERERGXUhgRERERl1IYEREREZdSGBERERGXUhgRERERl/p/SiuFJGF5nlQAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUHlJREFUeJzt3Xd4VFX+x/H3TJKZFNIDSQgBQkIR6SWRoqDisiqsXcECUlz7othgFVxXAcuCqKisCLqroljWzs8WawABQRTpnVASUiA9mWTm/v6YEAg1CZPclM/reeZh5s7MOd8UmA/nnnOuxTAMAxERERGTWM0uQERERJo2hRERERExlcKIiIiImEphREREREylMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRU3mYXUBUul4t9+/YRGBiIxWIxuxwRERGpAsMwyMvLo2XLllitJx//aBBhZN++fcTGxppdhoiIiNRAamoqrVq1OunzDSKMBAYGAu4vJigoyORqREREpCpyc3OJjY2t+Bw/mQYRRg6fmgkKClIYERERaWBON8VCE1hFRETEVAojIiIiYiqFERERETFVg5gzUhVOp5PS0lKzy5B6zsfHBy8vL7PLEBGRozSKMJKfn8+ePXswDMPsUqSes1gstGrVimbNmpldioiIlGvwYcTpdLJnzx78/f1p3ry5NkWTkzIMg4yMDPbs2UP79u01QiIiUk80+DBSWlqKYRg0b94cPz8/s8uReq558+bs3LmT0tJShRERkXqi0Uxg1YiIVIV+T0RE6p9GE0ZERESkYVIYEREREVMpjIiIiIipFEakgvZpERERMyiMmOiLL75g4MCBhISEEB4ezrBhw9i2bVvF83v27GHkyJGEhYUREBBAnz59WL58ecXzn376KX379sXX15eIiAiuuOKKiucsFgsfffRRpf5CQkJ4/fXXAdi5cycWi4VFixYxaNAgfH19eeutt8jKymLkyJHExMTg7+9P165defvttyu143K5ePrpp0lISMBut9O6dWumTZsGwAUXXMBdd91V6fUZGRnYbDaSk5M98W0TEZEaKC51su9QEX/szeHHzRl89OteFqTs4F9fbmLy/9aSnltsWm0NfmnvsQzDoKjUaUrffj5e1VqtUVBQwMSJE+nWrRv5+flMnTqVK664gjVr1lBYWMigQYOIiYnhk08+ISoqitWrV+NyuQD4/PPPueKKK3j44Yf573//i8PhYPHixdWuedKkScycOZOePXvi6+tLcXExvXv35qGHHiIoKIjPP/+cm266ifj4eBITEwGYPHky8+bN49lnn2XgwIHs37+fjRs3AjB+/HjuuusuZs6cid1uB+DNN98kJiaGCy64oNr1iYjI8QzDILe4jOwCB9kFJWQXlJJdUEJWgYODBQ6yChxkH3O/0HHqz8are8cQGeRbR19BZY0ujBSVOuk89UtT+l7/z6H426r+Lb3qqqsqPV6wYAHNmzdn/fr1LF26lIyMDFauXElYWBgACQkJFa+dNm0aI0aM4LHHHqs41r1792rXfM8993DllVdWOnb//fdX3L/77rv58ssveffdd0lMTCQvL4/nnnuOOXPmMHr0aADi4+MZOHAgAFdeeSV33XUXH3/8Mddeey0Ar7/+OjfffLOW1YqInESp08XBQkd5uDhyy8p3cLCwPFAcdf9ggYMyV/V3Hfe2WggNsBEeYCMswFbpfotAc4IINMIw0pBs2bKFqVOnsnz5cjIzMytGPXbv3s2aNWvo2bNnRRA51po1a7jlllvOuIY+ffpUeux0Opk+fTrvvvsue/fuxeFwUFJSgr+/PwAbNmygpKSECy+88ITt+fr6ctNNN7FgwQKuvfZaVq9ezR9//MEnn3xyxrWKiDQEh0fos/LLQ0WhO0gcfT+rwFERPrLyS8gtLqtRXwE2r5OECzthAT7lf9oqbkG+3vXyP4aNLoz4+Xix/p9DTeu7OoYPH06bNm2YN28eLVu2xOVy0aVLFxwOx2l3kz3d8xaL5bhr9ZxogmpAQEClx8888wzPPfccs2fPpmvXrgQEBHDPPffgcDiq1C+4T9X06NGDPXv28Nprr3HBBRfQpk2b075PRKS+MgyDQ4WlpOcVcyC3hAN5JaTnFpcHjpIj4aI8aJSUuardh8UCof42Qv19CC8PEUcHjRPdfKv5uVNfNbowYrFYqnWqxCxZWVls2rSJefPmce655wKQkpJS8Xy3bt149dVXyc7OPuHoSLdu3UhOTmbMmDEnbL958+bs37+/4vGWLVsoLCw8bV1Llizhsssu48YbbwTck1U3b95M586dAWjfvj1+fn4kJyczfvz4E7bRtWtX+vTpw7x581i4cCFz5sw5bb8iImZwuQyyCx2k5xZzIK+EjNySivsH8opJzy0hI899czirFzBsXtaK0BDezEaof/n9k4SMEH8bXtY6GLUwDCgrAUcBOPLL/yyAyM5gCzj9+2tB/f/UbqRCQ0MJDw/nlVdeITo6mt27dzNp0qSK50eOHMn06dO5/PLLmTFjBtHR0fz666+0bNmSfv368eijj3LhhRcSHx/PiBEjKCsrY/HixTz00EOAe1XLnDlz6NevH06nk4ceeggfH5/T1tW+fXvef/99li5dSmhoKLNmzSI9Pb0ijPj6+vLQQw/x4IMPYrPZGDBgABkZGaxbt45x48ZVtHN4ImtAQEClVT4iInWhzOkiq8BRPopRXDGScSCv5Mix3BIy80uqNfcixN+HyEBfWgTZaR7ovoUHuINGeLPy0yP+NsKa2QiwVW9RwwkZBpQVHx8cDt8vyT/m+OHnTvDao19vnGAy6y3fQUyvM6u3hhRGTGK1WnnnnXf429/+RpcuXejYsSPPP/88gwcPBsBms/HVV19x3333cckll1BWVkbnzp158cUXARg8eDDvvfcejz/+OE8++SRBQUGcd955Fe3PnDmTMWPGcO6559KyZUuee+45Vq1addq6HnnkEbZv387QoUPx9/fnr3/9K5dffjk5OTkVr5kyZQre3t5MnTqVffv2ER0dzW233VapnZEjR3LPPfcwcuRIfH3NmxQlIo1LqdNFRl5JeagorvznUYEjK7+E6szvjGhmo3mgLy0C7UQG2WlRHjhaBNppEeQ+3jzQjt37FKdFjg4OBelw8ARhoCpB4dhgcaLg4Ck+/u7REFsAUP0JsZ5iMY6dWFAP5ebmEhwcTE5ODkFBQZWeKy4uZseOHcTFxelDrx7ZuXMn8fHxrFy5kl69zEnaJ6LfF5H6qaTMWTEXI6P89MiBY+ZnZOSVkF3ooKqfWlYLRDSzl4cKXyKD7EcFDt/yoGEnopkdH69jtt0qK4GCTCjMhIIMKMhy/3ns4+JDxwSH6s8VqbKK4NCs/BZw1K0Z2JtVflxxP/AkxwPAWrtzTk71+X00jYyIR5WWlpKVlcUjjzzCOeecU6+CiIiYo9TpYt+hIlKzi9hzsJDUg4Xsz3GHi8MjGYcKq74DtLfVQvPAyqMWh0cyKkY1Au2EN7MfmYPhLIXC8gBRsNcdNPZmwuYM9/2CzKPCRiaU5J7ZF+0TcHwAqAgLxwaJk4QF+1HHffxrPTiYSWFEPGrJkiWcf/75dOjQgffff9/sckSkDjhdBum5xaRmF5J6sDxwZBeRerCQPdmFpOUWV+mUic3L6g4ZQfaKeRknChxh/jashhOKso+EiIIMd9jYl3FUsDgcPjLdIxjVZfUG/wgIKL/5R0BAcwgId//pHwF+oeUh46gQ4RMAVm1wXh0KI+JRgwcPPm5JsYg0bIZhkJnvIPVgIanZhew5JnDsO1REqfPUf+/t3lZahfoRG+ZPbKg/0SG+RwUOXyKbeRNMPpbDAaJw95ERi7QM2J5ZeQSj6CDVnuNgsYJ/eZCoFC6ODRvlj31D3OttpdYpjIiICDmFpe6RjKNCxtEjHcWlp54L4W210DLEj9gwP2JD/IgLMogLcBDrW0S0rZBgIw9L4S73aEZhNmRkws7MI/MyCrNqMN/CAv5hR0YpDoeIgOaVQ8fRoxgasaiXFEZERJqAQkfZkTkb5SHj8ChH6sFC8k6yA6gFF0EUEm3NIz7AQUKAg9b+xbS0FRHpnU+YpYAgIxff0kNYig7CoWzYlwWuGl4F3C/0+NMhJwwbEe4g0ojnUTQlCiMiIo1ASZmTvQeLKsJFxZyNg0XsyS4kq8CBN2WEUECIJY9Q8gm15NHVks955BHinU9LnwIifYqI8MonxMgjwJmLvSwHy+ERi1LgUPmtKrx93SMUfmHgH3rU/bATny7xDwOv0++HJI2PwoiISANgGAZpucXszCxfjZJ5kIOZ6eQfTKcoJxOKsggljxDyCbXk08GSRxJ5hFryCSWPUHs+QZbT7MJsAI6TPGcLdAcKv/Ig4R9W+X7F47AjocPm7+lvgzRSCiMiIvVMTlEpW1LTSdvxB/n7NmJkbaNZ/g5aufYTazlEd/Lwt5RUflN1BhR8QyqHhopwEXrioOEXCt52T36JIpUojIiImKTEUcLubRvJ2LWOwn2bsGZvJahgFy1de+ljyT7+DcfMvXThRak9BJdfKN4B4XgHRmA5dnTi2Pu+IeClf/qlftFvpIhIbTIMXHnpZOxcR+au9ZSkbcL70DZCinYT5dxPe4uT9se+p3w1aZ41iBz/NrhC4/GN6kBo67PwCW1dMYJhtQdh1+oQaQQURhqwtm3bcs8993DPPfeYXYqIlORB1jby920ie/c6Sg9sxpazg7Di3QQYhUQCkce+xwLF+JDuHUNeQFuM8AQCWnaiRduzadayE4H+YQSa8KWI1DWFERGRqnKWwsFdkLWV0gObyN27EWfGFnxzdxBUmglAs/Lb0VyGhb00J80nlqLAtlgiEgiM6UR0fFdaxLSjjZanShOnMCKmcDqdWCwWrBpilvrGMCAvDbK2QtYWXJlbKUrbhJG5Fb+CVLzKr6DqA4Qf89ZMI4jtRjQZPq0oDo7Du3kHglqdRWy7s2gTFU7ssRdjExHguOlQjYBhHHP55Tq8VWMb9FdeeYWWLVviclXecfCyyy5j7NixbNu2jcsuu4zIyEiaNWtG3759+eabb2r8bZk1axZdu3YlICCA2NhY7rjjDvLz8yu9ZsmSJQwePBh/f39CQ0MZOnQoBw8eBMDlcvH000+TkJCA3W6ndevWTJs2DYDvv/8ei8XCoUOHKtpas2YNFouFnTt3AvD6668TEhLCJ598QufOnbHb7ezevZuVK1dy0UUXERERQXBwMIMGDWL16tWV6jp06BC33norkZGR+Pr60qVLFz777DMKCgoICgo67ho4H330EQEBAeTl5dX4+yVNQHEu7F0Nv78L303HeH8spS+dS9m0GJjVCf4zDD67F+vPLxKw8xua5e/Ey3BSaNhZ52rDZ85zmGe5ihdDHmRex1f54KIUUsf9ztkPL+XSKf/jqr/N5LKRt3L+ueeRENP8+KvCikiFxjcyUloI01ua0/ff97kvklQF11xzDXfffTffffcdF154IQDZ2dl88cUXLF68mPz8fC655BKmTZuG3W7nv//9L8OHD2fTpk20bt262qVZrVaef/554uLi2L59O3fccQcPPvggL730EuAODxdeeCFjx47lueeew9vbm++++w6n0/2/wMmTJzNv3jyeffZZBg4cyP79+9m4cWO1aigsLOSpp57i1VdfJTw8nBYtWrB9+3ZGjx7NCy+8gGEYzJw5k0suuYQtW7YQGBiIy+Xi4osvJi8vjzfffJP4+HjWr1+Pl5cXAQEBjBgxgtdee42rr766op/DjwMDdbZdcF/qfe8vkLGxfLRjG67MLVgLDlR6mYUjq2PLDCupRnN2GNFsN6JJtbbEGeKeRBrVqh2dooNJigokopkNi65dInLGGl8YaSBCQ0O5+OKLWbhwYUUYef/994mIiOD888/HarXSvXv3itc//vjjfPjhh3zyySfcdddd1e7v6Emubdu25YknnuC2226rCCNPP/00ffr0qXgMcPbZZwOQl5fHc889x5w5cxg9ejQA8fHxDBw4sFo1lJaW8tJLL1X6ui644IJKr3nllVcICQnhhx9+YNiwYXzzzTesWLGCDRs20KFDBwDatWtX8frx48fTv39/9u/fT3R0NAcOHGDx4sVnNIokDZjL5Q4dqcshdQXsWeEOIMc4PEZxwAhhhxHFNlc0O4xodhKNI6QdQdEJJESF0zEqkAujAmkd5n/kUvQi4nGNL4z4+LtHKMzquxpuuOEGbrnlFl566SXsdjtvvfUWI0aMwGq1kp+fzz/+8Q8+//xz9u/fT1lZGUVFRezevbtGpX3zzTfMmDGDjRs3kpubS1lZGcXFxRQWFuLv78+aNWu45pprTvjeDRs2UFJSUhGaaspms9GtW7dKx9LT03nkkUf4/vvvOXDgAE6nk8LCwoqvc82aNbRq1aoiiBwrMTGRs88+m//85z9MmjSJN998kzZt2nDeeeedUa3SQBTnukc9Ule6A8ieX6Ak57iXbXHFsN5oww4jiu0u92hHYbM2xERF0ikqkI5RQVwWFUhCi2b4+mgyqUhda3xhxGKp8qkSsw0fPhzDMPj888/p27cvP/30E88++ywA999/P19//TX/+te/SEhIwM/Pj6uvvhqH42R7NZ/czp07GTZsGLfffjvTpk0jLCyMlJQUxo0bh8PhwN/fHz8/v5O+/1TPARWTUI2j5syUlh5/kSw/P7/jhrRHjx5NVlYWzz33HG3atMFut9OvX7+Kr/N0fYN7dOTFF19k0qRJvPbaa4wZM0ZD542RYUD2dtiz8sjIR/o6jr2MfIFhZ40rgVVGe1a7OrDalUDLqGh6tg6lU1Qg10cF0jEykNAAmzlfh4gcp/GFkQbE19eXK6+8krfeeoutW7fSsWNHevXqBbgnk958881cccUVAOTn51dMBq2uVatW4XK5mDlzZkVwePfddyu9plu3biQnJ/PYY48d9/727dvj5+dHcnIy48ePP+755s2bA7B//35CQ0MB94hGVSxZsoSXXnqJSy65BIDU1FQyMzMr1bVnzx42b9580tGRG2+8kQcffJDnn3+e9evXV5xKkgautAj2rTkSPFKXuy81f4xUowW/uNqzytWB1a72bDJiaRMRRL/4cK5NiGBWu3DCFDxE6jWFEZPdcMMNDBs2jHXr1nHjjTdWHG/fvj3/+9//GD58OBaLhSlTphy38qaqEhISKC0t5YUXXmD48OEsWbKEuXPnVnrN5MmT6dq1K3fccQe33XYbNpuN7777jmuuuYaIiAgeeughHnzwQWw2GwMGDCAjI4N169Yxbtw4EhISiI2N5R//+AfTpk1j8+bNzJw5s0q1tW/fnjfeeIM+ffqQm5vLAw88UGk0ZNCgQZx33nlcddVVzJo1i4SEBDZu3IjFYuHPf/4z4J5/c+WVV/LAAw/wpz/9iVatWtXo+yQmy91XOXjs//24y9CX4sNaI46VzsOjHu3JIISWwb70T4hgfHw4/eLDiQ4+/YiaiNQfCiMmu+CCCwgLC2PTpk1cf/31FcdnzZrF2LFj6d+/f0UYyM3NrVEf3bt3Z9asWTz11FNMnjyZ8847jxkzZjBq1KiK13To0IGvvvqKv//97yQmJuLn50dSUhIjR44EYMqUKXh7ezN16lT27dtHdHQ0t912GwA+Pj68/fbb3H777XTr1o2+ffvyxBNPnHQOytHmz5/PX//6V3r16kVsbCzTp0/n/vvvr/SaDz74gPvvv5+RI0dSUFBAQkICTz75ZKXXjBs3joULFzJ27NgafY+kjjlLIW3tkeCxZyXkpB73skNeYaxwtmd5aQK/utrzhxGHAx/CA2z0iw/n3vgI+seH0ybcX6fmRBowi2FUY3MMk+Tm5hIcHExOTg5BQUGVnisuLmbHjh3ExcXh6+trUoVitjfeeIN7772Xffv2YbOdfEhevy8mKchyr2xJXe6ebLp3FZQVVXqJy+LFHls8yxzxLClpx2qjA3uMCMBCoN2bpHbhDEgIp398BB0imyl8iDQAp/r8PppGRqRBKywsZP/+/Tz55JPceuutpwwiUkeOXl57eLLpCZbXOnyC2GbvzI/F7fi+MI7fXPEUFrkDoq+Plb5tw7ihfOTj7JZBeGvTMJFGS2GkEXjrrbe49dZbT/hcmzZtWLduXR1XVHeefvpppk2bxnnnncfkyZPNLqdpquLy2rzAeDb5nMW3hXF8mdOa7cXRGHnugOHjZaFn21D6xYfTPz6cHq1DsHtria1IU6HTNI1AXl4e6enpJ3zOx8eHNm3a1HFF9Zd+X85QFZfXGj4BHAztyjqvTnyd15aPM1uSc9Tl46wW6BITTP/ykY8+bUPxt+n/RiKNjU7TNCGBgYHa+lxqRxWX17pC2pAV0oPfLB1ZfCiWz9JDceRVPq3SMTKwYuQjKS6cYH+f49oRkaap0YSRBjDAI/WAfk9OwzDgwHrY+g1sTYbdy8B5zEZ7XjZc0T04ENKd1c72fJrdiuS9VhxplZeetwn3p398OP3iI+jXLpzmgfY6/EJEpCFp8GHEy8t9XtnhcFRpt05p2g7v7Hr490aAwmzY/h1s/Ra2JUPe/srPN4vEiE0iLagbK8oS+CyjOUt35lOw1XnUi1xEBtkrTrv0iw+nVWj1Lo8gIk1XjcLIiy++yDPPPENaWhrdu3fnhRdeIDEx8aSvnz17Ni+//DK7d+8mIiKCq6++mhkzZnjknL23tzf+/v5kZGTg4+NTscOoyLFcLhcZGRn4+/vj7d3gc3jNuZywd7V79GNbsnuZrXHUqIa3H8SdS3GbwXxVfDaL9zXj503ZHCo8vAGZe3JqqL8P/cpHPvrHh9MuIkDLbUWkRqr9L/KiRYuYOHEic+fOJSkpidmzZzN06FA2bdpEixYtjnv9woULmTRpEgsWLKB///5s3ryZm2++GYvFwqxZs874C7BYLERHR7Njxw527dp1xu1J42a1WmndunXT+9DM3e8OHlu/gW3fQfGhys83PwsSLoSEIexq1o3Xlqfx3lepFDgKgAIAAmxeJLULrxj5OCsqCKuuZCsiHlDt1TRJSUn07duXOXPmAO7/bcbGxnL33XczadKk415/1113sWHDBpKTkyuO3XfffSxfvpyUlJQq9VmV2bgul6tGF5GTpsVmszWN0bOyEvd8j63fuE+/HDhmebdvMLQ73x1A4i/ECGrJ8h3ZzE/ZwTcb0jn8r0KHyGb8pXtL+idE0DUmGB/t9SEi1VArq2kcDgerVq2qtJ+D1WplyJAhLFu27ITv6d+/P2+++SYrVqwgMTGR7du3s3jxYm666aaT9lNSUkJJSUmlL+Z0rFarlmpK03V4ye3hiac7f4LSwqNeYIGYXpAwxH1r2Qu8vCkpc/LZb/tZsCSFdfuO/D0b3LE5YwfEcW77iKY3iiQida5aYSQzMxOn00lkZGSl45GRkWzcuPGE77n++uvJzMxk4MCBGIZBWVkZt912G3//+99P2s+MGTNOePVYETlKSR7s+Kk8gHwDh445Tdks0h084i9w3/zDKp7Kyi/hreU7eOPnXWTkuYO/r4+VK3u1YuyAtiS00FJxEak7tT6L7/vvv2f69Om89NJLJCUlsXXrViZMmMDjjz/OlClTTvieyZMnM3HixIrHubm5xMbG1napIvWbYbgvLrf1G9j2Lez+ufJVba0+0PqcI6MfkWfDMaMam9PzWJCygw9/3UtJmXvSamSQnVH92nJ9YmtCA7SdvojUvWqFkYiICLy8vI7b7TM9PZ2oqKgTvmfKlCncdNNNjB8/HoCuXbtSUFDAX//6Vx5++OETnr+32+3Y7dqTQISCTPeE023J7tMvBQcqPx8aVx4+LoS254K92XFNuFwGP2zJYEHKDn7acmTDsm6tghk3MI6Lu0Rj89ZcEBExT7XCiM1mo3fv3iQnJ3P55ZcD7omjycnJ3HXXXSd8T2Fh4XGB4/AeD9qASuQYzjL3dV4On3rZt4ZKW637BEDcuUdOv4THn7SpIoeTD1bv4bUlO9iW4V4RY7XAnzpHMe7cOPq0CdV8EBGpF6p9mmbixImMHj2aPn36kJiYyOzZsykoKGDMmDEAjBo1ipiYGGbMmAHA8OHDmTVrFj179qw4TTNlyhSGDx+ujadEAA6lHhn52P7D8ReZi+ziDh4JQ9ynYbxPPWqYllPMf5ftZOGK3RV7gzSze3Nd31hu7t+W2DBtRiYi9Uu1w8h1111HRkYGU6dOJS0tjR49evDFF19UTGrdvXt3pZGQRx55BIvFwiOPPMLevXtp3rw5w4cPZ9q0aZ77KkQaktIi2LXUHT62JUPGMZO//ULLl92Wj34ERVep2d/3HGJByg4++30/ZS73aEpsmB8394/j2j6tCPTVtWBEpH5q8FftFan3DAMytxzZ8XRnCpQVH3neYoWYPkfmfrTsCdaqjRo6XQZfr09jfsoOVu48WHE8sW0YYwfGcVHnSLy0MZmImERX7RUxU3EO7PjxyL4fOamVnw9sCQnlp17iBlVadlsVecWlLFqZyutLd7LnYBEA3lYLw7u3ZOyAOLq2CvbUVyIiUusURkQ8KWcv/PgM/Ppm5WW3XjZo0x/i3Vuu0+Ks45bdVkVqdiGvLdnJu7+kkl9SBkCIvw83JLVmVL+2RAZp4z8RaXgURkQ8If8ApDwLK+eDs3z34PCEI+Gj7QCwBdSoacMwWLnzIPNTtvP1+nTKp4OQ0KIZYwfEcUXPGPxsmgwuIg2XwojImSjMhqXPw/J/H9l+vc0AuOAR90jIGXCUufh87T4WpOxk7d4jK2zO69CcsQPacl775rpQnYg0CgojIjVRnAs/vwzL5kBJ+TVdYnq7Q0i782t0CuawgwUOFq7YzX+X7SQ91z3KYve2cmWvGMYOiKN9pLZqF5HGRWFEpDochbDiFVgyG4rKV69EdoHzH4aOF59RCNl6II/5KTv58Nc9FJe6t2pvEWhnVL82XJ/UhjBt1S4ijZTCiEhVlJXAqtfhx38d2ZI9vD2cPxk6XwEnuKxBVRiGwY9bMlmQsoMfNmdUHO8SE8S4gXFc2rWltmoXkUZPYUTkVJylsGYh/PA05O5xHwtpDYMnQ9drwatmf4WKS518+OteFqTsYMuBfMA9qHLRWZGMGxhHYlyYtmoXkSZDYUTkRFxO+OMD+H4GZG93HwuMhvMegJ43gXfNTpkcyC3mjZ938dby3WQXOAAIsHlxbd9YxvSPo3W4tmoXkaZHYUTkaIYBGz6F76ZDxgb3Mf8IOHci9BkLPn41avaPvTksSNnBp7/vo9TpXpsbE+LHmAFtubZvLEHaql1EmjCFERFwh5AtX8N3T8D+39zHfINhwARIvBXszardpNNl8M2GdOan7GDFjuyK433ahDKufKt2by/NBxERURgR2fEjfPsEpC53P7Y1g3PugH53gl9ItZsrKXOycPluXl+6k11Z7r1HvK0WLu0WzdgBcXSPrX6bIiKNmcKINF2pK+Hbx2HHD+7H3r6QeAsMuBcCwmvU5Ka0PCa88ysb0/IA91bt1ye25qZ+bYgOrtkpHhGRxk5hRJqe/b/Bt9Ngy5fux1Yf6H0znHc/BEbVqEmXy+C1pTt56ouNOMpchAfYuOeiDlzdq5W2ahcROQ2FEWk6DmyE76fD+o/djy1e0ON6GPSge7luDaXnFnP/e7/x05ZMAC7o1IKnrupG80C7J6oWEWn0FEak8cveDt8/Cb+/CxiABbpeDYMmQUTCGTX9f2v3M/nDtRwqLMXXx8ojl3bmhqTW2iNERKQaFEak8crZ496s7Nc3wXC6j3Ua5t66PbLzGTWdV1zKY5+u5/1V7o3QusYEM3tED+KbV3/VjYhIU6cwIo1PXjqkzIJfFoDTvbEYCRfBBQ9Dy55n3PwvO7O59901pGYXYbXAHYMT+NuF7bVtu4hIDSmMSONRmA1LnnNfyK7UvaSWNgPdV9Jt0++Mmy91ung+eQsvfrcVlwGtQv149roe9G0bdsZti4g0ZQoj0vAV58LPL8GyF6Ek130spg9cOAXiBp3RlXQP256Rz72L1vDbnhwAruwVwz/+crZ2ThUR8QCFEWm4HAXuUZAlz0HRQfexyK7ukZAOQz0SQgzD4O0VqTz+2XqKSp0E+/kw7YouDOvW8ozbFhERN4URaXjKSuCX1+CnmVBwwH0sogOc/3c46zKwembuRmZ+CZM++J1vNrj7GJAQzr+u6a7Ny0REPExhRBoOZymseQt+eAZy3atYCGkDgydDt2vB6rnNxb7dmM6D7/9OZr4Dm5eVB//ckbED4rBatWRXRMTTFEak/nM5Ye378P0MOLjDfSwoBs57AHreCF6em7dR5HAybfF63vx5NwAdIwOZPaIHZ0UHeawPERGpTGFE6i+XCzZ+Ct9Nh4yN7mMBzeHc+6D3GPDx9Wh3a/fkMGHRr2zPKABg3MA4HhjaEV8fbecuIlKbFEak/jEM2PKV+0q6ab+7j/mGwIAJkHQr2AI82p3TZTD3h208+/VmylwGkUF2Zl7Tg4HtIzzaj4iInJjCiNQv239wh5A9K9yPbYHQ707odwf4Bnu8u9TsQia+u4aVO92rcS7pGsX0K7oS4m/zeF8iInJiCiNSP5Q54POJ8Osb7sfefpD0V+g/AQLCPd6dYRh8tGYvUz9aR15JGQE2Lx67rAtX9YrRdWVEROqYwoiYryAL3r0Jdi0BixX6jnfPCwmMqpXucgpLefijtXz2+34AercJ5dlre9A63L9W+hMRkVNTGBFzZWyChdfCwZ1gD4KrX4P2Q2qtu6VbM7nvvd/Yn1OMt9XCPUPac9ugeLy9dF0ZERGzKIyIebZ+A++NcW/hHtoWRi6CFp1qpauSMif/+nIT835yLw1uFxHAs9f1oHtsSK30JyIiVacwIuZY/gp88RAYLmjdH657s1bmhgBsSstjwju/sjEtD4Abklrz8KVn4W/Tr7+ISH2gf42lbjlL4YtJsPJV9+MeN8CwZ8Hb7vGuXC6D15fu5MkvNuIocxEeYOOpq7oxpHOkx/sSEZGaUxiRulN0CN4bDdu/Byxw0WPQ/28euaDdsdJzi7n/vd/4aUsmABd0asFTV3WjeaDnQ4+IiJwZhRGpG1nbYOF1kLUFfALgqnnQ6dJa6er/1u5n8odrOVRYiq+PlUcu7cwNSa21ZFdEpJ5SGJHat+MnWHQjFB+CoFYw8m2I7ubxbvKKS3ns0/W8v8p9Eb2uMcHMHtGD+ObNPN6XiIh4jsKI1K5V/3FvZuYqg5g+MGIhBHp+zsaqXdncs2gNqdlFWCxwx+B4JlzYAZu3luyKiNR3CiNSO1xO+HoqLJvjftzlarhsDvj4ebSbUqeLF5K3MOe7rbgMiAnx49nrepAYF+bRfkREpPYojIjnFefCB+Nhy5fux4P/DoMe9PhE1e0Z+dy7aA2/7ckB4MpeMfzjL2cT5Ovj0X5ERKR2KYyIZx3cBW+PgAPrwdsXLn8Zulzp0S4Mw+DtFak8/tl6ikqdBPv5MO2KLgzr1tKj/YiISN1QGBHP2b0c3rkeCjOhWRSMXAgxvT3aRWZ+CZM++J1vNhwAoH98ODOv7U50sGdP/4iISN1RGBHP+G0RfHIXOB0Q1Q1GvgPBMR7t4ruNB3jg/d/IzHdg87Ly4J87MnZAHFarluyKiDRkCiNyZlwu+O4J+Gmm+3GnYXDlK2AL8FgXRQ4n0xdv4I2fdwHQMTKQ2SN6cFZ0kMf6EBER8yiMSM05CuDDW2HDp+7H594H5z8CVs8tp127J4cJi35le0YBAOMGxvHA0I74+nh5rA8RETGXwojUTO4+90TV/b+Blw3+8gJ0H+Gx5p0ug7k/bOPZrzdT5jKIDLLzr2u6c2775h7rQ0RE6geFEam+vavh7ZGQnwb+ETDiLWh9jseaT80u5L53f2PFzmwALu4SxfQruhIaYPNYHyIiUn8ojEj1rPsQPrwdyoqg+Vlw/SIIbeORpg3D4KM1e5n60TrySsoIsHnx2GVduKpXjK4rIyLSiCmMSNUYBvz4DHw3zf24/Z/gqvng65lJpIZhMO3zDbyasgOA3m1CefbaHrQO9/dI+yIiUn8pjMjplRa7l+2ufc/9+Jw74U+Pg9Vzk0if/XpzRRCZeFEH7hgcj7eXrisjItIUKIzIqeWluzcy2/sLWL3h0pnQ+2aPdvHy99t4/tutADz2l7MZ3b+tR9sXEZH6TWFETi5tLSwcAbl7wDcErnsD4s7zaBf/XbaTp77YCMBDf+6kICIi0gQpjMiJbVzsvthdaQGEJ8D170J4vEe7eO+XVKZ+vA6Auy9I4PbBnm1fREQaBoURqcwwYOnz8PWjgAFxg+Da/4BfqEe7+fS3fTz0we8AjB0Qx8SLOni0fRERaThqNEPwxRdfpG3btvj6+pKUlMSKFStO+trBgwdjsViOu1166aU1LlpqSZkDPr4Lvp4KGNBnHNz4gceDyDfr07l30RpcBoxMbM2UYWdp6a6ISBNW7TCyaNEiJk6cyKOPPsrq1avp3r07Q4cO5cCBAyd8/f/+9z/2799fcfvjjz/w8vLimmuuOePixYMKsuCNy2HNm2CxwsVPuyerevl4tJuULZncsXA1ZS6Dy3u05InLuyiIiIg0cdUOI7NmzeKWW25hzJgxdO7cmblz5+Lv78+CBQtO+PqwsDCioqIqbl9//TX+/v4KI/XJgY3w6gWwawnYg+D69yDpVvBwSPhlZza3/PcXHGUuhp4dyb+u6Y6XrrgrItLkVSuMOBwOVq1axZAhQ440YLUyZMgQli1bVqU25s+fz4gRIwgIOPlVXUtKSsjNza10k1qy9RuYfxEc3AmhbWHc19B+yOneVW1r9+Qw5rWVFJU6Oa9Dc54f2VP7iIiICFDNMJKZmYnT6SQyMrLS8cjISNLS0k77/hUrVvDHH38wfvz4U75uxowZBAcHV9xiY2OrU6ZU1fJX4K1roCQXWveH8d9Ci04e72ZTWh43LVhOXkkZiXFh/PvG3ti9ddVdERFxq9P/ms6fP5+uXbuSmJh4ytdNnjyZnJyciltqamodVdhEOEvh8/vg/x4AwwU9boBRH0FAuMe72pFZwI3zl3OosJTusSEsuLkvfjYFEREROaJaS3sjIiLw8vIiPT290vH09HSioqJO+d6CggLeeecd/vnPf562H7vdjt1ur05pUlVFB+G9m2H794AFLnoM+v/N4/NDAPYcLOSGeT+TkVdCp6hA/jOmL83sWk0uIiKVVWtkxGaz0bt3b5KTkyuOuVwukpOT6dev3ynf+95771FSUsKNN95Ys0rlzGVtg1cvcgcRnwAY8RYMmFArQeRAbjE3vrqcfTnFtGsewBvjkgjxt3m8HxERafiq/d/UiRMnMnr0aPr06UNiYiKzZ8+moKCAMWPGADBq1ChiYmKYMWNGpffNnz+fyy+/nPBwz58KkCrY8RMsuhGKD0FQKxj5NkR3q5Wusgsc3Dh/OTuzCmkV6sdb45NoHqiRLhERObFqh5HrrruOjIwMpk6dSlpaGj169OCLL76omNS6e/durNbKAy6bNm0iJSWFr776yjNVS/Ws+g98PhFcZRDTB0YshMDI07+vBnKLSxm1YDmb0/OJDLKzcPw5RAf71UpfIiLSOFgMwzDMLuJ0cnNzCQ4OJicnh6CgILPLaThcTvduqsvmuB93uRoumwM+tRMOCh1l3DR/Bat2HSQ8wMaiW/uR0KJZrfQlIiL1X1U/vzWbsLEqznVf6G7Ll+7Hg/8Ogx6slfkhAMWlTm757y+s2nWQIF9v/jsuUUFERESqRGGkMTq4C94eAQfWg7cvXP4ydLmy1rordbq4863VLNmaRYDNi9fHJnJ2y+Ba609ERBoXhZHGZvdyeOd6KMyEZlEwciHE9K617pwug3sWrSF54wHs3lZeHd2XXq09e2E9ERFp3BRGGpPf3oFP7ganA6K6wch3IDim1rpzuQwe+uB3Pv99Pz5eFv59U2/6xWu1lIiIVI/CSGPgcsG3j0PKLPfjTsPgylfAdvLr/5wpwzD4x6freH/VHrysFl4Y2YvBHVvUWn8iItJ4KYw0Bl89DD+/5L5/7n1w/iNgrb2d/g3D4MkvNvLfZbuwWOBf13Tjz11OvQOviIjIySiMNHS7lh0JIpe9BD1vqPUu53y7lX//sB2AaZd35YqerWq9TxERabx0DfeGrLTYPUcEoOeNdRJEXv1pOzO/3gzAI5eexfVJrWu9TxERadwURhqyH5+BrC3QLBL+9EStd7dw+W6e+HwDABMv6sD4c9vVep8iItL4KYw0VGl/wJLZ7vuXPAN+tbuc9qNf9/LwR2sBuHVQO+6+IKFW+xMRkaZDYaQhcpbBJ3e5rzXTaRh0vqxWu/vijzTue+83DANuOqcNk/7cCUst7eQqIiJNj8JIQ7T8Zdj3K9iD4ZJ/1WpX3286wN1vr8bpMriqVyse+8vZCiIiIuJRCiMNTfZ2+Haa+/6fHoeg6Frr6uftWdz6xipKnQaXdo3mqau6YrUqiIiIiGcpjDQkhgGfToCyImh7LvQaVWtdrUk9xLjXV1JS5uKCTi149roeeHvp10VERDxPny4Nya9vwo4f3Re/G/5crV2Bd/2+XEbNX06Bw0n/+HBeuqEXNm/9qoiISO3QJ0xDkZfu3mkV4Py/Q3h8rXSz9UA+N81fTm5xGb1ahzBvVB98fbxqpS8RERFQGGk4/u8BKM6B6B5wzp210kVqdiE3vrqcrAIHZ7cM4rUxiQTYtUmviIjULoWRhmDDZ7D+Y7B4wV9eAC/PB4T9OUVc/+rPpOUW075FM94Yl0Swn4/H+xERETmWwkh9V3QIPr/PfX/ABIju5vEuMvNLuOHV5aRmF9Em3J83xycRFmDzeD8iIiInojBS3309FfLTIDwBBj3k8eYPFTq48dXlbM8ooGWwL2+NTyIyyNfj/YiIiJyMwkh9tuMnWP0f9/3hz4OPZ0NCfkkZo19byca0PCKa2XnrlnNoFerv0T5EREROR2Gkviotgk//5r7fZyy0HeDR5oscTsa+vpLfUg8R4u/DW+OTiIsI8GgfIiIiVaEwUl99P8O922pgSxjymEebLilzctubq1ixI5tAuzdvjE2iY1SgR/sQERGpKoWR+mjfGlg6x31/2CzwDfJY02VOF397+1d+2JyBn48XC8b0pWurYI+1LyIiUl0KI/WNs9R9RV7DCWdfCR0v9ljTLpfB/e/9xpfr0rF5WZk3qg9924Z5rH0REZGaUBipb5a+AGlrwS8ULn7aY80ahsHDH/3BR2v24W218NINvRjYPsJj7YuIiNSUwkh9krkVvn/SfX/oDGjW3CPNGobBE59v4O0Vu7FY4NnrejCkc6RH2hYRETlTCiP1hcvlXj3jLIH4C6D7CI81/ew3W5ifsgOAp67sxvDuLT3WtoiIyJlSGKkvVr8Ou5aATwAMm+2xK/LO/WEbzydvAeAfwztzbd9Yj7QrIiLiKQoj9UHuPvj6Uff9C6dAaBuPNPvGsp08+X8bAXjwzx25eUCcR9oVERHxJIURsxmG+9ozJbkQ0wcS/+qRZt9ftYcpH68D4K7zE7hjcIJH2hUREfE0hRGzrfsQNi0Gq4/7irxWrzNu8vPf9/Pg+78BMGZAW+77U4czblNERKS2KIyYqTAb/u9B9/1zJ0Jk5zNuMnlDOhPe+RWXASP6xjJ1WGcsHpp/IiIiUhsURsz01SNQkAERHeHc+864uSVbM7n9rdWUuQz+0r0l067oqiAiIiL1nsKIWbZ9C2veAixw2Rzwtp9Rc7/szGb8f37BUebios6RzLy2O15WBREREan/FEbM4CiATye47yf+FWITz6i59ftyGfPaSopKnZzbPoI51/fEx0s/WhERaRj0iWWGb6fBod0QHAsXTj3j5p75ciN5JWUktg3jlZv6YPc+80mwIiIidUVhpK7tWQXLX3bfHzYb7M3OqDlHmYuft2cD8NhlZ+NnUxAREZGGRWGkLpU5yq/I64Ju10H7IWfc5K+7D1JU6iSimY1OUYEeKFJERKRuKYzUpSWz4cB68A93XwjPE01uzQSgf3yEVs6IiEiDpDBSVzI2wY/PuO9f/DQEhHuk2ZTyMDIwIcIj7YmIiNQ1hZG64HLBJ3eD0wHth0KXqzzSbG5xKb/tyQFgQHuFERERaZgURurCylchdTnYAmHYLI9dkXf59mycLoO4iABiQvw80qaIiEhdUxipbYdSIfkx9/0hj0JwK481fXi+yIAEz5zyERERMYPCSG0yDPjsXnDkQ+t+0GecR5vXfBEREWkMFEZq09r3YOvX4GWD4c+D1XPf7vTcYrYeyMdigX7tFEZERKThUhipLQWZ8H8Pue8PehCad/Bo84dP0XSNCSbY38ejbYuIiNQlhZHa8sUkKMqGyC4w4B6PN59SMV9EoyIiItKwKYzUhs1fuk/RWKzwlxfAy7MjF4ZhVIyMaL6IiIg0dAojnlaSB59NdN8/5w6I6eXxLrZl5JOeW4Ld20rvNqEeb19ERKQuKYx4WvI/IXcPhLaF8x+ulS5StrhHRfq2DcPXRxfGExGRhk1hxJN2L4cV89z3hz8HNv9a6SZlaxag+SIiItI4KIx4SlmJe8t3DOhxI7QbXDvdOF0s3+4OI5ovIiIijUGNwsiLL75I27Zt8fX1JSkpiRUrVpzy9YcOHeLOO+8kOjoau91Ohw4dWLx4cY0Krrd+/BdkboKAFjD0iVrr5ve9OeSVlBHs50PnlkG11o+IiEhd8a7uGxYtWsTEiROZO3cuSUlJzJ49m6FDh7Jp0yZatGhx3OsdDgcXXXQRLVq04P333ycmJoZdu3YREhLiifrrh/R1kDLLff+SZ8Cv9iaVLimfL9I/Phwvq2eucSMiImKmaoeRWbNmccsttzBmzBgA5s6dy+eff86CBQuYNGnSca9fsGAB2dnZLF26FB8f9xLXtm3bnlnV9YnL6T494yqDTsOg82W12p32FxERkcamWqdpHA4Hq1atYsiQIUcasFoZMmQIy5YtO+F7PvnkE/r168edd95JZGQkXbp0Yfr06TidzpP2U1JSQm5ubqVbvbV8LuxdBfZguORfHrsi74kUOspYvfsgoPkiIiLSeFQrjGRmZuJ0OomMjKx0PDIykrS0tBO+Z/v27bz//vs4nU4WL17MlClTmDlzJk88cfJ5FTNmzCA4OLjiFhsbW50y687BnfBt+dfxp39CUHStdrdiRzalToOYED/ahNfOSh0REZG6VuuraVwuFy1atOCVV16hd+/eXHfddTz88MPMnTv3pO+ZPHkyOTk5FbfU1NTaLrP6DAM+nQClhdD2XOg1uta7PHrXVUstjsCIiIjUpWrNGYmIiMDLy4v09PRKx9PT04mKijrhe6Kjo/Hx8cHL68jmXGeddRZpaWk4HA5sNttx77Hb7djt9uqUVvfWLITt34O3r3tPkToIBxX7i7TXKRoREWk8qjUyYrPZ6N27N8nJyRXHXC4XycnJ9OvX74TvGTBgAFu3bsXlclUc27x5M9HR0ScMIg1C/gH48u/u+4MnQ3h8rXeZlV/Chv3uuTP948NrvT8REZG6Uu3TNBMnTmTevHn85z//YcOGDdx+++0UFBRUrK4ZNWoUkydPrnj97bffTnZ2NhMmTGDz5s18/vnnTJ8+nTvvvNNzX0VdW/wAFB+C6O7Q76466XLpNveoSKeoQCKa1fNRIxERkWqo9tLe6667joyMDKZOnUpaWho9evTgiy++qJjUunv3bqzWIxknNjaWL7/8knvvvZdu3boRExPDhAkTeOihhzz3VdSljZ/D+o/A4gV/mQNe1f4W1oiu0isiIo2VxTAMw+wiTic3N5fg4GBycnIICjJx19HiHHgxCfL2w8B7Ycg/6qRbwzAY+NR37D1UxGtj+nJ+x+M3lxMREalvqvr5rWvTVMfXU91BJCweBtXdyM7u7EL2HirCx8tCYtuwOutXRESkLiiMVNXOFFj1uvv+X14AH7866/rwrqs9W4cSYK+b00IiIiJ1RWGkKkqLyq/IC/QeA20H1Gn3mi8iIiKNmcJIVXz/JGRvh8BouOixOu3a5TIqVtLoejQiItIYKYyczv7fYOkL7vuXzgLf4Drtfv3+XA4VltLM7k33VnXbt4iISF1QGDkVZ5n79IzhhLOvgE6X1HkJh+eLnNMuDG8v/bhERKTx0afbqSyb4x4Z8Q2Bi582pYTD80V0ikZERBorhZGTydoG389w3//zDGhW93t7FJc6WbEjG9DkVRERabwURk7k8BV5y4oh/gLoPtKUMlbvOkhJmYsWgXYSWjQzpQYREZHapjByIqv/Azt/Ah9/GDa7Tq7IeyIpRy3ptZhUg4iISG1TGDlW7n74aqr7/gVTILSNaaVovoiIiDQFCiNHMwxYfD+U5EBMb0i61bRScgpL+X1vDqAwIiIijZvCyNHWfwwbPwOrt3vLd6uXaaUs256FYUB88wCign1Nq0NERKS2KYwcVpgNix9w3x84ESLPNrUcbQEvIiJNhcLIYV9NgYIDENERzrvf7Go0X0RERJoMhRGAbd/BmjcBi/v0jLfd1HL2Hipie2YBVgucEx9uai0iIiK1TWHEUeDeUwQg8RZonWRuPRwZFekeG0KQr4/J1YiIiNQuhZHvpsOhXRDUCi6canY1gOaLiIhI09K0w8jeVfDzS+77w2eDPdDUcgAMw2DJ1ixA80VERKRpaLphpMwBH98Nhgu6XgvtLzK7IgA2p+eTmV+Cr4+Vnq1DzC5HRESk1jXdMGKxQvfrIDgW/vyk2dVUOLwFfGJcOHZv8/Y5ERERqSveZhdgGi9vGDABkm4zffXM0Y7MF9EqGhERaRqa7sjIYfUoiJQ6Xfy8XfNFRESkaVEYqUfWpB6i0OEkLMDGWVFBZpcjIiJSJxRG6pGULe5TNP3jw7FaLSZXIyIiUjcURuoR7S8iIiJNkcJIPZFfUsaa1EOA5ouIiEjTojBST6zYkUWZy6B1mD+xYf5mlyMiIlJnFEbqiZQtWkUjIiJNk8JIPaH5IiIi0lQpjNQDB/KK2ZSeh8UC/eK12ZmIiDQtCiP1wNLyC+Od3TKIsACbydWIiIjULYWReuDw9Wg0X0RERJoihRGTGYah+SIiItKkKYyYbEdmAftzirF5WenTJszsckREROqcwojJDo+K9G4Tip/Ny+RqRERE6p7CiMkOzxcZ2F6naEREpGlSGDGR02WwdJs2OxMRkaZNYcREa/fmkFdcRqCvN11jgs0uR0RExBQKIyY6PF+kf3w4XlaLydWIiIiYQ2HERClbtKRXREREYcQkRQ4nq3YdBDRfREREmjaFEZP8sisbh9NFdLAvcREBZpcjIiJiGoURkxy9BbzFovkiIiLSdCmMmERbwIuIiLgpjJggu8DBun25APRPCDe5GhEREXMpjJhg2bYsDAM6RgbSItDX7HJERERMpTBigqPni4iIiDR1CiMmqJgv0l6naERERBRG6lhqdiG7swvxtlpIjFMYERERURipY4dHRXrEhtDM7m1yNSIiIuZTGKljmi8iIiJSmcJIHXK5DJZuywJgYHuFEREREahhGHnxxRdp27Ytvr6+JCUlsWLFipO+9vXXX8disVS6+fo2zeWsG9JyyS5wEGDzokdsiNnliIiI1AvVDiOLFi1i4sSJPProo6xevZru3bszdOhQDhw4cNL3BAUFsX///orbrl27zqjohurwfJGkduH4eGlQSkREBGoQRmbNmsUtt9zCmDFj6Ny5M3PnzsXf358FCxac9D0Wi4WoqKiKW2Rk5BkV3VClbHWfotF8ERERkSOqFUYcDgerVq1iyJAhRxqwWhkyZAjLli076fvy8/Np06YNsbGxXHbZZaxbt+6U/ZSUlJCbm1vp1tCVlDlZsaN8vojCiIiISIVqhZHMzEycTudxIxuRkZGkpaWd8D0dO3ZkwYIFfPzxx7z55pu4XC769+/Pnj17TtrPjBkzCA4OrrjFxsZWp8x66dfdhygudRHRzE6HyGZmlyMiIlJv1PrEhX79+jFq1Ch69OjBoEGD+N///kfz5s3597//fdL3TJ48mZycnIpbampqbZdZ65ZULOkNx2KxmFyNiIhI/VGtXbciIiLw8vIiPT290vH09HSioqKq1IaPjw89e/Zk69atJ32N3W7HbrdXp7R6T/uLiIiInFi1RkZsNhu9e/cmOTm54pjL5SI5OZl+/fpVqQ2n08natWuJjo6uXqUNWG5xKb+lHgIURkRERI5V7f3IJ06cyOjRo+nTpw+JiYnMnj2bgoICxowZA8CoUaOIiYlhxowZAPzzn//knHPOISEhgUOHDvHMM8+wa9cuxo8f79mvpB77eVsWLgPaRQQQE+JndjkiIiL1SrXDyHXXXUdGRgZTp04lLS2NHj168MUXX1RMat29ezdW65EBl4MHD3LLLbeQlpZGaGgovXv3ZunSpXTu3NlzX0U9t0SnaERERE7KYhiGYXYRp5Obm0twcDA5OTkEBQWZXU61XTjze7ZlFDD3xt78uUvV5taIiIg0dFX9/NY2oLUsLaeYbRkFWC3Qr1242eWIiIjUOwojtezwKZquMcEE+/uYXI2IiEj9ozBSyzRfRERE5NQURmqRYRgV+4toC3gREZETUxipRVsP5HMgrwS7t5VebULNLkdERKReUhipRYdHRRLjwvD18TK5GhERkfpJYaQWab6IiIjI6SmM1JIyp4uft2cDmi8iIiJyKgojteS3PTnkl5QR4u9D5+iGt1GbiIhIXVEYqSWHT9H0jw/HarWYXI2IiEj9pTBSS1I0X0RERKRKFEZqQUFJGb/uPghovoiIiMjpKIzUghU7syl1GrQK9aN1mL/Z5YiIiNRrCiO1YMmWI7uuWiyaLyIiInIqCiO1QPNFREREqk5hxMMy80vYmJYHuFfSiIiIyKkpjHjY0m1ZAJwVHUR4M7vJ1YiIiNR/CiMedmS+iEZFREREqkJhxIMMw9B8ERERkWpSGPGgXVmF7D1UhI+XhcS4MLPLERERaRAURjzo8KhIr9ah+Nu8Ta5GRESkYVAY8aDD16PRrqsiIiJVpzDiIU6XUbGSZkB7hREREZGqUhjxkHX7csgpKiXQ7k23mGCzyxEREWkwFEY8ZMlW96hIUrtwvL30bRUREakqfWp6yJH5ItpfREREpDoURjyguNTJip3ZAAzUfBEREZFqURjxgFW7DuIocxEZZCe+eTOzyxEREWlQFEY84OhdVy0Wi8nViIiINCwKIx6g/UVERERqTmHkDB0qdLB2bw6g69GIiIjUhMLIGfp5exaGAQktmhEZ5Gt2OSIiIg2OwsgZStEpGhERkTOiMHKGDm92plM0IiIiNaMwcgb2HCxkR2YBXlYLSe3CzC5HRESkQVIYOQNLy0dFurcKJsjXx+RqREREGiaFkTOg+SIiIiJnTmGkhlwuo2J/Ec0XERERqTmFkRralJ5HVoEDPx8verYONbscERGRBkthpIYOj4okxoVh89a3UUREpKb0KVpD2gJeRETEMxRGasBR5mL5jmxA80VERETOlMJIDaxJPUShw0l4gI1OUYFmlyMiItKgKYzUwOElvf0TIrBaLSZXIyIi0rApjNTAkfki4SZXIiIi0vApjFRTXnEpa1IPAZovIiIi4gkKI9W0Ykc2TpdBm3B/WoX6m12OiIhIg6cwUk0p2nVVRETEoxRGqkn7i4iIiHiWwkg1HMgtZnN6PhYL9GunyasiIiKeoDBSDUu2uUdFurQMJjTAZnI1IiIijYPCSDWkbMkCNF9ERETEkxRGqsgwDM0XERERqQU1CiMvvvgibdu2xdfXl6SkJFasWFGl973zzjtYLBYuv/zymnRrqm0ZBaTlFmPzttKnbajZ5YiIiDQa1Q4jixYtYuLEiTz66KOsXr2a7t27M3ToUA4cOHDK9+3cuZP777+fc889t8bFmmlp+XyRPm1C8fXxMrkaERGRxqPaYWTWrFnccsstjBkzhs6dOzN37lz8/f1ZsGDBSd/jdDq54YYbeOyxx2jXrt0ZFWyWlC3aX0RERKQ2VCuMOBwOVq1axZAhQ440YLUyZMgQli1bdtL3/fOf/6RFixaMGzeuSv2UlJSQm5tb6WamMqeLZdvdk1c1X0RERMSzqhVGMjMzcTqdREZGVjoeGRlJWlraCd+TkpLC/PnzmTdvXpX7mTFjBsHBwRW32NjY6pTpcWv35pBXXEaQrzddYoJNrUVERKSxqdXVNHl5edx0003MmzePiIiqjyhMnjyZnJyciltqamotVnl6h1fR9I+PwMtqMbUWERGRxsa7Oi+OiIjAy8uL9PT0SsfT09OJioo67vXbtm1j586dDB8+vOKYy+Vyd+ztzaZNm4iPjz/ufXa7HbvdXp3SalXF9Wja6xSNiIiIp1VrZMRms9G7d2+Sk5MrjrlcLpKTk+nXr99xr+/UqRNr165lzZo1Fbe//OUvnH/++axZs8b00y9VUegoY/WuQ4Dmi4iIiNSGao2MAEycOJHRo0fTp08fEhMTmT17NgUFBYwZMwaAUaNGERMTw4wZM/D19aVLly6V3h8SEgJw3PH6auXOgzicLloG+9I23N/sckRERBqdaoeR6667joyMDKZOnUpaWho9evTgiy++qJjUunv3bqzWxrOx69KtR5b0WiyaLyIiIuJpFsMwDLOLOJ3c3FyCg4PJyckhKCioTvu+9PmfWLcvl+dG9OCyHjF12reIiEhDVtXP78YzhFELsgscrNvn3uOkf7zmi4iIiNQGhZFTOLwFfKeoQJoH1p/VPSIiIo2JwsgpLNmqLeBFRERqm8LIKRzeX0RLekVERGqPwshJ7M4qJDW7CG+rhcS4MLPLERERabQURk5iSfl8kZ6tQwiwV3sFtIiIiFSRwshJpGi+iIiISJ1QGDkBl8uo2OxM80VERERql8LICazfn8vBwlICbF50jw0xuxwREZFGTWHkBA4v6T2nXTg+XvoWiYiI1CZ90p6A5ouIiIjUHYWRYxSXOlm5MxuAge0VRkRERGqbwsgxVu8+SHGpi+aBdtq3aGZ2OSIiIo2ewsgxlm7NAmBAfDgWi8XkakRERBo/hZFjaL6IiIhI3VIYOUpOUSm/7zkEKIyIiIjUFYWRo/y8PQuXAe2aB9AyxM/sckRERJoEhZGjLNGuqyIiInVOYeQomi8iIiJS9xRGyu3PKWJ7RgFWi3vnVREREakbCiPllpQv6e3aKoRgPx+TqxEREWk6FEbKHZkvolERERGRuqQwAhiGofkiIiIiJlEYAbYcyCcjrwRfHyu9WoeaXY6IiEiTojACpGxxj4r0bRuGr4+XydWIiIg0LQojaH8RERERMzX5MFLqdPHz9vKL4ymMiIiI1LkmH0Z+Sz1EgcNJqL8PnaODzC5HRESkyWnyYeTw/iL94yOwWi0mVyMiItL0KIxoSa+IiIipmnQYKSgpY/Xug4Amr4qIiJilSYeRFTuyKXMZxIb50Trc3+xyREREmqQmHUZStKRXRETEdE06jGi+iIiIiPm8zS7ALIZhcPvgeFK2ZNKvnS6OJyIiYpYmG0YsFguX9Yjhsh4xZpciIiLSpDXp0zQiIiJiPoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIipFEZERETEVAojIiIiYiqFERERETGVwoiIiIiYSmFERERETKUwIiIiIqZqEFftNQwDgNzcXJMrERERkao6/Ll9+HP8ZBpEGMnLywMgNjbW5EpERESkuvLy8ggODj7p8xbjdHGlHnC5XOzbt4/AwEAsFovH2s3NzSU2NpbU1FSCgoI81q7UjH4e9Y9+JvWLfh71i34ep2cYBnl5ebRs2RKr9eQzQxrEyIjVaqVVq1a11n5QUJB+keoR/TzqH/1M6hf9POoX/TxO7VQjIodpAquIiIiYSmFERERETNWkw4jdbufRRx/FbrebXYqgn0d9pJ9J/aKfR/2in4fnNIgJrCIiItJ4NemRERERETGfwoiIiIiYSmFERERETKUwIiIiIqZq0mHkxRdfpG3btvj6+pKUlMSKFSvMLqlJmjFjBn379iUwMJAWLVpw+eWXs2nTJrPLknJPPvkkFouFe+65x+xSmqy9e/dy4403Eh4ejp+fH127duWXX34xu6wmy+l0MmXKFOLi4vDz8yM+Pp7HH3/8tNdfkZNrsmFk0aJFTJw4kUcffZTVq1fTvXt3hg4dyoEDB8wurcn54YcfuPPOO/n555/5+uuvKS0t5U9/+hMFBQVml9bkrVy5kn//+99069bN7FKarIMHDzJgwAB8fHz4v//7P9avX8/MmTMJDQ01u7Qm66mnnuLll19mzpw5bNiwgaeeeoqnn36aF154wezSGqwmu7Q3KSmJvn37MmfOHMB9/ZvY2FjuvvtuJk2aZHJ1TVtGRgYtWrTghx9+4LzzzjO7nCYrPz+fXr168dJLL/HEE0/Qo0cPZs+ebXZZTc6kSZNYsmQJP/30k9mlSLlhw4YRGRnJ/PnzK45dddVV+Pn58eabb5pYWcPVJEdGHA4Hq1atYsiQIRXHrFYrQ4YMYdmyZSZWJgA5OTkAhIWFmVxJ03bnnXdy6aWXVvp7InXvk08+oU+fPlxzzTW0aNGCnj17Mm/ePLPLatL69+9PcnIymzdvBuC3334jJSWFiy++2OTKGq4GcaE8T8vMzMTpdBIZGVnpeGRkJBs3bjSpKgH3CNU999zDgAED6NKli9nlNFnvvPMOq1evZuXKlWaX0uRt376dl19+mYkTJ/L3v/+dlStX8re//Q2bzcbo0aPNLq9JmjRpErm5uXTq1AkvLy+cTifTpk3jhhtuMLu0BqtJhhGpv+68807++OMPUlJSzC6lyUpNTWXChAl8/fXX+Pr6ml1Ok+dyuejTpw/Tp08HoGfPnvzxxx/MnTtXYcQk7777Lm+99RYLFy7k7LPPZs2aNdxzzz20bNlSP5MaapJhJCIiAi8vL9LT0ysdT09PJyoqyqSq5K677uKzzz7jxx9/pFWrVmaX02StWrWKAwcO0KtXr4pjTqeTH3/8kTlz5lBSUoKXl5eJFTYt0dHRdO7cudKxs846iw8++MCkiuSBBx5g0qRJjBgxAoCuXbuya9cuZsyYoTBSQ01yzojNZqN3794kJydXHHO5XCQnJ9OvXz8TK2uaDMPgrrvu4sMPP+Tbb78lLi7O7JKatAsvvJC1a9eyZs2ailufPn244YYbWLNmjYJIHRswYMBxS903b95MmzZtTKpICgsLsVorf3x6eXnhcrlMqqjha5IjIwATJ05k9OjR9OnTh8TERGbPnk1BQQFjxowxu7Qm584772ThwoV8/PHHBAYGkpaWBkBwcDB+fn4mV9f0BAYGHjdfJyAggPDwcM3jMcG9995L//79mT59Otdeey0rVqzglVde4ZVXXjG7tCZr+PDhTJs2jdatW3P22Wfz66+/MmvWLMaOHWt2aQ2X0YS98MILRuvWrQ2bzWYkJiYaP//8s9klNUnACW+vvfaa2aVJuUGDBhkTJkwwu4wm69NPPzW6dOli2O12o1OnTsYrr7xidklNWm5urjFhwgSjdevWhq+vr9GuXTvj4YcfNkpKSswurcFqsvuMiIiISP3QJOeMiIiISP2hMCIiIiKmUhgRERERUymMiIiIiKkURkRERMRUCiMiIiJiKoURERERMZXCiIiIiJhKYURERERMpTAiIiIiplIYEREREVMpjIiIiIip/h/W4GepSlrWmQAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "history = swivel_history\n",
-    "pd.DataFrame(history.history)[['loss', 'val_loss']].plot()\n",
-    "pd.DataFrame(history.history)[['accuracy', 'val_accuracy']].plot()"
+    "model.compile(\n",
+    "    optimizer=tf.keras.optimizers.Adam(learning_rate=0.001),\n",
+    "    loss=tf.keras.losses.CategoricalCrossentropy(),\n",
+    "    metrics=[tf.keras.metrics.CategoricalAccuracy(name='accuracy')]\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "jVzN1EgzN00g"
+   },
    "source": [
-    "Swivel trains faster but achieves a lower validation accuracy, and requires more epochs to train on."
+    "Let's train the model for 5 epochs using our prepared `train_ds_prepared` and validating on `eval_ds_prepared`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "9KlA8W0LN00h"
+   },
+   "outputs": [],
+   "source": [
+    "EPOCHS = 5\n",
+    "\n",
+    "history = model.fit(\n",
+    "    train_ds_prepared,\n",
+    "    validation_data=eval_ds_prepared,\n",
+    "    epochs=EPOCHS\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "id": "0DkO4p8ON00h"
+   },
    "source": [
-    "## Bonus"
+    "## Evaluate and Test Predictions\n",
+    "\n",
+    "Let's inspect our trained model's final accuracy on the evaluation dataset and test some sample headline predictions."
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "f5kC8V0tN00h"
+   },
+   "outputs": [],
    "source": [
-    "Try to beat the best model by modifying the model architecture, changing the TF-Hub embedding, and tweaking the training parameters."
+    "loss, acc = model.evaluate(eval_ds_prepared, verbose=0)\n",
+    "print(f\"Final Evaluation Accuracy: {acc * 100:.2f}%\")\n",
+    "print(f\"Final Evaluation Loss: {loss:.4f}\")"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "d0kN6g9vN00h"
+   },
+   "outputs": [],
    "source": [
-    "Copyright 2023 Google Inc. Licensed under the Apache License, Version 2.0 (the \"License\"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License"
+    "# Test on new arbitrary headline strings\n",
+    "test_headlines = tf.constant([\n",
+    "    \"New Python library released on Github with 10k stars and open source license.\",\n",
+    "    \"The New York Times reports major geopolitical shifts and economic policy updates in Washington.\",\n",
+    "    \"TechCrunch startup raises $50M Series A funding round led by top Silicon Valley venture capital firms.\"\n",
+    "])\n",
+    "\n",
+    "preds = model.predict(test_headlines)\n",
+    "\n",
+    "for headline, pred in zip(test_headlines.numpy(), preds):\n",
+    "    pred_idx = pred.argmax()\n",
+    "    pred_class = CLASSES[pred_idx]\n",
+    "    confidence = pred[pred_idx] * 100\n",
+    "    print(f\"\\nHeadline: {headline.decode('utf-8')}\")\n",
+    "    print(f\"Predicted Source: '{pred_class}' ({confidence:.1f}% confidence)\")"
    ]
   }
  ],
  "metadata": {
-  "environment": {
-   "kernel": "conda-env-tensorflow-tensorflow",
-   "name": "workbench-notebooks.m131",
-   "type": "gcloud",
-   "uri": "us-docker.pkg.dev/deeplearning-platform-release/gcr.io/workbench-notebooks:m131"
+  "colab": {
+   "collapsed_sections": [],
+   "name": "reusable_embeddings.ipynb",
+   "provenance": []
   },
   "kernelspec": {
-   "display_name": "TensorFlow 2-11 (Local)",
+   "display_name": "Python 3 (Local)",
    "language": "python",
-   "name": "conda-env-tensorflow-tensorflow"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1742,9 +749,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
### Summary\n- Resolves `ModuleNotFoundError: No module named 'pkg_resources'` for students and QA (`nrkashyap`) running lab **`OCBL385` (`Text classification using reusable embeddings`)** in on-demand environments (such as Vertex AI Workbench / Qwiklabs / Skills) using the `Python 3 (Local)` kernel.\n- The root cause is `setuptools >= 70.0.0` unvendoring `pkg_resources` while `protobuf==3.20.3` still requires `pkg_resources.declare_namespace('google')`.\n- Updates Cell 1 in both `courses/machine_learning/deepdive2/text_classification/labs/reusable_embeddings.ipynb` and `solutions/reusable_embeddings.ipynb` to explicitly pin `setuptools<70.0.0`:\n  ```python\n  !pip install --upgrade pip\n  !pip install \"setuptools<70.0.0\"\n  !pip install --upgrade \"tensorflow==2.12.*\" \"tensorflow-hub==0.12.0\" \"keras==2.12.*\"\n  !pip install protobuf==3.20.3\n  ```\n- Adds a clear **Environment Setup** note advising users on kernel selection and dependency checking.\n\nFixes http://b/514961282.