### PR TITLE
Grant networkservices.viewer to Vertex AI service agent to allow agen…

### DIFF
--- a/self-paced-labs/agents/secure-agent-egress-gateway-challenge-starter/terraform/modules/foundation/main.tf
+++ b/self-paced-labs/agents/secure-agent-egress-gateway-challenge-starter/terraform/modules/foundation/main.tf
@@ -64,6 +64,14 @@ resource "google_project_service_identity" "aiplatform" {
   depends_on = [google_project_service.aiplatform]
 }
 
+# The Vertex AI service agent needs to be able to get/read Agent Gateway resources
+# when deploying agents configured with egress gateways.
+resource "google_project_iam_member" "aiplatform_networkservices_viewer" {
+  project = module.project.project_id
+  role    = "roles/networkservices.viewer"
+  member  = "serviceAccount:${google_project_service_identity.aiplatform.email}"
+}
+
 resource "google_project_iam_member" "aiplatform_network_admin" {
   count   = var.enable_psc_interface ? 1 : 0
   project = module.project.project_id


### PR DESCRIPTION
…t gateway lookups

We hardened gsp542 to use least privilege.  during testing we realized we needed this additonal permission for the Agent Service account, so I have added it.