### PR TITLE
Restore default model fallback to gemini-2.5-flash

### DIFF
--- a/self-paced-labs/agents/build-multi-agent-system/multi-agent-system-skills-starter/agents/content_builder/agent.py
+++ b/self-paced-labs/agents/build-multi-agent-system/multi-agent-system-skills-starter/agents/content_builder/agent.py
@@ -4,7 +4,7 @@ from google.adk.agents import Agent
 from google.adk.skills import load_skill_from_dir
 from google.adk.tools.skill_toolset import SkillToolset
 
-MODEL = os.environ.get("MODEL", "gemini-3.5-flash")
+MODEL = os.environ.get("MODEL", "gemini-2.5-flash")
 
 # Load local skill folder
 skill_dir = pathlib.Path(__file__).parent / "skills"

--- a/self-paced-labs/agents/build-multi-agent-system/multi-agent-system-skills-starter/agents/judge/agent.py
+++ b/self-paced-labs/agents/build-multi-agent-system/multi-agent-system-skills-starter/agents/judge/agent.py
@@ -5,7 +5,7 @@ from google.adk.apps.app import App
 from pydantic import BaseModel, Field
 
 
-MODEL = os.environ.get("MODEL", "gemini-3.5-flash")
+MODEL = os.environ.get("MODEL", "gemini-2.5-flash")
 
 # TODO 1: Define the JudgeFeedback schema class extending BaseModel
 class JudgeFeedback(BaseModel):

--- a/self-paced-labs/agents/build-multi-agent-system/multi-agent-system-skills-starter/agents/researcher/agent.py
+++ b/self-paced-labs/agents/build-multi-agent-system/multi-agent-system-skills-starter/agents/researcher/agent.py
@@ -4,7 +4,7 @@ from google.adk.agents import Agent
 from google.adk.skills import load_skill_from_dir
 from google.adk.tools.skill_toolset import SkillToolset
 
-MODEL = os.environ.get("MODEL", "gemini-3.5-flash")
+MODEL = os.environ.get("MODEL", "gemini-2.5-flash")
 
 # Load local skill folder
 skill_dir = pathlib.Path(__file__).parent / "skills"


### PR DESCRIPTION
gemini flash 2.5 is the only way to make gsp541 work both locally and with containers in multiple regions as of July 24, 2026.