### PR TITLE
Fix AttributeError in courses/ai-agents-with-databases/notebooks/1_setup_and_explore_databases.ipynb

### DIFF
--- a/courses/ai-agents-with-databases/notebooks/1_setup_and_explore_databases.ipynb
+++ b/courses/ai-agents-with-databases/notebooks/1_setup_and_explore_databases.ipynb
@@ -217,6 +217,7 @@
    "source": [
     "import requests\n",
     "import google.auth\n",
+    "import google.auth.transport.requests\n",
     "import json\n",
     "\n",
     "# Get an access token based upon the current user\n",


### PR DESCRIPTION

The cell imports `google.auth` and then calls `google.auth.transport.requests.AuthorizedSession`, but `google.auth.transport.requests` is a submodule that is not loaded by importing the parent package. 

This raises `AttributeError: module 'google.auth.transport'` has no attribute 'requests'" unless some earlier import happens to have loaded it.