### PR TITLE
Update deploy_agent.py

### DIFF
--- a/self-paced-labs/agents/secure-agent-egress-gateway-challenge-starter/src/mortgage-agent/deploy_agent.py
+++ b/self-paced-labs/agents/secure-agent-egress-gateway-challenge-starter/src/mortgage-agent/deploy_agent.py
@@ -569,7 +569,7 @@ def main() -> None:
                 # Make denied MCP tool calls (gateway 403) fail fast instead of
                 # hanging the turn as a broken-stream TaskGroup/TimeoutError.
                 "ADK_ENABLE_MCP_GRACEFUL_ERROR_HANDLING": "true",
-                "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY": "true",
+                "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY": "false",
                 "GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES": "false",
                 "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "true",
                 "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",

--- a/self-paced-labs/agents/secure-agent-egress-gateway/src/mortgage-agent/deploy_agent.py
+++ b/self-paced-labs/agents/secure-agent-egress-gateway/src/mortgage-agent/deploy_agent.py
@@ -569,7 +569,7 @@ def main() -> None:
                 # Make denied MCP tool calls (gateway 403) fail fast instead of
                 # hanging the turn as a broken-stream TaskGroup/TimeoutError.
                 "ADK_ENABLE_MCP_GRACEFUL_ERROR_HANDLING": "true",
-                "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY": "true",
+                "GOOGLE_CLOUD_AGENT_ENGINE_ENABLE_TELEMETRY": "false",
                 "GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES": "false",
                 "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "true",
                 "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",


### PR DESCRIPTION
Open telemetry causes error with currently used python packages.  Have to disable for gsp542 to work at August 6 launch.

Otherwise you will get error, task 5, step 2 upon deployment of the agent.

Traceback (most recent call last):
  File "/home/student_02_41e19308915a/agent-security-lab/src/mortgage-agent/deploy_agent.py", line 709, in <module>
    main()
  File "/home/student_02_41e19308915a/agent-security-lab/src/mortgage-agent/deploy_agent.py", line 673, in main
    engine = client.agent_engines.update(name=reasoning_engine_name, agent=app, config=deploy_config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/student_02_41e19308915a/.local/lib/python3.12/site-packages/vertexai/_genai/agent_engines.py", line 2824, in update
    raise RuntimeError(f"Failed to update Agent Engine: {operation.error}")
RuntimeError: Failed to update Agent Engine: {'code': 3, 'message': 'Reasoning Engine resource [projects/525884312903/locations/us-central1/reasoningEngines/5126135964191686656] failed to start and cannot serve traffic. Please refer to our troubleshooting pages (e.g., https://docs.cloud.google.com/gemini-enterprise-agent-platform/troubleshooting/agent-deployment) to debug and fix the error.'}